### PR TITLE
changed right side double quotes to single quotes

### DIFF
--- a/docs/source/getting_started/quick_start.rst
+++ b/docs/source/getting_started/quick_start.rst
@@ -36,7 +36,7 @@ Replace ``YOURKEYID`` and ``YOURACCESSKEY`` to collect your AWS inventory.
     $ mkdir -p ~/data/test
     $ docker run -d -v "${HOME}/data/test":/data:rw \
     -e AWS_ACCESS_KEY_ID=YOURKEYID -e AWS_SECRET_ACCESS_KEY='YOURACCESSKEY' \
-    -e CKWORKER_COLLECTOR=”aws example” \
+    -e CKWORKER_COLLECTOR='aws example' \
     --name cloudkeeper ghcr.io/someengineering/cloudkeeper:2.0.0a6
 
 Start the Cloudkeeper CLI


### PR DESCRIPTION
Sadly, docker (version 20.10.7) isn't able to handle the right side double quotes and exits with a reference error.
`docker: invalid reference format.`