### PR TITLE
[resotocore][fix] Allow absolute path in jq

### DIFF
--- a/resotocore/core/cli/command.py
+++ b/resotocore/core/cli/command.py
@@ -1285,7 +1285,7 @@ class JqCommand(CLICommand, OutputTransformer):
     def info(self) -> str:
         return "Filter and process json."
 
-    path_re = re.compile("[.](?:([A-Za-z])+|(\\[]))[A-Za-z0-9\\[\\].]*")
+    path_re = re.compile("[.](?:(/?[A-Za-z]+)|(\\[]))[A-Za-z0-9\\[\\].]*")
 
     @staticmethod
     def rewrite_props(arg: str, ctx: CLIContext) -> str:


### PR DESCRIPTION
# Description

```
query xxxx | jq ./reported
```
<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`
