### PR TITLE
[github][fix] Add truncate marker to generated release notes

### DIFF
--- a/tools/release_notes.py
+++ b/tools/release_notes.py
@@ -81,6 +81,7 @@ def show_log(from_tag: str, to_tag: str):
                 f"([#{commit.pr}](https://github.com/someengineering/resoto/pull/{commit.pr}))"
             )
 
+    print("\n<!--truncate-->")
     print("\n## Docker Images")
     print("\n### All-in-One\n")
     print(f"- `somecr.io/someengineering/resoto:{to_tag}`")


### PR DESCRIPTION
# Description

Adds truncate marker to generated release notes, for better list view in Docusaurus.

**Note:** This marker should be moved above the changelog in cases where additional content is added above the auto-generated list of commits.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
