### PR TITLE
[resotolib][feat] Implement a dependent node iterator

### DIFF
--- a/resotolib/resotolib/graph/graph_extensions.py
+++ b/resotolib/resotolib/graph/graph_extensions.py
@@ -5,7 +5,7 @@ from networkx import DiGraph, connected_components
 
 def dependent_node_iterator(
     in_graph: DiGraph,
-) -> List[Generator[List[Any], None, None]]:
+) -> Generator[List[Any], None, None]:
     """
     Produces a list of generators, where each generator produces a list of nodes.
     Each generation of nodes only depend on previously generated nodes.
@@ -37,7 +37,17 @@ def dependent_node_iterator(
     # reverse the directed graph -> a leaf becomes a root
     graph = in_graph.reverse()
     # find all islands and create a generator per island
-    return [
+    generators = [
         successor_it(graph.subgraph(island_nodes))
         for island_nodes in connected_components(graph.to_undirected(as_view=True))
     ]
+    # concatenate the result of the generators
+    while generators:
+        nxt = []
+        for e in generators:
+            try:
+                nxt.extend(next(e))
+            except StopIteration:
+                generators.remove(e)
+        if nxt:
+            yield nxt

--- a/resotolib/resotolib/graph/graph_extensions.py
+++ b/resotolib/resotolib/graph/graph_extensions.py
@@ -1,4 +1,4 @@
-from typing import List, Any, Generator
+from typing import List, Any, Generator, Hashable
 
 from networkx import DiGraph, connected_components
 
@@ -19,7 +19,7 @@ def dependent_node_iterator(
 
         # make sure a node is only selected if it is not visited already
         # and all predecessors have been visited already
-        def allowed(nid: Any) -> bool:
+        def allowed(nid: Hashable) -> bool:
             pred = g.predecessors(nid)
             req = [n for n in pred if n != nid and n not in visited]
             return nid not in visited and not req

--- a/resotolib/resotolib/graph/graph_extensions.py
+++ b/resotolib/resotolib/graph/graph_extensions.py
@@ -7,7 +7,7 @@ def dependent_node_iterator(
     in_graph: DiGraph,
 ) -> Generator[List[Any], None, None]:
     """
-    Produces a list of generators, where each generator produces a list of nodes.
+    Create a generator that produces a list of nodes.
     Each generation of nodes only depend on previously generated nodes.
     """
 

--- a/resotolib/resotolib/graph/graph_extensions.py
+++ b/resotolib/resotolib/graph/graph_extensions.py
@@ -1,0 +1,44 @@
+from typing import List, Any, Generator
+
+from networkx import DiGraph, connected_components
+
+
+def dependent_node_iterator(
+    in_graph: DiGraph,
+) -> List[Generator[List[Any], None, None]]:
+    """
+    Produces a list of generators, where each generator produces a list of nodes.
+    Each generation of nodes only depend on previously generated nodes.
+    All nodes from the same generation can be treated
+    """
+
+    def successor_it(g: DiGraph) -> Generator[List[Any], None, None]:
+        nodes = g.nodes
+        visited = set()
+        # start with all roots of the sub-graph
+        to_emit = {n for n, d in g.in_degree if d == 0}
+
+        # make sure a node is only selected if it is not visited already
+        # and all predecessors have been visited already
+        def allowed(nid: Any) -> bool:
+            pred = g.predecessors(nid)
+            req = [n for n in pred if n != nid and n not in visited]
+            return nid not in visited and not req
+
+        while to_emit:
+            # emit the related node data
+            yield [nodes[nid] for nid in to_emit]
+            # add all nodes as visited
+            visited.update(to_emit)
+            # get all successors
+            to_emit = {
+                succ for nid in to_emit for succ in g.successors(nid) if allowed(succ)
+            }
+
+    # reverse the directed graph -> a leaf becomes a root
+    graph = in_graph.reverse()
+    # find all islands and create a generator per island
+    return [
+        successor_it(graph.subgraph(island_nodes))
+        for island_nodes in connected_components(graph.to_undirected(as_view=True))
+    ]

--- a/resotolib/resotolib/graph/graph_extensions.py
+++ b/resotolib/resotolib/graph/graph_extensions.py
@@ -9,7 +9,6 @@ def dependent_node_iterator(
     """
     Produces a list of generators, where each generator produces a list of nodes.
     Each generation of nodes only depend on previously generated nodes.
-    All nodes from the same generation can be treated
     """
 
     def successor_it(g: DiGraph) -> Generator[List[Any], None, None]:

--- a/resotolib/test/test_graph_extensions.py
+++ b/resotolib/test/test_graph_extensions.py
@@ -21,21 +21,21 @@ def graph() -> DiGraph:
 
 def test_reversed_directed_traversal(graph: DiGraph):
     result = [list(island) for island in dependent_node_iterator(graph)]
-    assert len(result) == 3  # 3 islands
+    assert len(result) == 3  # 3 steps to complete
 
-    def nodes(ls: List[List[int]]) -> List[List[Dict[str, int]]]:
-        return [[{"id": e} for e in sub] for sub in ls]
+    def nodes(*ls: int) -> List[Dict[str, int]]:
+        return [{"id": e} for e in ls]
 
-    island1, island2, island3 = result
-    assert island1 == nodes([[3], [2], [1]])  # 3 -> 2 -> 1
-    assert island2 == nodes([[5, 7], [6], [4]])  # 5,7 -> 6 -> 4
-    assert island3 == nodes([[10, 11, 13], [9, 12], [8]])  # 10,11,13 -> 9,12 -> 8
+    assert result == [
+        nodes(3, 5, 7, 10, 11, 13),
+        nodes(2, 6, 9, 12),
+        nodes(1, 4, 8),
+    ]
 
 
 def test_delete_nodes(graph: DiGraph):
     to_delete = graph.copy()
-    for island in dependent_node_iterator(graph):
-        for parallel in island:
-            for node in parallel:
-                to_delete.remove_node(node["id"])
+    for parallel in dependent_node_iterator(graph):
+        for node in parallel:
+            to_delete.remove_node(node["id"])
     assert len(to_delete.nodes) == 0

--- a/resotolib/test/test_graph_extensions.py
+++ b/resotolib/test/test_graph_extensions.py
@@ -20,16 +20,15 @@ def graph() -> DiGraph:
 
 
 def test_reversed_directed_traversal(graph: DiGraph):
-    result = [list(island) for island in dependent_node_iterator(graph)]
-    assert len(result) == 3  # 3 steps to complete
-
     def nodes(*ls: int) -> List[Dict[str, int]]:
         return [{"id": e} for e in ls]
 
+    result = list(dependent_node_iterator(graph))
+    assert len(result) == 3  # 3 steps to complete
     assert result == [
-        nodes(3, 5, 7, 10, 11, 13),
-        nodes(2, 6, 9, 12),
-        nodes(1, 4, 8),
+        nodes(3, 5, 7, 10, 11, 13),  # step 1
+        nodes(2, 6, 9, 12),  # step 2
+        nodes(1, 4, 8),  # step 3
     ]
 
 

--- a/resotolib/test/test_graph_extensions.py
+++ b/resotolib/test/test_graph_extensions.py
@@ -38,3 +38,7 @@ def test_delete_nodes(graph: DiGraph):
         for node in parallel:
             to_delete.remove_node(node["id"])
     assert len(to_delete.nodes) == 0
+
+
+def test_empty_graph():
+    assert list(dependent_node_iterator(DiGraph())) == []

--- a/resotolib/test/test_graph_extensions.py
+++ b/resotolib/test/test_graph_extensions.py
@@ -1,0 +1,41 @@
+from typing import Dict, List
+
+from networkx import DiGraph
+from pytest import fixture
+
+from resotolib.graph.graph_extensions import dependent_node_iterator
+
+
+@fixture
+def graph() -> DiGraph:
+    g = DiGraph()
+    for i in range(1, 14):
+        g.add_node(i, id=i)
+    g.add_edges_from([(1, 2), (1, 3), (2, 3)])  # island 1
+    g.add_edges_from([(4, 5), (4, 6), (6, 7)])  # island 2
+    g.add_edges_from(
+        [(8, 9), (9, 10), (9, 11), (8, 12), (12, 11), (12, 13)]
+    )  # island 3
+    return g
+
+
+def test_reversed_directed_traversal(graph: DiGraph):
+    result = [list(island) for island in dependent_node_iterator(graph)]
+    assert len(result) == 3  # 3 islands
+
+    def nodes(ls: List[List[int]]) -> List[List[Dict[str, int]]]:
+        return [[{"id": e} for e in sub] for sub in ls]
+
+    island1, island2, island3 = result
+    assert island1 == nodes([[3], [2], [1]])  # 3 -> 2 -> 1
+    assert island2 == nodes([[5, 7], [6], [4]])  # 5,7 -> 6 -> 4
+    assert island3 == nodes([[10, 11, 13], [9, 12], [8]])  # 10,11,13 -> 9,12 -> 8
+
+
+def test_delete_nodes(graph: DiGraph):
+    to_delete = graph.copy()
+    for island in dependent_node_iterator(graph):
+        for parallel in island:
+            for node in parallel:
+                to_delete.remove_node(node["id"])
+    assert len(to_delete.nodes) == 0


### PR DESCRIPTION
# Description
Walk a loosely connected graph by dependent edges.
Emit list of nodes in generations, so one generation of nodes always only depend on previous generations of nodes.


<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`

# Issues Fixed

<!-- If this PR will fix/resolve an open issue on the repository, please reference it below. -->
<!-- (Otherwise, feel free to delete this section.) -->

- Fixes #XXXX

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
