### PR TITLE
Deploy API docs to GH Pages

### DIFF
--- a/.github/workflows/deploy-api-docs.yml
+++ b/.github/workflows/deploy-api-docs.yml
@@ -1,0 +1,24 @@
+name: Deploy resotocore API Docs
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    name: Deploy resotocore API Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Generate Swagger UI
+        uses: Legion2/swagger-ui-action@v1
+        with:
+          output: swagger-ui
+          spec-file: resotocore/core/static/api-doc.yaml
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: swagger-ui

--- a/resotocore/core/static/api-doc.yaml
+++ b/resotocore/core/static/api-doc.yaml
@@ -3,9 +3,9 @@ servers:
     -   url: ../
         description: current system
 info:
-    description: API provided by keeper-core
+    description: API provided by resotocore
     version: V1
-    title: keeper-core REST API
+    title: resotocore REST API
 tags:
     -   name: graph_query
         description: Endpoints to query all sections of the graph.


### PR DESCRIPTION
Generates and deploys Swagger UI to GitHub Pages, so that we can link to it from the docs rather than instructing users to view it from their own installs.