### PR TITLE
[resotocore][fix] Fix aggregation functions using the same variable

### DIFF
--- a/resotocore/core/cli/cli.py
+++ b/resotocore/core/cli/cli.py
@@ -123,7 +123,9 @@ class HelpCommand(CLICommand):
             aliases = "\n".join(
                 f"{indent}- `{alias}` (`{cmd}`) - {self.parts[cmd].info()}" for alias, cmd in self.aliases.items()
             )
-            replacements = "\n".join(f"{indent}- `@{key}@` -> {value}" for key, value in CLI.replacements().items())
+            replacements = "\n".join(
+                f"{indent}- `@{key}@` -> {value}" for key, value in CLI.replacements(**ctx.env).items()
+            )
             result = dedent(
                 f"""
                  # resotocore CLI ({version()})

--- a/resotocore/core/db/arango_query.py
+++ b/resotocore/core/db/arango_query.py
@@ -110,12 +110,10 @@ def query_string(
             name = f"{cursor}.{fn.name}" if isinstance(fn.name, str) else str(fn.name)
             return f"{name} {fn.combined_ops()}" if fn.ops else name
 
-        vs = {str(v.name): f"var_{num}" for num, v in enumerate(a.group_by)}
-        fs = {v.name: f"fn_{num}" for num, v in enumerate(a.group_func)}
-        variables = ", ".join(f"{vs[str(v.name)]}={var_name(v.name)}" for v in a.group_by)
-        funcs = ", ".join(f"{fs[v.name]}={v.function}({func_term(v)})" for v in a.group_func)
-        agg_vars = ", ".join(f'"{v.get_as_name()}": {vs[str(v.name)]}' for v in a.group_by)
-        agg_funcs = ", ".join(f'"{f.get_as_name()}": {fs[f.name]}' for f in a.group_func)
+        variables = ", ".join(f"var_{num}={var_name(v.name)}" for num, v in enumerate(a.group_by))
+        funcs = ", ".join(f"fn_{num}={f.function}({func_term(f)})" for num, f in enumerate(a.group_func))
+        agg_vars = ", ".join(f'"{v.get_as_name()}": var_{num}' for num, v in enumerate(a.group_by))
+        agg_funcs = ", ".join(f'"{f.get_as_name()}": fn_{num}' for num, f in enumerate(a.group_func))
         group_result = f'"group":{{{agg_vars}}},' if a.group_by else ""
         aggregate_term = f"collect {variables} aggregate {funcs}"
         return_result = f"{{{group_result} {agg_funcs}}}"

--- a/resotocore/tests/core/cli/command_test.py
+++ b/resotocore/tests/core/cli/command_test.py
@@ -675,7 +675,7 @@ async def test_write_command(cli: CLI) -> None:
     assert await cli.execute_cli_command("help", stream.list, truecolor) != mono_out
     # We expect the content of the written file to contain monochrome output.
     assert await cli.execute_cli_command(
-        "help | write write_test.txt", partial(check_file, check_content="\n".join(mono_out[0])), truecolor
+        "help | write write_test.txt", partial(check_file, check_content="\n".join(mono_out[0]), env=env), truecolor
     )
 
 

--- a/resotocore/tests/core/cli/command_test.py
+++ b/resotocore/tests/core/cli/command_test.py
@@ -675,7 +675,7 @@ async def test_write_command(cli: CLI) -> None:
     assert await cli.execute_cli_command("help", stream.list, truecolor) != mono_out
     # We expect the content of the written file to contain monochrome output.
     assert await cli.execute_cli_command(
-        "help | write write_test.txt", partial(check_file, check_content="\n".join(mono_out[0]), env=env), truecolor
+        "help | write write_test.txt", partial(check_file, check_content="\n".join(mono_out[0])), truecolor
     )
 
 

--- a/resotocore/tests/core/db/graphdb_test.py
+++ b/resotocore/tests/core/db/graphdb_test.py
@@ -414,6 +414,10 @@ async def test_query_aggregate(filled_graph_db: ArangoGraphDB, foo_model: Model)
     async with await filled_graph_db.query_aggregation(QueryModel(agg_combined_var_query, foo_model)) as g:
         assert [x async for x in g] == [{"group": {"kind": "test_foo_0_"}, "instances": 11}]
 
+    agg_multi_fn_same_prop = parse_query('aggregate(sum(f) as a, max(f) as b): is("bla")').on_section("reported")
+    async with await filled_graph_db.query_aggregation(QueryModel(agg_multi_fn_same_prop, foo_model)) as g:
+        assert [x async for x in g] == [{"a": 2300, "b": 23}]
+
 
 @pytest.mark.asyncio
 async def test_query_with_merge(filled_graph_db: ArangoGraphDB, foo_model: Model) -> None:


### PR DESCRIPTION
# Description

Queries that use the same variable in different aggregation functions did not work properly.
```
> query is(instance) | aggregate sum(1) as count,  sum(instance_cores) as cores, sum(instance_memory) as memory, max(instance_memory) as max_mem
```

<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`
