### PR TITLE
[plugin gcp][feat] Add GKE clusters resource

### DIFF
--- a/plugins/gcp/resoto_plugin_gcp/collector.py
+++ b/plugins/gcp/resoto_plugin_gcp/collector.py
@@ -553,7 +553,7 @@ class GCPProjectCollector:
         successors: List = None,
         predecessors: List = None,
         client_kwargs: Dict = None,
-        client_nested_callables: Type[str] = [],
+        client_nested_callables: List[str] = None,
         resource_kwargs: Dict = None,
         paginate_subitems_name: str = None,
         post_process: Callable = None,
@@ -594,6 +594,8 @@ class GCPProjectCollector:
             paginate_subitems_name = client_method_name
         if client_kwargs is None:
             client_kwargs = {}
+        if client_nested_callables is None:
+            client_nested_callables = []
         if resource_kwargs is None:
             resource_kwargs = {}
         if successors is None:

--- a/plugins/gcp/resoto_plugin_gcp/collector.py
+++ b/plugins/gcp/resoto_plugin_gcp/collector.py
@@ -9,6 +9,7 @@ from resotolib.args import ArgumentParser
 from resotolib.utils import except_log_and_pass
 from prometheus_client import Summary
 from .resources import (
+    GCPGKECluster,
     GCPProject,
     GCPQuota,
     GCPRegion,
@@ -222,6 +223,10 @@ metrics_collect_instance_templates = Summary(
     "resoto_plugin_gcp_collect_instance_templates_seconds",
     "Time it took the collect_instance_templates() method",
 )
+metrics_collect_gke_clusters = Summary(
+    "resoto_plugin_gcp_collect_gke_clusters_seconds",
+    "Time it took the collect_gke_clusters() method",
+)
 
 
 class GCPProjectCollector:
@@ -292,6 +297,7 @@ class GCPProjectCollector:
             "buckets": self.collect_buckets,
             "databases": self.collect_databases,
             "instance_templates": self.collect_instance_templates,
+            "gke_clusters": self.collect_gke_clusters,
         }
         # Region collectors collect resources in a single region.
         # They are being passed the GCPRegion resource object as `region` arg.
@@ -547,6 +553,7 @@ class GCPProjectCollector:
         successors: List = None,
         predecessors: List = None,
         client_kwargs: Dict = None,
+        client_nested_callables: Type[str] = [],
         resource_kwargs: Dict = None,
         paginate_subitems_name: str = None,
         post_process: Callable = None,
@@ -595,7 +602,9 @@ class GCPProjectCollector:
             predecessors = []
         parent_map = {True: predecessors, False: successors}
 
-        if "project" in default_resource_args:
+        # For APIs that take a parent (`projects/*/locations/*`) parameter,
+        # setting the project is not expected.
+        if not "parent" in resource_kwargs and "project" in default_resource_args:
             resource_kwargs["project"] = self.project.id
 
         client = gcp_client(
@@ -604,6 +613,13 @@ class GCPProjectCollector:
             credentials=self.credentials,
             **client_kwargs,
         )
+        
+        # Some more recent client implementations have nested callables before
+        # the actual client_method_name method, 
+        # e.g. discovery.build('container', 'v1').projects().locations().clusters()
+        for client_nested_callable in client_nested_callables:
+           client = getattr(client, client_nested_callable)()
+           
         gcp_resource = getattr(client, client_method_name)
         if not callable(gcp_resource):
             raise RuntimeError(f"No method {client_method_name} on client {client}")
@@ -1513,3 +1529,20 @@ class GCPProjectCollector:
             },
             predecessors=["__machine_type"],
         )
+
+    @metrics_collect_gke_clusters.time()
+    def collect_gke_clusters(self):
+        self.collect_something(
+            resource_class=GCPGKECluster,
+            resource_kwargs = {"parent": f"projects/{self.project.id}/locations/-"},
+            client_nested_callables = ["projects", "locations"],
+            paginate_items_name = "clusters",
+            attr_map={
+                "ctime": lambda r: iso2datetime(r.get("createTime")),
+                "initial_cluster_version": "initialClusterVersion",
+                "current_master_version": "currentMasterVersion",
+                "cluster_status": "status",
+                "current_node_count": "currentNodeCount",
+            },
+        )
+

--- a/plugins/gcp/resoto_plugin_gcp/collector.py
+++ b/plugins/gcp/resoto_plugin_gcp/collector.py
@@ -604,7 +604,7 @@ class GCPProjectCollector:
 
         # For APIs that take a parent (`projects/*/locations/*`) parameter,
         # setting the project is not expected.
-        if not "parent" in resource_kwargs and "project" in default_resource_args:
+        if "parent" not in resource_kwargs and "project" in default_resource_args:
             resource_kwargs["project"] = self.project.id
 
         client = gcp_client(
@@ -613,13 +613,13 @@ class GCPProjectCollector:
             credentials=self.credentials,
             **client_kwargs,
         )
-        
+
         # Some more recent client implementations have nested callables before
-        # the actual client_method_name method, 
+        # the actual client_method_name method,
         # e.g. discovery.build('container', 'v1').projects().locations().clusters()
         for client_nested_callable in client_nested_callables:
-           client = getattr(client, client_nested_callable)()
-           
+            client = getattr(client, client_nested_callable)()
+
         gcp_resource = getattr(client, client_method_name)
         if not callable(gcp_resource):
             raise RuntimeError(f"No method {client_method_name} on client {client}")
@@ -1534,9 +1534,9 @@ class GCPProjectCollector:
     def collect_gke_clusters(self):
         self.collect_something(
             resource_class=GCPGKECluster,
-            resource_kwargs = {"parent": f"projects/{self.project.id}/locations/-"},
-            client_nested_callables = ["projects", "locations"],
-            paginate_items_name = "clusters",
+            resource_kwargs={"parent": f"projects/{self.project.id}/locations/-"},
+            client_nested_callables=["projects", "locations"],
+            paginate_items_name="clusters",
             attr_map={
                 "ctime": lambda r: iso2datetime(r.get("createTime")),
                 "initial_cluster_version": "initialClusterVersion",
@@ -1545,4 +1545,3 @@ class GCPProjectCollector:
                 "current_node_count": "currentNodeCount",
             },
         )
-

--- a/plugins/gcp/resoto_plugin_gcp/resources.py
+++ b/plugins/gcp/resoto_plugin_gcp/resources.py
@@ -638,6 +638,7 @@ class GCPServiceSKU(GCPResource, PhantomBaseResource):
             if cost > -1:
                 self.usage_unit_nanos = cost
 
+
 @dataclass(eq=False)
 class GCPGKECluster(GCPResource, BaseResource):
     kind: ClassVar[str] = "gcp_gke_cluster"
@@ -671,9 +672,10 @@ class GCPGKECluster(GCPResource, BaseResource):
         )
         if self._cluster_status == InstanceStatus.TERMINATED:
             self._cleaned = True
-    
+
     def _cluster_status_getter(self) -> str:
         return self._cluster_status.value
+
 
 GCPGKECluster.cluster_status = property(
     GCPGKECluster._cluster_status_getter, GCPGKECluster._cluster_status_setter


### PR DESCRIPTION
# Description

Adding a GKE cluster resource with collector to the GCP plugin. This allows to collect `gke_clusters`. 
Please note that we are not collecting GKE nodepools yet and therefore do not link any instances.

```
> query is(gcp_gke_cluster) | head 3
kind=gcp_gke_cluster, id=b1256ccc4e044930b78633db406ccbec65792471847f418e979667415d30aa23, name=us-east1-fast-demo-9ccc7f42-gke, age=8mo23d, cloud=gcp, account=acme-labs
kind=gcp_gke_cluster, id=1ccc7052286042049a861bdd7afbe73cd75e0649f6e8477d9c30ec3744051e42, name=test-cluster-one, age=4mo25d, cloud=gcp, account=acme-labs
kind=gcp_gke_cluster, id=f0a9caae11dd416d961814188af5e8198c4b5714746e424ca6abff3204706042, name=marv-private-terraform-test-2, age=6d12h, cloud=gcp, account=acme-labs
```

# To-Dos
- [x] Add test coverage for new or updated functionality
- [X] Lint and test with `tox`
- [x] Document new or updated functionality (someengineering/resoto.com#XXXX)

The GCP plugin ships with practically no tests. Manual tests collections confirmed it is working as expected, as well as not breaking other resource type collections.

Additionally I'm unsure how to proceed with the documentation for the new resource. Is that something you folks can help me with?

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
