### PR TITLE
[resotolib/resotoworker][feat] Allow specifying the directory to create temp files in

### DIFF
--- a/resotolib/resotolib/graph/__init__.py
+++ b/resotolib/resotolib/graph/__init__.py
@@ -784,10 +784,13 @@ def sanitize(graph: Graph, root: GraphRoot = None) -> None:
 
 
 class GraphExportIterator:
-    def __init__(self, graph: Graph, delete_tempfile: bool = True):
+    def __init__(self, graph: Graph, delete_tempfile: bool = True, tempdir: str = None):
         self.graph = graph
         self.tempfile = tempfile.NamedTemporaryFile(
-            prefix="resoto-graph-", suffix=".ndjson", delete=delete_tempfile
+            prefix="resoto-graph-",
+            suffix=".ndjson",
+            delete=delete_tempfile,
+            dir=tempdir,
         )
         if not delete_tempfile:
             log.info(f"Writing graph json to file {self.tempfile.name}")


### PR DESCRIPTION

# Description

Introduces an arg `--tempdir` to `resotoworker` that allows specifying a directory to create temporary files in. This is useful in environments with large graphs where there is no swap and `/tmp` resides on a RAM backed `tmpfs`. This might be a situation where one would want to specify an alternative temp location on disk like `/var/tmp` or something custom.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
