### PR TITLE
[resotocore][feat] Tag update allows format like templating

### DIFF
--- a/resotocore/tox.ini
+++ b/resotocore/tox.ini
@@ -5,6 +5,7 @@ application-import-names=core tests
 
 [pytest]
 testpaths= tests
+asyncio_mode = auto
 
 [testenv]
 usedevelop = true


### PR DESCRIPTION
# Description

The value of a tag update can back-reference attributes from a resource in the same way as the `format` command.
<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`

# Issues Fixed

<!-- If this PR will fix/resolve an open issue on the repository, please reference it below. -->
<!-- (Otherwise, feel free to delete this section.) -->

- Fixes #595

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
