### PR TITLE
[resotoshell][fix] Send command utf8 encoded

### DIFF
--- a/resotoshell/resotoshell/__main__.py
+++ b/resotoshell/resotoshell/__main__.py
@@ -150,7 +150,7 @@ def send_command(
                     return
 
     try:
-        handle_response(post_request(command, "text/plain"))
+        handle_response(post_request(command.encode("utf-8"), "text/plain"))
     except Exception as ex:
         print(f"Error performing command: `{command}`\nReason: {ex}")
 


### PR DESCRIPTION
# Description

Commands were encoded with the system defined encoding, but the server expected utf8.

# Issues Fixed

<!-- If this PR will fix/resolve an open issue on the repository, please reference it below. -->
<!-- (Otherwise, feel free to delete this section.) -->

- Fixes #663

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
