### PR TITLE
[resotocore][fix] Use color theme that is better readable

### DIFF
--- a/resotocore/core/console_renderer.py
+++ b/resotocore/core/console_renderer.py
@@ -88,7 +88,11 @@ class ConsoleRenderer:
     console_pool: ClassVar[ConsolePool] = ConsolePool()
 
     def render(self, element: Union[str, JupyterMixin]) -> str:
-        to_render = Markdown(element) if isinstance(element, str) else element
+        # Code blocks are rendered via pygments, which can be styled using themes.
+        # For a list of styles see: https://stylishthemes.github.io/Syntax-Themes/pygments/
+        # The default uses monokai, which can be hard to read on standard terminal devices.
+        # See: https://github.com/someengineering/resoto/issues/652 for problems with monokai.
+        to_render = Markdown(element, code_theme="native") if isinstance(element, str) else element
         # get a console with the correct color system
         cs = self.color_system
         system = cs if cs else (ConsoleColorSystem.standard if self.terminal else ConsoleColorSystem.monochrome)


### PR DESCRIPTION
# Description

Examples in help use code blocks, which are rendered via pygments.
The default style is very hard to read on terminals with less than 256 colors.
This change uses the `native` theme, which seem to deliver better results.

See: https://github.com/someengineering/resoto/issues/652 for examples.

<!-- Please describe the changes included in this PR here. -->

# Issues Fixed

<!-- If this PR will fix/resolve an open issue on the repository, please reference it below. -->
<!-- (Otherwise, feel free to delete this section.) -->

- Fixes #652

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
