### PR TITLE
[plugin gcp] Add auto discovery for GCP service account

### DIFF
--- a/plugins/gcp/README.md
+++ b/plugins/gcp/README.md
@@ -2,7 +2,7 @@
 An GCP collector plugin for Cloudkeeper.
 
 ## Usage
-When the collector is enabled (`--collector gcp`) it will automatically collect any accounts specified for `--gcp-service-account`.
+When the collector is enabled (`--collector gcp`) it will automatically collect any accounts specified for `--gcp-service-account`. Set to empty string to use default service account discovery on GCE, GKE etc.
 
 ## List of arguments
 ```

--- a/plugins/gcp/cloudkeeper_plugin_gcp/utils.py
+++ b/plugins/gcp/cloudkeeper_plugin_gcp/utils.py
@@ -76,6 +76,8 @@ class Credentials:
 
 
 def load_credentials(sa_data: str):
+    if len(sa_data) == 0:
+        return None
     if os.path.isfile(sa_data):
         return service_account.Credentials.from_service_account_file(
             sa_data, scopes=SCOPES


### PR DESCRIPTION
When running cloudkeeper on GCP we should be able to leverage [the infrastructures default service account - a.k.a. Application Default Credentials (ADC).](https://cloud.google.com/docs/authentication/production#auth-cloud-implicit-python)

This PR allows users to specify an empty `gcp-service-account`, which results in the ADC logic being invoked instead of expecting an explicit service account.