### PR TITLE
[resotocore][fix] Tag commands that require plain output

### DIFF
--- a/resotocore/core/cli/cli.py
+++ b/resotocore/core/cli/cli.py
@@ -45,7 +45,9 @@ from core.cli.model import (
     CLIContext,
     EmptyContext,
     CLISource,
+    NoTerminalOutput,
 )
+from core.console_renderer import ConsoleRenderer
 from core.error import CLIParseError
 from core.model.typed_model import class_fqn
 from core.parse_util import (
@@ -316,9 +318,17 @@ class CLI:
                 return ctx_wq, [*query_parts, *remaining]
             return ctx, commands
 
-        async def parse_line(parsed: ParsedCommands) -> ParsedCommandLine:
+        def adjust_context(parsed: ParsedCommands) -> CLIContext:
             cmd_env = {**self.cli_env, **context.env, **parsed.env}
             ctx = replace(context, env=cmd_env)
+            last_command = self.commands.get(parsed.commands[-1].cmd) if parsed.commands else None
+            if isinstance(last_command, NoTerminalOutput) and ctx.console_renderer:
+                return replace(ctx, env=cmd_env, console_renderer=ConsoleRenderer.default_renderer())
+            else:
+                return replace(context, env=cmd_env)
+
+        async def parse_line(parsed: ParsedCommands) -> ParsedCommandLine:
+            ctx = adjust_context(parsed)
             ctx, commands = await combine_query_parts([self.command(c.cmd, c.args, ctx) for c in parsed.commands], ctx)
             not_met = [r for cmd in commands for r in cmd.action.required if r.name not in context.uploaded_files]
             return ParsedCommandLine(ctx, parsed, commands, not_met)

--- a/resotocore/core/cli/command.py
+++ b/resotocore/core/cli/command.py
@@ -65,6 +65,7 @@ from core.cli.model import (
     CLIFileRequirement,
     CLIDependencies,
     ParsedCommand,
+    NoTerminalOutput,
 )
 from core.db.model import QueryModel
 from core.dependencies import system_info
@@ -2734,7 +2735,7 @@ class SystemCommand(CLICommand, PreserveOutputFormat):
             raise CLIParseError(f"system: Can not parse {arg}")
 
 
-class WriteCommand(CLICommand):
+class WriteCommand(CLICommand, NoTerminalOutput):
     """
     ```shell
     write <file-name>

--- a/resotocore/core/cli/model.py
+++ b/resotocore/core/cli/model.py
@@ -60,7 +60,7 @@ class CLIContext:
     uploaded_files: Dict[str, str] = field(default_factory=dict)  # id -> path
     query: Optional[Query] = None
     query_options: Dict[str, Any] = field(default_factory=dict)
-    console_formatter: Optional[ConsoleRenderer] = None
+    console_renderer: Optional[ConsoleRenderer] = None
 
     def variable_in_section(self, variable: str) -> str:
         # if there is no query, always assume the root section
@@ -68,8 +68,8 @@ class CLIContext:
         return variable_to_absolute(section, variable)
 
     def render_console(self, element: Union[str, JupyterMixin]) -> str:
-        if self.console_formatter:
-            return self.console_formatter.render(element)
+        if self.console_renderer:
+            return self.console_renderer.render(element)
         elif isinstance(element, JupyterMixin):
             return str(element)
         else:
@@ -301,6 +301,12 @@ class OutputTransformer(ABC):
 class PreserveOutputFormat(ABC):
     """
     Mark all commands where the output should not be flattened to default line output.
+    """
+
+
+class NoTerminalOutput(ABC):
+    """
+    Mark all commands where the output should not contain any terminal escape codes.
     """
 
 

--- a/resotocore/core/web/api.py
+++ b/resotocore/core/web/api.py
@@ -704,13 +704,11 @@ class Api:
             rows = int(request.headers.get("Resoto-Shell-Rows", "50"))
             terminal = request.headers.get("Resoto-Shell-Terminal", "false") == "true"
             colors = ConsoleColorSystem.from_name(request.headers.get("Resoto-Shell-Color-System", "monochrome"))
-            formatter = ConsoleRenderer.create_renderer(
-                width=columns, height=rows, color_system=colors, terminal=terminal
-            )
-            return CLIContext(env=dict(request.query), console_formatter=formatter)
+            renderer = ConsoleRenderer(width=columns, height=rows, color_system=colors, terminal=terminal)
+            return CLIContext(env=dict(request.query), console_renderer=renderer)
         except Exception as ex:
             log.debug("Could not create CLI context.", exc_info=ex)
-            return CLIContext(env=dict(request.query), console_formatter=ConsoleRenderer.create_renderer())
+            return CLIContext(env=dict(request.query), console_renderer=ConsoleRenderer.default_renderer())
 
     async def evaluate(self, request: Request) -> StreamResponse:
         ctx = self.cli_context_from_request(request)

--- a/resotocore/tests/core/console_renderer_test.py
+++ b/resotocore/tests/core/console_renderer_test.py
@@ -19,7 +19,7 @@ def test_from_name() -> None:
 
 def test_renderer_is_thread_safe() -> None:
     element = Text("some", "blue").append(Text("=", "dim").append("23", "green"))
-    renderer = ConsoleRenderer.create_renderer(color_system=ConsoleColorSystem.standard)
+    renderer = ConsoleRenderer(color_system=ConsoleColorSystem.standard)
     expected = renderer.render(element)
 
     def render() -> None:

--- a/resotocore/tests/core/model/model_test.py
+++ b/resotocore/tests/core/model/model_test.py
@@ -430,7 +430,7 @@ def model_json() -> str:
 
 
 def test_markup() -> None:
-    ctx = CLIContext(console_formatter=ConsoleRenderer.create_renderer(color_system=ConsoleColorSystem.monochrome))
+    ctx = CLIContext(console_renderer=ConsoleRenderer(color_system=ConsoleColorSystem.monochrome))
     md = dedent(
         """
         - b1 test


### PR DESCRIPTION
# Description

Introduce a marker trait to identify commands that do not write to the console.
Terminal escape codes are stripped in such a case.
The `write` command is marked with this trait.

<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`

# Issues Fixed

<!-- If this PR will fix/resolve an open issue on the repository, please reference it below. -->
<!-- (Otherwise, feel free to delete this section.) -->

- Fixes #623

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
