### PR TITLE
[resotocore] Use proper time units

### DIFF
--- a/resotocore/core/durations.py
+++ b/resotocore/core/durations.py
@@ -1,0 +1,58 @@
+import operator
+from datetime import timedelta
+from functools import reduce
+import re
+from itertools import chain
+from typing import Union, List
+
+import parsy
+from parsy import string, Parser
+
+from core.parse_util import lexeme, float_p, integer_p
+
+
+# See https://en.wikipedia.org/wiki/Unit_of_time for reference
+# unit, long name, number of seconds
+# The order is relevant: from highest to lowest
+time_units = [
+    ("yr", "year", 365 * 24 * 3600),
+    ("mo", "month", 31 * 24 * 3600),
+    ("d", "day", 24 * 3600),
+    ("h", "hour", 3600),
+    ("min", "minute", 60),
+    ("s", "second", 1),
+]
+
+time_unit_combines = [",", "and"]
+
+# Check if a string is a valid
+DurationRe = re.compile(
+    "^[+-]?([\\d.]+("
+    + "|".join(chain.from_iterable([short, long, long + "s"] for short, long, _ in time_units))
+    + ")\\s*("
+    + "|".join(time_unit_combines)
+    + ")?\\s*)+$"
+)
+
+
+def combine_durations(elems: List[Union[int, float]]) -> Union[int, float]:
+    result = 0.0
+    for d in elems:
+        result += abs(d)
+    return result if elems[0] >= 0 else -result
+
+
+time_units_parser: Parser = reduce(
+    lambda result, tpl: result
+    | lexeme(string(tpl[1]) << string("s").optional()).result(tpl[2])
+    | lexeme(string(tpl[0])).result(tpl[2]),
+    time_units,
+    parsy.fail(None),
+)
+time_unit_combination: Parser = reduce(lambda x, y: x | y, [lexeme(string(a)) for a in [",", "and"]])
+single_duration_parser = parsy.seq((float_p | integer_p), time_units_parser).combine(operator.mul)
+duration_parser = single_duration_parser.sep_by(time_unit_combination.optional(), min=1).map(combine_durations)
+
+
+def parse_duration(ds: str) -> timedelta:
+    return timedelta(seconds=duration_parser.parse(ds))

--- a/resotocore/core/model/adjust_node.py
+++ b/resotocore/core/model/adjust_node.py
@@ -2,8 +2,9 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Optional, List
 
+from core.durations import DurationRe
 from core.model.graph_access import Section
-from core.model.model import DateTimeKind, DurationKind
+from core.model.model import DateTimeKind
 from core.model.resolve_in_graph import NodePath
 from core.types import Json
 from core.util import value_in_path, from_utc
@@ -48,7 +49,7 @@ class DirectAdjuster(AdjustNode):
                 expires = DateTimeKind.from_datetime(expires_tag)
             else:
                 expiration_tag = first_matching(self.expiration_values)
-                if expiration_tag and expires_tag != "never" and DurationKind.DurationRe.fullmatch(expiration_tag):
+                if expiration_tag and expires_tag != "never" and DurationRe.fullmatch(expiration_tag):
                     ctime_str = value_in_path(json, NodePath.reported_ctime)
                     if ctime_str:
                         ctime = from_utc(ctime_str)

--- a/resotocore/core/model/transform_kind_convert.py
+++ b/resotocore/core/model/transform_kind_convert.py
@@ -1,25 +1,11 @@
-from datetime import timedelta
-
-from durations_nlp import Duration
-
+from core.durations import parse_duration, time_units
 from core.util import utc, utc_str, from_utc
 
 
 def datetime_before_now(duration_string: str) -> str:
-    duration = timedelta(seconds=Duration(duration_string).seconds)
+    duration = parse_duration(duration_string)
     timestamp = utc() - duration
     return utc_str(timestamp)
-
-
-unit_in_secs = {
-    "y": 365 * 24 * 3600,
-    "M": 31 * 24 * 3600,
-    "w": 7 * 24 * 3600,
-    "d": 24 * 3600,
-    "h": 3600,
-    "m": 60,
-    "s": 1,
-}
 
 
 def duration_until_now(at: str) -> str:
@@ -29,7 +15,7 @@ def duration_until_now(at: str) -> str:
     found = False
     count = 0
     result = ""
-    for unit, factor in unit_in_secs.items():
+    for unit, _, factor in time_units:
         if seconds > factor:
             found = True
             num = int(seconds / factor)

--- a/resotocore/core/util.py
+++ b/resotocore/core/util.py
@@ -30,8 +30,8 @@ from typing import (
 
 import sys
 from dateutil.parser import isoparse
-from durations_nlp import Duration
 
+from core.durations import parse_duration
 from core.types import JsonElement, Json
 
 log = logging.getLogger(__name__)
@@ -81,7 +81,7 @@ def from_utc(date_string: str) -> datetime:
 
 
 def duration(d: str) -> timedelta:
-    return timedelta(seconds=int(Duration(d).seconds))
+    return parse_duration(d)
 
 
 def uuid_str(from_object: Optional[Any] = None) -> str:

--- a/resotocore/requirements.txt
+++ b/resotocore/requirements.txt
@@ -2,7 +2,6 @@
 
 aiohttp-swagger3==0.7.0
 aiohttp[speedups]==3.8.1
-durations_nlp==1.0.1
 jsons==1.6.1
 parsy==1.4.0
 plantuml==0.3.0

--- a/resotocore/tests/core/durations_test.py
+++ b/resotocore/tests/core/durations_test.py
@@ -1,0 +1,44 @@
+from datetime import timedelta
+from itertools import chain
+
+from hypothesis import given
+from hypothesis.strategies import sampled_from, tuples, integers, composite, lists
+
+from core.durations import time_units_parser, time_units, parse_duration, DurationRe
+from tests.core.hypothesis_extension import UD, Drawer
+
+units_gen = sampled_from(list(chain.from_iterable([short, long, long + "s"] for short, long, _ in time_units)))
+combines_gen = sampled_from(["", ", ", " and "])
+duration_gen = tuples(integers(1000, 1000), units_gen).map(lambda x: f"{x[0]}{x[1]}")
+
+
+@composite
+def durations_gen(ud: UD) -> str:
+    d = Drawer(ud)
+    result = d.draw(sampled_from(["", "+", "-"]))
+    first = True
+    for duration in d.draw(lists(duration_gen, min_size=1, max_size=4)):
+        if first:
+            first = False
+        else:
+            result += d.draw(combines_gen)
+        result += duration
+    return result
+
+
+@given(durations_gen())
+def test_arbitrary_durations(duration_str: str) -> None:
+    assert DurationRe.fullmatch(duration_str)
+    parse_duration(duration_str)
+
+
+def test_parse_duration() -> None:
+    for short, long, seconds in time_units:
+        assert time_units_parser.parse(short) == seconds
+        assert time_units_parser.parse(long) == seconds
+        assert time_units_parser.parse(f"{long}s") == seconds
+
+    assert parse_duration("4d") == timedelta(days=4)
+    assert parse_duration("1h") == timedelta(hours=1)
+    assert parse_duration("32days, 4hours and 3min and 3s") == timedelta(days=32, hours=4, minutes=3, seconds=3)
+    assert parse_duration("-32days, 4hours and 3min and 3s") == timedelta(days=-32, hours=-4, minutes=-3, seconds=-3)

--- a/resotocore/tests/core/model/adjust_node_test.py
+++ b/resotocore/tests/core/model/adjust_node_test.py
@@ -35,9 +35,9 @@ def test_adjust_expired() -> None:
     expect_expires({**reported, "tags": {"expiration": "never"}}, None)  # never can not be parsed
     expect_expires({**reported, "tags": {"resoto:expiration": "never"}}, None)  # never can not be parsed
     expect_expires({"tags": {"resoto:expiration": "12h"}}, None)  # no ctime given
-    expect_expires({"tags": {"expiration": "2w3d4h5m"}}, None)  # no ctime given
-    expect_expires({**reported, "tags": {"resoto:expiration": "2w3d4h5m"}}, "2021-01-18T04:05:00Z")
-    expect_expires({**reported, "tags": {"expiration": "2w3d4h5m"}}, "2021-01-18T04:05:00Z")
+    expect_expires({"tags": {"expiration": "2mo3d4h5min"}}, None)  # no ctime given
+    expect_expires({**reported, "tags": {"resoto:expiration": "2mo3d4h5min"}}, "2021-03-07T04:05:00Z")
+    expect_expires({**reported, "tags": {"expiration": "2mo3d4h5min"}}, "2021-03-07T04:05:00Z")
 
     # multiple values given: use order: ck:expiration -> ck:expires -> expiration -> expires
     expect_expires(

--- a/resotocore/tests/core/model/model_test.py
+++ b/resotocore/tests/core/model/model_test.py
@@ -89,10 +89,12 @@ def test_boolean() -> None:
 
 def test_duration() -> None:
     a = DurationKind("dt")
-    assert a.check_valid("2w3d5h6m3s") is None
+    assert a.check_valid("3d5h6min3s") is None
     assert expect_error(a, True) == "Expected type duration but got bool"
-    assert expect_error(a, "23df") == "Wrong format for duration: 23df. Examples: 2w, 4h3m, 2weeks, 1second"
-    assert a.coerce("12w") == "7257600s"
+    assert (
+        expect_error(a, "23df") == "Wrong format for duration: 23df. Examples: 1yr, 3mo, 3d4h3min1s, 3days and 2hours"
+    )
+    assert a.coerce("12d") == "1036800s"
     with pytest.raises(AttributeError) as no_date:
         a.coerce("simply no duration")
     assert str(no_date.value) == f"Expected duration but got: >simply no duration<"
@@ -109,10 +111,10 @@ def test_transform() -> None:
     assert (one_day_old - (utc() - timedelta(hours=24))).total_seconds() <= 2
 
     # transform back from underlying timestamp to timedelta
-    assert age.transform(utc_str(utc() - timedelta(seconds=123))) == "2m3s"
+    assert age.transform(utc_str(utc() - timedelta(seconds=123))) == "2min3s"
     assert age.transform(utc_str(utc() - timedelta(seconds=123456))) == "1d10h"
-    assert age.transform(utc_str(utc() - timedelta(seconds=1234567))) == "2w"
-    assert age.transform(utc_str(utc() - timedelta(seconds=123456789))) == "3y10M"
+    assert age.transform(utc_str(utc() - timedelta(seconds=1234567))) == "14d6h"
+    assert age.transform(utc_str(utc() - timedelta(seconds=123456789))) == "3yr10mo"
 
 
 def test_datetime() -> None:
@@ -131,7 +133,7 @@ def test_datetime() -> None:
     assert a.coerce("08:56:15").startswith(today[0:11])  # type: ignore
     assert a.coerce("08:56:15").endswith(":56:15Z")  # type: ignore# ignore the hours, time zone dependant
     assert a.coerce("-12d").startswith("20")  # type: ignore
-    assert a.coerce("12w").startswith("20")  # type: ignore
+    assert a.coerce("12mo").startswith("20")  # type: ignore
     with pytest.raises(AttributeError) as no_date:
         a.coerce("simply no date")
     assert str(no_date.value) == f"Expected datetime but got: >simply no date<"
@@ -144,7 +146,7 @@ def test_date() -> None:
     assert a.coerce("2021-06-08") == "2021-06-08"
     assert a.coerce("2021 06 08") == "2021-06-08"
     assert a.coerce("-12d").startswith("20")  # type: ignore
-    assert a.coerce("12w").startswith("20")  # type: ignore
+    assert a.coerce("12mo").startswith("20")  # type: ignore
     with pytest.raises(AttributeError) as no_date:
         a.coerce("simply no date")
     assert str(no_date.value) == f"Expected date but got: >simply no date<"


### PR DESCRIPTION

So far, we used https://github.com/timwedde/durations_nlp for duration parsing, which uses single letter units as short names, which is not standard.

This PR uses durations with proper time units.
See: https://en.wikipedia.org/wiki/Unit_of_time 
Following time units are supported:

|short | long |
|------|-----|
yr | year
mo | month
d | day
h | hour
min | minute
s | second

The parts can be combined with an empty string, comma, or term.

Examples:

```
5d
5d3h12min
5 days and 12 hours
```