### PR TITLE
[resotocore][feat] successors,predecessors,ancestors, descendants useedge_type from env

### DIFF
--- a/resotocore/core/cli/cli.py
+++ b/resotocore/core/cli/cli.py
@@ -260,16 +260,16 @@ class CLI:
             if isinstance(part, QueryAllPart):
                 query = query.combine(await parse_query(arg))
             elif isinstance(part, PredecessorPart):
-                origin, edge = PredecessorPart.parse_args(arg)
+                origin, edge = PredecessorPart.parse_args(arg, ctx)
                 query = query.traverse_in(origin, 1, edge)
             elif isinstance(part, SuccessorPart):
-                origin, edge = PredecessorPart.parse_args(arg)
+                origin, edge = PredecessorPart.parse_args(arg, ctx)
                 query = query.traverse_out(origin, 1, edge)
             elif isinstance(part, AncestorPart):
-                origin, edge = PredecessorPart.parse_args(arg)
+                origin, edge = PredecessorPart.parse_args(arg, ctx)
                 query = query.traverse_in(origin, Navigation.Max, edge)
             elif isinstance(part, DescendantPart):
-                origin, edge = PredecessorPart.parse_args(arg)
+                origin, edge = PredecessorPart.parse_args(arg, ctx)
                 query = query.traverse_out(origin, Navigation.Max, edge)
             elif isinstance(part, AggregatePart):
                 group_vars, group_function_vars = aggregate_parameter_parser.parse(arg)

--- a/resotocore/core/cli/command.py
+++ b/resotocore/core/cli/command.py
@@ -342,7 +342,7 @@ class PredecessorPart(QueryPart):
     - `edge_type` [Optional, default to `default`]: Defines the type of edge to navigate.
 
     ## Environment Variables
-    - `edge_type` [Optional]: Defines the type if the edge to navigate.
+    - `edge_type` [Optional]: Defines the type of the edge to navigate.
       The parameter takes precedence over the env var.
 
     ## Examples
@@ -399,7 +399,7 @@ class SuccessorPart(QueryPart):
     - `edge_type` [Optional, default to `default`]: Defines the type of edge to navigate.
 
     ## Environment Variables
-    - `edge_type` [Optional]: Defines the type if the edge to navigate.
+    - `edge_type` [Optional]: Defines the type of the edge to navigate.
       The parameter takes precedence over the env var.
 
 
@@ -443,7 +443,7 @@ class AncestorPart(QueryPart):
     - `edge_type` [Optional, default to `default`]: Defines the type of edge to navigate.
 
     ## Environment Variables
-    - `edge_type` [Optional]: Defines the type if the edge to navigate.
+    - `edge_type` [Optional]: Defines the type of the edge to navigate.
       The parameter takes precedence over the env var.
 
     ## Examples
@@ -490,7 +490,7 @@ class DescendantPart(QueryPart):
     - `edge_type` [Optional, default to `default`]: Defines the type of edge to navigate.
 
     ## Environment Variables
-    - `edge_type` [Optional]: Defines the type if the edge to navigate.
+    - `edge_type` [Optional]: Defines the type of the edge to navigate.
       The parameter takes precedence over the env var.
 
     ## Examples

--- a/resotocore/core/cli/command.py
+++ b/resotocore/core/cli/command.py
@@ -341,14 +341,9 @@ class PredecessorPart(QueryPart):
     ## Parameters
     - `edge_type` [Optional, default to `default`]: Defines the type of edge to navigate.
 
-    This command extends an already existing query.
-    It will select all descendants of the currently selected nodes of the query.
-    The graph may contain different types of edges (e.g. the `default` graph or the `delete` graph).
-    In order to define which graph to walk, the edge_type can be specified.
-
-    If --with-origin is specified, the current element is included in the result set as well.
-    Assume node A with descendant B with descendant C: A --> B --> C `query id(A) | descendants`
-    will select B and A, while `query id(A) | descendants --with-origin` will select C and B and A.
+    ## Environment Variables
+    - `edge_type` [Optional]: Defines the type if the edge to navigate.
+      The parameter takes precedence over the env var.
 
     ## Examples
 
@@ -368,7 +363,7 @@ class PredecessorPart(QueryPart):
         return "Select all predecessors of this node in the graph."
 
     @staticmethod
-    def parse_args(arg: Optional[str] = None) -> Tuple[int, str]:
+    def parse_args(arg: Optional[str], ctx: CLIContext) -> Tuple[int, str]:
         def valid_edge_type(name: str) -> str:
             if name in EdgeType.all:
                 return name
@@ -377,7 +372,7 @@ class PredecessorPart(QueryPart):
 
         parser = NoExitArgumentParser()
         parser.add_argument("--with-origin", dest="origin", default=1, action="store_const", const=0)
-        parser.add_argument("edge", default=EdgeType.default, type=valid_edge_type, nargs="?")
+        parser.add_argument("edge", default=ctx.env.get("edge_type", EdgeType.default), type=valid_edge_type, nargs="?")
         parsed = parser.parse_args(arg.split() if arg else [])
         return parsed.origin, parsed.edge
 
@@ -402,14 +397,10 @@ class SuccessorPart(QueryPart):
 
     ## Parameters
     - `edge_type` [Optional, default to `default`]: Defines the type of edge to navigate.
-    This command extends an already existing query.
-    It will select all descendants of the currently selected nodes of the query.
-    The graph may contain different types of edges (e.g. the `default` graph or the `delete` graph).
-    In order to define which graph to walk, the edge_type can be specified.
 
-    If --with-origin is specified, the current element is included in the result set as well.
-    Assume node A with descendant B with descendant C: A --> B --> C `query id(A) | descendants`
-    will select B and A, while `query id(A) | descendants --with-origin` will select C and B and A.
+    ## Environment Variables
+    - `edge_type` [Optional]: Defines the type if the edge to navigate.
+      The parameter takes precedence over the env var.
 
 
     ## Examples
@@ -450,14 +441,10 @@ class AncestorPart(QueryPart):
 
     ## Parameters
     - `edge_type` [Optional, default to `default`]: Defines the type of edge to navigate.
-    This command extends an already existing query.
-    It will select all descendants of the currently selected nodes of the query.
-    The graph may contain different types of edges (e.g. the `default` graph or the `delete` graph).
-    In order to define which graph to walk, the edge_type can be specified.
 
-    If --with-origin is specified, the current element is included in the result set as well.
-    Assume node A with descendant B with descendant C: A --> B --> C `query id(A) | descendants`
-    will select B and A, while `query id(A) | descendants --with-origin` will select C and B and A.
+    ## Environment Variables
+    - `edge_type` [Optional]: Defines the type if the edge to navigate.
+      The parameter takes precedence over the env var.
 
     ## Examples
 
@@ -501,6 +488,10 @@ class DescendantPart(QueryPart):
 
     ## Parameters
     - `edge_type` [Optional, default to `default`]: Defines the type of edge to navigate.
+
+    ## Environment Variables
+    - `edge_type` [Optional]: Defines the type if the edge to navigate.
+      The parameter takes precedence over the env var.
 
     ## Examples
 

--- a/resotocore/tests/core/cli/cli_test.py
+++ b/resotocore/tests/core/cli/cli_test.py
@@ -6,7 +6,7 @@ from pytest import fixture
 from typing import Tuple, List, AsyncIterator
 
 from core.analytics import InMemoryEventSender
-from core.cli.model import ParsedCommands, ParsedCommand
+from core.cli.model import ParsedCommands, ParsedCommand, CLIContext
 from core.cli.cli import CLI, multi_command_parser
 from core.cli.model import CLIDependencies
 from core.cli.command import (
@@ -184,10 +184,15 @@ async def test_parse_env_vars(cli: CLI) -> None:
 
 
 def test_parse_predecessor_successor_ancestor_descendant_args() -> None:
-    assert PredecessorPart.parse_args() == (1, EdgeType.default)
-    assert PredecessorPart.parse_args("--with-origin") == (0, EdgeType.default)
-    assert PredecessorPart.parse_args("--with-origin delete") == (0, EdgeType.delete)
-    assert PredecessorPart.parse_args("delete") == (1, EdgeType.delete)
+    plain = CLIContext()
+    w_delete = CLIContext(env={"edge_type": EdgeType.delete})
+    assert PredecessorPart.parse_args(None, w_delete) == (1, EdgeType.delete)
+    assert PredecessorPart.parse_args(None, plain) == (1, EdgeType.default)
+    assert PredecessorPart.parse_args("--with-origin", plain) == (0, EdgeType.default)
+    assert PredecessorPart.parse_args("--with-origin", w_delete) == (0, EdgeType.delete)
+    assert PredecessorPart.parse_args("--with-origin delete", plain) == (0, EdgeType.delete)
+    assert PredecessorPart.parse_args("--with-origin delete", w_delete) == (0, EdgeType.delete)
+    assert PredecessorPart.parse_args("delete", w_delete) == (1, EdgeType.delete)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION

# Description

The edge type can be either defined as an argument or as env var.
The argument takes always precedence over the env var.

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`
