### PR TITLE
[github] Update PR template w/ documentation to-do

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,16 +4,18 @@
 
 # To-Dos
 
-<!-- Before submitting this PR, please lint and build your changes locally. -->
+<!-- Before submitting this PR, please lint and test your changes locally. -->
 <!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
+<!-- (Feel free to remove any items that do not apply to this PR.) -->
 
-- [ ] Test coverage for new or updated functionality
+- [ ] Add test coverage for new or updated functionality
 - [ ] Lint and test with `tox`
+- [ ] Document new or updated functionality (someengineering/resoto.com#XXXX)
 
 # Issues Fixed
 
 <!-- If this PR will fix/resolve an open issue on the repository, please reference it below. -->
-<!-- Otherwise, please delete this section. -->
+<!-- (Otherwise, feel free to delete this section.) -->
 
 - Fixes #XXXX
 


### PR DESCRIPTION
# Description

Remind PR authors that documentation needs to be updated, by adding a to-do to the PR template.

Users can easily reference the relevant documentation PR in the someengineering/resoto.com repo by simply replacing `XXXX` with the PR number/ID.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
