### PR TITLE
[resotocore][feat] Allow multiple edges types to traverse

### DIFF
--- a/resotocore/core/db/arango_query.py
+++ b/resotocore/core/db/arango_query.py
@@ -310,9 +310,10 @@ def query_string(
                 filter_clause = f"({term(crsr, cl.term)})" if cl.term else "true"
                 inner = traversal_filter(cl.with_clause, crsr, depth + 1) if cl.with_clause else ""
                 filter_root = f"({l0crsr}._key=={crsr}._key) or " if depth > 0 else ""
+                edge_type_traversals = f", {direction} ".join(db.edge_collection(et) for et in nav.edge_types)
                 return (
                     f"FOR {crsr} IN 0..{nav.until} {direction} {in_crs} "
-                    f"{db.edge_collection(nav.edge_type)} OPTIONS {{ bfs: true, {unique} }} "
+                    f"{edge_type_traversals} OPTIONS {{ bfs: true, {unique} }} "
                     f"FILTER {filter_root}{filter_clause} "
                 ) + inner
 
@@ -345,7 +346,9 @@ def query_string(
             )
             return out
 
-        def inout(in_crsr: str, start: int, until: int, edge_type: str, direction: str) -> str:
+        def inout(
+            in_crsr: str, start: int, until: int, edge_types: List[str], direction: str, out_edge_types: List[str]
+        ) -> str:
             nonlocal query_part
             in_c = next_crs("io_in")
             out = next_crs("io_out")
@@ -366,26 +369,34 @@ def query_string(
                 graph_cursor = in_c
                 outer_for = f"FOR {in_c} in {in_crsr} "
 
+            edge_type_traversals = f", {dir_bound} ".join(db.edge_collection(et) for et in edge_types)
+            two_direction_traversal = (
+                ", " + (", ".join(f"OUTBOUND {db.edge_collection(et)}" for et in out_edge_types))
+                if direction == Direction.any
+                else ""
+            )
             query_part += (
                 f"LET {out} =({outer_for}"
                 f"FOR {out_crsr}{link_str} IN {start}..{until} {dir_bound} {graph_cursor} "
-                f"{db.edge_collection(edge_type)} OPTIONS {{ bfs: true, {unique} }} "
+                f"{edge_type_traversals}{two_direction_traversal} OPTIONS {{ bfs: true, {unique} }} "
                 f"RETURN DISTINCT {inout_result}) "
             )
             return out
 
         def navigation(in_crsr: str, nav: Navigation) -> str:
             nonlocal query_part
-            if nav.direction == Direction.any:
+            out = nav.maybe_two_directional_outbound_edge_type or nav.edge_types
+            # arango can traverse inbound and outbound at the same time, but not using the same edge type
+            if nav.direction == Direction.any and set(out) & set(nav.edge_types):
                 # traverse to root
-                to_in = inout(in_crsr, nav.start, nav.until, nav.edge_type, Direction.inbound)
+                to_in = inout(in_crsr, nav.start, nav.until, nav.edge_types, Direction.inbound, out)
                 # traverse to leaf (in case of 0: use 1 to not have the current element twice)
-                to_out = inout(in_crsr, max(1, nav.start), nav.until, nav.edge_type, Direction.outbound)
+                to_out = inout(in_crsr, max(1, nav.start), nav.until, out, Direction.outbound, out)
                 nav_crsr = next_crs()
                 query_part += f"LET {nav_crsr} = UNION({to_in}, {to_out})"
                 return nav_crsr
             else:
-                return inout(in_crsr, nav.start, nav.until, nav.edge_type, nav.direction)
+                return inout(in_crsr, nav.start, nav.until, nav.edge_types, nav.direction, out)
 
         if isinstance(p.term, MergeTerm):
             filter_cursor = filter_statement(in_cursor, p.term.pre_filter)

--- a/resotocore/core/db/async_arangodb.py
+++ b/resotocore/core/db/async_arangodb.py
@@ -162,6 +162,7 @@ class AsyncArangoDBBase:
         skip_inaccessible_cols: Optional[bool] = None,
         max_runtime: Optional[Number] = None,
     ) -> AsyncCursorContext:
+        print(f"\n>>>>>>>>>>> {query}\n")
         cursor = await run_async(
             self.db.aql.execute,
             query,

--- a/resotocore/core/model/graph_access.py
+++ b/resotocore/core/model/graph_access.py
@@ -91,7 +91,7 @@ class Direction:
     # Same direction as the edge direction
     outbound = "out"
     # Ignore the direction of the edge and traverse in any direction.
-    any = "inout"
+    any = "any"
 
     # The set of all allowed directions.
     all: Set[str] = {inbound, outbound, any}

--- a/resotocore/core/query/model.py
+++ b/resotocore/core/query/model.py
@@ -337,19 +337,22 @@ class Navigation:
 
     start: int = 1
     until: int = 1
-    maybe_edge_type: Optional[str] = EdgeType.default
+    maybe_edge_types: Optional[List[str]] = None
     direction: str = Direction.outbound
+    maybe_two_directional_outbound_edge_type: Optional[List[str]] = None
 
     @property
-    def edge_type(self) -> str:
-        return EdgeType.default if self.maybe_edge_type is None else self.maybe_edge_type
+    def edge_types(self) -> List[str]:
+        return self.maybe_edge_types or [EdgeType.default]
 
     def __str__(self) -> str:
         start = self.start
         until = self.until
         until_str = "" if until == Navigation.Max else until
-        depth = ("" if start == 1 else f"[{start}]") if start == until else f"[{start}:{until_str}]"
-        nav = f"{self.edge_type}{depth}"
+        mo = self.maybe_two_directional_outbound_edge_type
+        depth = ("" if start == 1 else f"[{start}]") if start == until and not mo else f"[{start}:{until_str}]"
+        out_nav = ",".join(mo) if mo else ""
+        nav = f'{",".join(self.edge_types)}{depth}{out_nav}'
         if self.direction == Direction.outbound:
             return f"-{nav}->"
         elif self.direction == Direction.inbound:
@@ -359,10 +362,10 @@ class Navigation:
 
 
 NavigateUntilRoot = Navigation(
-    start=1, until=Navigation.Max, maybe_edge_type=EdgeType.default, direction=Direction.inbound
+    start=1, until=Navigation.Max, maybe_edge_types=[EdgeType.default], direction=Direction.inbound
 )
 NavigateUntilLeaf = Navigation(
-    start=1, until=Navigation.Max, maybe_edge_type=EdgeType.default, direction=Direction.outbound
+    start=1, until=Navigation.Max, maybe_edge_types=[EdgeType.default], direction=Direction.outbound
 )
 
 
@@ -728,15 +731,15 @@ class Query:
         p0 = parts[0]
         if p0.navigation:
             # we already traverse in this direction: add start and until
-            if p0.navigation.edge_type == edge_type and p0.navigation.direction == direction:
+            if edge_type in p0.navigation.edge_types and p0.navigation.direction == direction:
                 start_m = min(Navigation.Max, start + p0.navigation.start)
                 until_m = min(Navigation.Max, until + p0.navigation.until)
-                parts[0] = replace(p0, navigation=Navigation(start_m, until_m, edge_type, direction))
+                parts[0] = replace(p0, navigation=replace(p0.navigation, start=start_m, until=until_m))
             # this is another traversal: so we need to start a new part
             else:
-                parts.insert(0, Part(AllTerm(), navigation=Navigation(start, until, edge_type, direction)))
+                parts.insert(0, Part(AllTerm(), navigation=Navigation(start, until, [edge_type], direction)))
         else:
-            parts[0] = replace(p0, navigation=Navigation(start, until, edge_type, direction))
+            parts[0] = replace(p0, navigation=Navigation(start, until, [edge_type], direction))
         return replace(self, parts=parts)
 
     def group_by(self, variables: List[AggregateVariable], funcs: List[AggregateFunction]) -> Query:
@@ -890,7 +893,7 @@ class Query:
         def navigation_analytics(navigation: Navigation) -> None:
             counters["navigation"] += 1
             counters[f"navigation_{navigation.direction}"] += 1
-            counters[f"navigation_{navigation.edge_type}"] += 1
+            counters[f"navigation_{navigation.edge_types}"] += 1
             counters["navigation_until_max"] = max(counters["navigation_until_max"], navigation.until)
 
         def is_ancestor_merge(q: Query) -> bool:

--- a/resotocore/core/query/query_parser.py
+++ b/resotocore/core/query/query_parser.py
@@ -1,5 +1,6 @@
 from dataclasses import replace
 from functools import reduce
+from typing import List
 
 import parsy
 from parsy import string, Parser, regex
@@ -182,21 +183,38 @@ edge_type_p = lexeme(regex("[A-Za-z][A-Za-z0-9_]*"))
 
 
 @make_parser
-def edge_definition() -> Parser:
-    maybe_edge_type = yield edge_type_p.optional()
+def edge_type_parser() -> Parser:
+    edge_types = yield edge_type_p.sep_by(comma_p).map(set)
+    edge_types = EdgeType.all if "all" in edge_types else edge_types
+    for et in edge_types:
+        if et not in EdgeType.all:
+            raise AttributeError(f"Given EdgeType is not known: {et}")
+    return list(edge_types)
+
+
+@make_parser
+def edge_definition_parser() -> Parser:
+    edge_types = yield edge_type_parser
     maybe_range = yield range_parser.optional()
-    parsed_range = maybe_range if maybe_range else (1, 1)
-    return parsed_range[0], parsed_range[1], maybe_edge_type
+    start, until = maybe_range if maybe_range else (1, 1)
+    return start, until, edge_types
 
 
-out_p = lexeme(string("-") >> edge_definition << string("->")).map(
+@make_parser
+def two_directional_edge_definition_parser() -> Parser:
+    start, until, edge_types = yield edge_definition_parser
+    outbound_edge_types = yield edge_type_parser
+    return start, until, edge_types, outbound_edge_types
+
+
+out_p = lexeme(string("-") >> edge_definition_parser << string("->")).map(
     lambda nav: Navigation(nav[0], nav[1], nav[2], Direction.outbound)
 )
-in_p = lexeme(string("<-") >> edge_definition << string("-")).map(
+in_p = lexeme(string("<-") >> edge_definition_parser << string("-")).map(
     lambda nav: Navigation(nav[0], nav[1], nav[2], Direction.inbound)
 )
-in_out_p = lexeme(string("<-") >> edge_definition << string("->")).map(
-    lambda nav: Navigation(nav[0], nav[1], nav[2], Direction.any)
+in_out_p = lexeme(string("<-") >> two_directional_edge_definition_parser << string("->")).map(
+    lambda nav: Navigation(nav[0], nav[1], nav[2], Direction.any, nav[3])
 )
 navigation_parser = in_out_p | out_p | in_p
 
@@ -368,27 +386,29 @@ def query_parser() -> Parser:
 
 
 def parse_query(query: str, **env: str) -> Query:
-    def set_edge_type_if_not_set(part: Part, edge_type: str) -> Part:
+    def set_edge_type_if_not_set(part: Part, edge_types: List[str]) -> Part:
         def set_in_with_clause(wc: WithClause) -> WithClause:
             nav = wc.navigation
-            if wc.navigation and not wc.navigation.maybe_edge_type:
-                nav = replace(nav, maybe_edge_type=edge_type)
+            if wc.navigation and not wc.navigation.maybe_edge_types:
+                nav = replace(nav, maybe_edge_types=edge_types)
             inner = set_in_with_clause(wc.with_clause) if wc.with_clause else wc.with_clause
             return replace(wc, navigation=nav, with_clause=inner)
 
         nav = part.navigation
-        if part.navigation and not part.navigation.maybe_edge_type:
-            nav = replace(nav, maybe_edge_type=edge_type)
+        if part.navigation and not part.navigation.maybe_edge_types:
+            nav = replace(nav, maybe_edge_types=edge_types)
         adapted_wc = set_in_with_clause(part.with_clause) if part.with_clause else part.with_clause
         return replace(part, navigation=nav, with_clause=adapted_wc)
 
     try:
         parsed: Query = query_parser.parse(query.strip())
-        et: str = parsed.preamble.get("edge_type", env.get("edge_type", EdgeType.default))  # type: ignore
-        if et not in EdgeType.all:
-            raise AttributeError(f"Given edge_type {et} is not available. Use one of {EdgeType.all}")
+        pre = parsed.preamble
+        ets: List[str] = pre.get("edge_type", env.get("edge_type", EdgeType.default)).split(",")  # type: ignore
+        for et in ets:
+            if et not in EdgeType.all:
+                raise AttributeError(f"Given edge_type {et} is not available. Use one of {EdgeType.all}")
 
-        adapted = [set_edge_type_if_not_set(part, et) for part in parsed.parts]
+        adapted = [set_edge_type_if_not_set(part, ets) for part in parsed.parts]
         # remove values from preamble, that are only used at parsing time
         preamble = parsed.preamble.copy()
         preamble.pop("edge_type", None)

--- a/resotocore/tests/core/query/__init__.py
+++ b/resotocore/tests/core/query/__init__.py
@@ -78,7 +78,7 @@ def navigation(ud: UD) -> Navigation:
     length = d.draw(integers(min_value=0, max_value=100))
     ed = d.draw(edge_type)
     direction = d.draw(edge_direction)
-    return Navigation(start, length + start, ed, direction)
+    return Navigation(start, length + start, [ed], direction)
 
 
 @composite


### PR DESCRIPTION
# Description

Allows the definition of multiple edge types per traversal:
```
# single edge type
-delete->
# list of edge types
-delete,default->
# shorthand for all edge types
-all-> 
# traverse inbound using default edge and inbound using delete edge
<-default[0:2]delete->
```
<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [ ] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`
- [ ] Document new or updated functionality (someengineering/resoto.com#XXXX)

# Issues Fixed

<!-- If this PR will fix/resolve an open issue on the repository, please reference it below. -->
<!-- (Otherwise, feel free to delete this section.) -->

- Fixes #XXXX

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
