### PR TITLE
[README] fix dead link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ We assume you are familiar with basic Docker operations and how to operate a Lin
 
 # Component list
 - [`resotocore`](resotocore/) the platform maintaining the [MultiDiGraph](https://en.wikipedia.org/wiki/Multigraph#Directed_multigraph_(edges_with_own_identity)).
-- [`resotosh`](resotosh/) the Resoto shell to interact with the core.
+- [`resotoshell`](resotoshell/) the Resoto shell to interact with the core.
 - [`resotoworker`](resotoworker/) provides workers that load [plugins](plugins/) to perform collect and cleanup operations.
 - [`resotometrics`](resotometrics/) is a [Prometheus](https://prometheus.io/) [exporter](https://prometheus.io/docs/instrumenting/exporters/).
 - [`plugins`](plugins/) are a collection of worker plugins like [AWS](plugins/aws/)


### PR DESCRIPTION
# Description

Link to `resotoshell` had a typo.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
