### PR TITLE
[resotoworker] [bug] Export graph to disk before opening connection t…

### DIFF
--- a/resotolib/resotolib/graph/__init__.py
+++ b/resotolib/resotolib/graph/__init__.py
@@ -795,7 +795,7 @@ class GraphExportIterator:
         gmk = getattr(ArgumentParser.args, "graph_merge_kind", "cloud")
         if gmk == "account":
             self.graph_merge_kind = BaseAccount
-        self.graph_dumped = False
+        self.graph_exported = False
         self.total_lines = 0
         self.dump_lock = threading.Lock()
 
@@ -806,8 +806,8 @@ class GraphExportIterator:
             pass
 
     def __iter__(self):
-        if not self.graph_dumped:
-            self.dump_graph()
+        if not self.graph_exported:
+            self.export_graph()
         start_time = time()
         last_sent = time()
         lines_sent = 0
@@ -829,7 +829,7 @@ class GraphExportIterator:
         log.debug(f"Sent {lines_sent} nodes and edges in {elapsed:.4f}s")
         self.tempfile.seek(0)
 
-    def dump_graph(self):
+    def export_graph(self):
         with self.dump_lock:
             start_time = time()
             for node in self.graph.nodes:
@@ -865,6 +865,6 @@ class GraphExportIterator:
                 f"Wrote {self.total_lines} nodes and edges"
                 f" to {self.tempfile.name} in {elapsed:.4f}s"
             )
-            self.graph_dumped = True
+            self.graph_exported = True
             del self.graph
             self.tempfile.seek(0)

--- a/resotolib/resotolib/graph/__init__.py
+++ b/resotolib/resotolib/graph/__init__.py
@@ -796,8 +796,8 @@ class GraphExportIterator:
         if gmk == "account":
             self.graph_merge_kind = BaseAccount
         self.graph_exported = False
+        self.export_lock = threading.Lock()
         self.total_lines = 0
-        self.dump_lock = threading.Lock()
 
     def __del__(self):
         try:
@@ -830,7 +830,7 @@ class GraphExportIterator:
         self.tempfile.seek(0)
 
     def export_graph(self):
-        with self.dump_lock:
+        with self.export_lock:
             start_time = time()
             for node in self.graph.nodes:
                 node_dict = node_to_dict(node)

--- a/resotoworker/resotoworker/resotocore.py
+++ b/resotoworker/resotoworker/resotocore.py
@@ -72,6 +72,7 @@ def send_graph(
     log.debug(f"Sending graph via {merge_uri}")
 
     graph_export_iterator = GraphExportIterator(graph, delete_tempfile=not dump_json)
+    graph_export_iterator.dump_graph()
 
     headers = {
         "Content-Type": "application/x-ndjson",

--- a/resotoworker/resotoworker/resotocore.py
+++ b/resotoworker/resotoworker/resotocore.py
@@ -72,7 +72,7 @@ def send_graph(
     log.debug(f"Sending graph via {merge_uri}")
 
     graph_export_iterator = GraphExportIterator(graph, delete_tempfile=not dump_json)
-    graph_export_iterator.dump_graph()
+    graph_export_iterator.export_graph()
 
     headers = {
         "Content-Type": "application/x-ndjson",


### PR DESCRIPTION
# Description

Call the `export_graph()` method before opening the connection to `resotocore`.
For very large graphs, if the graph is only exported after the connection to core has been established, it might take longer than 30 seconds and cause a timeout in the core.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
