### PR TITLE
[plugin gcp] Fix discovery of custom machine types

### DIFF
--- a/plugins/gcp/cloudkeeper_plugin_gcp/collector.py
+++ b/plugins/gcp/cloudkeeper_plugin_gcp/collector.py
@@ -740,7 +740,7 @@ class GCPProjectCollector:
                 machine_type = GCPMachineType(
                     resource._machine_type_link.split("/")[-1],
                     {},
-                    _region=resource.region(graph),
+                    _zone=resource.zone(graph),
                     _account=resource.account(graph),
                     link=resource._machine_type_link,
                 )


### PR DESCRIPTION
The googleapiclient does not expect `region`, but `zone` for getting custom machine types.

This PR closes #358.