### PR TITLE
[ckcore] CLI Commands parse a CLIAction that can be performed

### DIFF
--- a/ckcore/core/__main__.py
+++ b/ckcore/core/__main__.py
@@ -7,7 +7,7 @@ from aiohttp import web
 from aiohttp.web_app import Application
 
 from core.cli.cli import CLI
-from core.cli.command import all_parts, aliases, CLIDependencies
+from core.cli.command import aliases, CLIDependencies, all_commands
 from core.dependencies import db_access, setup_process, parse_args
 from core.message_bus import MessageBus
 from core.model.model_handler import ModelHandlerDB
@@ -34,7 +34,7 @@ def main() -> None:
     worker_task_queue = WorkerTaskQueue()
     model = ModelHandlerDB(db.get_model_db(), args.plantuml_server)
     cli_deps = CLIDependencies()
-    cli = CLI(cli_deps, all_parts(cli_deps), dict(os.environ), aliases())
+    cli = CLI(cli_deps, all_commands(cli_deps), dict(os.environ), aliases())
 
     subscriptions = SubscriptionHandler(db.subscribers_db, message_bus)
     task_handler = TaskHandler(db.running_task_db, db.job_db, message_bus, subscriptions, scheduler, cli, args)

--- a/ckcore/core/cli/__init__.py
+++ b/ckcore/core/cli/__init__.py
@@ -21,10 +21,6 @@ T = TypeVar("T")
 # Allow the function to return either a coroutine or the result directly
 Result = Union[T, Coroutine[Any, Any, T]]
 JsGen = Union[Stream, AsyncGenerator[JsonElement, None]]
-# A source provides a stream of objects
-Source = JsGen
-# Every Command will return a function that transforms a JsGen to another JsGen
-Flow = Callable[[JsGen], JsGen]
 # A sink function takes a stream and creates a result
 Sink = Callable[[JsGen], Coroutine[Any, Any, T]]
 

--- a/ckcore/core/cli/cli.py
+++ b/ckcore/core/cli/cli.py
@@ -1,30 +1,28 @@
 from __future__ import annotations
 
-import asyncio
 import calendar
 from dataclasses import dataclass, field, replace
 from datetime import timedelta
 from functools import reduce
 from itertools import takewhile
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Type
 from typing import Optional, Union, Any, AsyncGenerator
 
 from aiostream import stream
 from aiostream.core import Stream
 from parsy import Parser
 
-from core.cli import cmd_args_parser, key_values_parser, T, Sink, Source, Flow
+from core.cli import cmd_args_parser, key_values_parser, T, Sink
 from core.cli.command import (
-    CLIPart,
     CLIDependencies,
     QueryAllPart,
     ReportedPart,
     DesiredPart,
     MetadataPart,
-    Predecessor,
-    Successor,
-    Ancestor,
-    Descendant,
+    PredecessorPart,
+    SuccessorPart,
+    AncestorPart,
+    DescendantPart,
     AggregatePart,
     MergeAncestorsPart,
     CountCommand,
@@ -34,6 +32,9 @@ from core.cli.command import (
     CLICommand,
     CLISource,
     InternalPart,
+    CLIAction,
+    CLIFlow,
+    MediaType,
 )
 from core.error import CLIParseError
 from core.model.graph_access import EdgeType, Section
@@ -82,30 +83,26 @@ class ParsedCommandLine:
     """
     The parsed command line holds:
     - env: the resulting environment coming from the parsed environment + the provided environment
-    - parts: all parts this command is defined from
+    - commands: all commands this command is defined from
     - generator: this generator can be used in order to execute the command line
     """
 
     env: JsonElement
     parsed_commands: ParsedCommands
-    parts_with_args: List[Tuple[CLIPart, Optional[str]]]
+    parts_with_args: List[Tuple[CLICommand, Optional[str]]]
     generator: AsyncGenerator[JsonElement, None]
+    result_action: CLIAction
 
     async def to_sink(self, sink: Sink[T]) -> T:
         return await sink(self.generator)
 
     @property
-    def parts(self) -> List[CLIPart]:
+    def commands(self) -> List[CLICommand]:
         return [part for part, _ in self.parts_with_args]
 
-    def produces(self) -> str:
-        return self.parts_with_args[-1][0].produces() if self.parts_with_args else "application/json"
-
-    def produces_json(self) -> bool:
-        return self.produces() == "application/json"
-
-    def produces_binary(self) -> bool:
-        return self.produces() == "application/octet-stream"
+    @property
+    def produces(self) -> MediaType:
+        return self.result_action.produces()
 
 
 @make_parser
@@ -127,7 +124,7 @@ def command_line_parser() -> Parser:
 multi_command_parser = command_line_parser.sep_by(semicolon_p)
 
 
-class HelpCommand(CLISource):
+class HelpCommand(CLICommand):
     """
     Usage: help [command]
 
@@ -137,7 +134,7 @@ class HelpCommand(CLISource):
     Show help text for a command or general help information.
     """
 
-    def __init__(self, dependencies: CLIDependencies, parts: List[CLIPart], aliases: Dict[str, str]):
+    def __init__(self, dependencies: CLIDependencies, parts: List[CLICommand], aliases: Dict[str, str]):
         super().__init__(dependencies)
         self.all_parts = {p.name: p for p in parts + [self]}
         self.parts = {p.name: p for p in parts + [self] if not isinstance(p, InternalPart)}
@@ -150,37 +147,42 @@ class HelpCommand(CLISource):
     def info(self) -> str:
         return "Shows available commands, as well as help for any specific command."
 
-    async def parse(self, arg: Optional[str] = None, **env: str) -> Source:
-        def show_cmd(cmd: CLIPart) -> str:
-            return f"{cmd.name} - {cmd.info()}\n\n{cmd.help()}"
+    async def parse(self, arg: Optional[str] = None, **env: str) -> CLISource:
+        def help_command() -> Stream:
+            def show_cmd(cmd: CLICommand) -> str:
+                return f"{cmd.name} - {cmd.info()}\n\n{cmd.help()}"
 
-        if not arg:
-            all_parts = sorted(self.parts.values(), key=lambda p: p.name)
-            parts = (p for p in all_parts if isinstance(p, (CLISource, CLICommand)))
-            available = "\n".join(f"   {part.name} - {part.info()}" for part in parts)
-            aliases = "\n".join(f"   {alias} ({cmd}) - {self.parts[cmd].info()}" for alias, cmd in self.aliases.items())
-            replacements = "\n".join(f"   @{key}@ -> {value}" for key, value in CLI.replacements().items())
-            result = (
-                f"\nckcore CLI\n\n\n"
-                f"Valid placeholder string:\n{replacements}\n\n"
-                f"Available Commands:\n{available}\n\n"
-                f"Available Aliases:\n{aliases}\n\n"
-                f"Note that you can pipe commands using the pipe character (|)\n"
-                f"and chain multiple commands using the semicolon (;)."
-            )
-        elif arg and arg in self.all_parts:
-            result = show_cmd(self.all_parts[arg])
-        elif arg and arg in self.aliases:
-            alias = self.aliases[arg]
-            explain = f"{arg} is an alias for {alias}\n\n"
-            result = explain + show_cmd(self.all_parts[alias])
-        else:
-            result = f"No command found with this name: {arg}"
+            if not arg:
+                all_parts = sorted(self.parts.values(), key=lambda p: p.name)
+                parts = (p for p in all_parts if isinstance(p, CLICommand))
+                available = "\n".join(f"   {part.name} - {part.info()}" for part in parts)
+                aliases = "\n".join(
+                    f"   {alias} ({cmd}) - {self.parts[cmd].info()}" for alias, cmd in self.aliases.items()
+                )
+                replacements = "\n".join(f"   @{key}@ -> {value}" for key, value in CLI.replacements().items())
+                result = (
+                    f"\nckcore CLI\n\n\n"
+                    f"Valid placeholder string:\n{replacements}\n\n"
+                    f"Available Commands:\n{available}\n\n"
+                    f"Available Aliases:\n{aliases}\n\n"
+                    f"Note that you can pipe commands using the pipe character (|)\n"
+                    f"and chain multiple commands using the semicolon (;)."
+                )
+            elif arg and arg in self.all_parts:
+                result = show_cmd(self.all_parts[arg])
+            elif arg and arg in self.aliases:
+                alias = self.aliases[arg]
+                explain = f"{arg} is an alias for {alias}\n\n"
+                result = explain + show_cmd(self.all_parts[alias])
+            else:
+                result = f"No command found with this name: {arg}"
 
-        return stream.just(result)
+            return stream.just(result)
+
+        return CLISource(help_command)
 
 
-CLIArg = Tuple[CLIPart, Optional[str]]
+CLIArg = Tuple[CLICommand, Optional[str]]
 
 
 class CLI:
@@ -190,12 +192,12 @@ class CLI:
     """
 
     def __init__(
-        self, dependencies: CLIDependencies, parts: List[CLIPart], env: Dict[str, Any], aliases: Dict[str, str]
+        self, dependencies: CLIDependencies, parts: List[CLICommand], env: Dict[str, Any], aliases: Dict[str, str]
     ):
         help_cmd = HelpCommand(dependencies, parts, aliases)
         cmds = {p.name: p for p in parts + [help_cmd]}
         alias_cmds = {alias: cmds[name] for alias, name in aliases.items() if name in cmds and alias not in cmds}
-        self.parts: Dict[str, CLIPart] = {**cmds, **alias_cmds}
+        self.commands: Dict[str, CLICommand] = {**cmds, **alias_cmds}
         self.cli_env = env
         self.dependencies = dependencies
         self.aliases = aliases
@@ -213,13 +215,13 @@ class CLI:
                 query = query.combine(parse_query(arg).on_section(Section.desired))
             elif isinstance(part, MetadataPart):
                 query = query.combine(parse_query(arg).on_section(Section.metadata))
-            elif isinstance(part, Predecessor):
+            elif isinstance(part, PredecessorPart):
                 query = query.traverse_in(1, 1, arg if arg else EdgeType.default)
-            elif isinstance(part, Successor):
+            elif isinstance(part, SuccessorPart):
                 query = query.traverse_out(1, 1, arg if arg else EdgeType.default)
-            elif isinstance(part, Ancestor):
+            elif isinstance(part, AncestorPart):
                 query = query.traverse_in(1, Navigation.Max, arg if arg else EdgeType.default)
-            elif isinstance(part, Descendant):
+            elif isinstance(part, DescendantPart):
                 query = query.traverse_out(1, Navigation.Max, arg if arg else EdgeType.default)
             elif isinstance(part, AggregatePart):
                 group_vars, group_function_vars = aggregate_parameter_parser.parse(arg)
@@ -233,7 +235,7 @@ class CLI:
                 assert query.aggregate is None, "Can not combine aggregate and count!"
                 group_by = [AggregateVariable(AggregateVariableName(arg), "name")] if arg else []
                 aggregate = Aggregate(group_by, [AggregateFunction("sum", 1, [], "count")])
-                additional_commands.append((self.parts["aggregate_to_count"], arg))
+                additional_commands.append((self.commands["aggregate_to_count"], arg))
                 query = replace(query, aggregate=aggregate, sort=[Sort("count")])
             elif isinstance(part, HeadCommand):
                 size = HeadCommand.parse_size(arg)
@@ -244,14 +246,14 @@ class CLI:
                 query = replace(query, limit=size, sort=sort)
             else:
                 raise AttributeError(f"Do not understand: {part} of type: {class_fqn(part)}")
-        return [(self.parts["execute_query"], str(query.simplify())), *additional_commands]
+        return [(self.commands["execute_query"], str(query.simplify())), *additional_commands]
 
     async def evaluate_cli_command(
         self, cli_input: str, replace_place_holder: bool = True, **env: str
     ) -> List[ParsedCommandLine]:
-        def parse_single_command(command: ParsedCommand) -> Tuple[CLIPart, Optional[str]]:
-            if command.cmd in self.parts:
-                part: CLIPart = self.parts[command.cmd]
+        def parse_single_command(command: ParsedCommand) -> CLIArg:
+            if command.cmd in self.commands:
+                part: CLICommand = self.commands[command.cmd]
                 return part, command.args
             else:
                 raise CLIParseError(f"Command >{command.cmd}< is not known. typo?")
@@ -259,44 +261,38 @@ class CLI:
         def combine_single_command(commands: List[CLIArg]) -> List[CLIArg]:
             parts = list(takewhile(lambda x: isinstance(x[0], QueryPart), commands))
             query_parts = self.create_query(parts)
-
-            # fmt: off
-            result = [*query_parts, *commands[len(parts):]] if parts else commands
-            # fmt: on
-            for index, part_num in enumerate(result):
-                part, _ = part_num
-                expected = CLICommand if index else CLISource
-                if not isinstance(part, expected):
-                    detail = "no source data given" if index == 0 else "must be the first command"
-                    raise CLIParseError(f"Command >{part.name}< can not be used in this position: {detail}")
+            result = [*query_parts, *commands[len(parts) :]] if parts else commands  # noqa: E203
             return result
 
-        async def parse_arg(part: Any, args_str: Optional[str], **resulting_env: str) -> Any:
+        async def parse_arg(expect: Type[T], cmd: CLICommand, arg: Optional[str], cmd_env: Dict[str, Any]) -> T:
             try:
-                fn = part.parse(args_str, **resulting_env)
-                return await fn if asyncio.iscoroutine(fn) else fn
+                result = await cmd.parse(arg, **cmd_env)
             except Exception as ex:
-                kind = type(ex).__name__
-                raise CLIParseError(f"{part.name}: can not parse: {args_str}: {kind}: {str(ex)}") from ex
+                raise CLIParseError(f"{cmd.name} can not parse arg: {arg}") from ex
+            if isinstance(result, expect):
+                return result
+            else:
+                message = "must be the first command" if issubclass(type(result), CLISource) else "no source data given"
+                raise CLIParseError(f"Command >{cmd.name}< can not be used in this position: {message}")
 
         async def parse_line(commands: ParsedCommands) -> ParsedCommandLine:
-            def make_stream(in_stream: Union[Stream, AsyncGenerator[JsonElement, None]]) -> Stream:
-                return in_stream if isinstance(in_stream, Stream) else stream.iterate(in_stream)
 
             resulting_env = {**self.cli_env, **env, **commands.env}
             parts_with_args = combine_single_command([parse_single_command(cmd) for cmd in commands.commands])
 
             if parts_with_args:
                 source, source_arg = parts_with_args[0]
-                flow = make_stream(await parse_arg(source, source_arg, **resulting_env))
+                source_action = await parse_arg(CLISource, source, source_arg, resulting_env)
+                flow = await source_action.source()
+                result_action: Union[CLISource, CLIFlow] = source_action
                 for command, arg in parts_with_args[1:]:
-                    flow_fn: Flow = await parse_arg(command, arg, **resulting_env)
-                    # noinspection PyTypeChecker
-                    flow = make_stream(flow_fn(flow))
+                    flow_action = await parse_arg(CLIFlow, command, arg, resulting_env)
+                    flow = await flow_action.flow(flow)
+                    result_action = flow_action
                 # noinspection PyTypeChecker
-                return ParsedCommandLine(resulting_env, commands, parts_with_args, flow)
+                return ParsedCommandLine(resulting_env, commands, parts_with_args, flow, result_action)
             else:
-                return ParsedCommandLine(resulting_env, commands, [], CLISource.empty())
+                return ParsedCommandLine(resulting_env, commands, [], stream.empty(), CLISource.empty())
 
         replaced = self.replace_placeholder(cli_input, **env)
         command_lines: List[ParsedCommands] = multi_command_parser.parse(replaced)

--- a/ckcore/core/db/graphdb.py
+++ b/ckcore/core/db/graphdb.py
@@ -1058,7 +1058,7 @@ class ArangoGraphDB(GraphDB):
                 bind_vars,
             )
         else:  # return results
-            # return all tagged parts (last result is "tagged" automatically)
+            # return all tagged commands (last result is "tagged" automatically)
             tagged = {out for part, _, out, _ in parts if part.tag}
             result = f'UNION({",".join(tagged)},{resulting_cursor})' if tagged else resulting_cursor
             sort_by = sort("r", query.sort, section_dot) if query.sort else ""

--- a/ckcore/core/model/db_updater.py
+++ b/ckcore/core/model/db_updater.py
@@ -103,7 +103,7 @@ class DbUpdaterProcess(Process):
     This process has 2 queues to read input from and write output to.
     All elements in either queues are of type ProcessAction.
 
-    The parent process should stream the raw parts of graph to this process via ReadElement objects.
+    The parent process should stream the raw commands of graph to this process via ReadElement objects.
     Once the MergeGraph action is received, the graph gets imported.
     From here the parent expects result messages from the child.
     All events happen in the child are forwarded to the parent via EmitEvent.

--- a/ckcore/core/model/graph_access.py
+++ b/ckcore/core/model/graph_access.py
@@ -26,7 +26,7 @@ class Section:
 
     # This section holds changes that should be reflected by the given node.
     # The desired section can be queried the same way as the reported section
-    # and allows to query parts of the graph with a common desired state.
+    # and allows to query commands of the graph with a common desired state.
     # For example the clean flag is manifested in the desired section.
     # The separate clean step would query all nodes that should be cleaned
     # and can compute the correct order of action by walking the graph structure.

--- a/ckcore/core/web/api.py
+++ b/ckcore/core/web/api.py
@@ -622,9 +622,9 @@ class Api:
             first_result = parsed[0]
             # flat the results from 0 or 1
             async with stream.iterate(first_result.generator).stream() as streamer:
-                if first_result.produces_json():
+                if first_result.produces.json:
                     return await self.stream_response_from_gen(request, streamer)
-                elif first_result.produces_binary():
+                elif first_result.produces.file_path:
                     files = [elem async for elem in streamer]
                     if len(files) == 1:
                         dph = content_disposition_header("attachment", True, filename=os.path.basename(files[0]))
@@ -634,21 +634,21 @@ class Api:
                         await Api.multi_file_response(files, boundary, mp_response)
                         return mp_response
                 else:
-                    raise AttributeError(f"Can not handle type: {first_result.produces()}")
+                    raise AttributeError(f"Can not handle type: {first_result.produces}")
         elif len(parsed) > 1:
             await mp_response.prepare(request)
             for single in parsed:
                 async with stream.iterate(single.generator).stream() as streamer:
                     gen = await force_gen(streamer)
-                    if single.produces_json():
-                        with MultipartWriter(single.produces(), boundary) as mp:
+                    if single.produces.json:
+                        with MultipartWriter(repr(single.produces), boundary) as mp:
                             result_stream = await Api.result_binary_gen(content_type, gen)
                             mp.append_payload(AsyncIterablePayload(result_stream, content_type=content_type))
                             await mp.write(mp_response, close_boundary=True)
-                    elif single.produces_binary():
+                    elif single.produces.file_path:
                         await Api.multi_file_response([elem async for elem in gen], boundary, mp_response)
                     else:
-                        raise AttributeError(f"Can not handle type: {single.produces()}")
+                        raise AttributeError(f"Can not handle type: {single.produces}")
             await mp_response.write_eof()
             return mp_response
         else:

--- a/ckcore/tests/core/cli/command_test.py
+++ b/ckcore/tests/core/cli/command_test.py
@@ -10,8 +10,7 @@ from pytest import fixture
 
 from core.cli.cli import CLI
 
-# noinspection PyUnresolvedReferences
-from core.cli.command import ListSink, CLIDependencies
+from core.cli.command import CLIDependencies
 from core.db.jobdb import JobDb
 from core.error import CLIParseError
 from core.model.model import predefined_kinds


### PR DESCRIPTION
Main reason: the CLIAction also holds the information about the content type that is produced.
The same command can now produce different output formats, depending on the arg.