### PR TITLE
[CI] Use edge tag for k8s build test

### DIFF
--- a/.github/workflows/k8s-build.yml
+++ b/.github/workflows/k8s-build.yml
@@ -30,7 +30,7 @@ jobs:
                 version: "v0.11.1"
             - name: Testing
               run: |
-                  NO_START_KIND=1 IMAGE_TAG=latest bash -x ./kubernetes/setup-kind.sh
+                  NO_START_KIND=1 IMAGE_TAG=edge bash -x ./kubernetes/setup-kind.sh
                   # make sure we get the example collector in a reasonable time.
                   timeout 1m /bin/bash -c "until echo kind |kubectl --namespace resoto exec -i deploy/resoto-resotocore -- resh --stdin|grep example_resource; do sleep 1; done"
             - name: Debug info on failure

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@
 
 [![Version](https://img.shields.io/github/v/tag/someengineering/resoto?label=latest)](https://github.com/someengineering/resoto/tags/)
 [![Build](https://img.shields.io/github/workflow/status/someengineering/resoto/Build%20Docker%20Images/main)](https://github.com/someengineering/resoto/commits/main)
-[![Docs](https://img.shields.io/badge/docs-latest-<COLOR>.svg)](https://docs.some.engineering)
+[![Docs](https://img.shields.io/badge/docs-latest-<COLOR>.svg)](https://resoto.com/docs)
 [![Discord](https://img.shields.io/discord/778029408132923432?label=discord)](https://discord.gg/someengineering)
 [![CodeCoverage](https://img.shields.io/codecov/c/github/someengineering/resoto?token=ZEZW5JAR5J)](https://app.codecov.io/gh/someengineering/resoto/)
 
 ## Table of contents
 
 * [Overview](#overview)
-* [Docker based quick start](#docker-based-quick-start)
+* [Docker-based quick start](#docker-based-quick-start)
 * [Cloning this repository](#cloning-this-repository)
 * [Component list](#component-list)
 * [Contact](#contact)


### PR DESCRIPTION
# Description

I noticed that the k8s build CI is pulling the `latest` tag, which does not necessarily reflect the current state of the repo:

```
Containers:
  resoto:
    Container ID:  
    Image:         ghcr.io/someengineering/resoto:latest
```

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
