### PR TITLE
[resotocore][fix] Define configfile parameter explicitly

### DIFF
--- a/resotocore/core/cli/command.py
+++ b/resotocore/core/cli/command.py
@@ -2198,6 +2198,7 @@ class SystemCommand(CLICommand, PreserveOutputFormat):
                 "--server.database", args.graphdb_database,
                 "--server.username", args.graphdb_username,
                 "--server.password", args.graphdb_password,
+                "--configuration", "none",
                 stderr=asyncio.subprocess.PIPE,
             )
             # fmt: on
@@ -2251,6 +2252,7 @@ class SystemCommand(CLICommand, PreserveOutputFormat):
                 "--server.database", args.graphdb_database,
                 "--server.username", args.graphdb_username,
                 "--server.password", args.graphdb_password,
+                "--configuration", "none",
                 stderr=asyncio.subprocess.PIPE,
             )
             # fmt: on


### PR DESCRIPTION
Otherwise the system command might fail in certain scenarios.
This happens under tox, but not under pytest directly.