### PR TITLE
[resotoshell][fix] Use lru_cache instead of cache

### DIFF
--- a/resotoshell/resotoshell/__main__.py
+++ b/resotoshell/resotoshell/__main__.py
@@ -3,7 +3,7 @@ import pathlib
 import re
 import shutil
 import sys
-from functools import cache
+from functools import lru_cache
 from threading import Event
 from typing import Dict, Union, Any, Optional
 from urllib.parse import urlencode, urlsplit
@@ -194,7 +194,7 @@ def handle_result(part: Union[Response, BodyPart], first: bool = True) -> None:
             handle_result(part, num == 0)
 
 
-@cache
+@lru_cache()
 def color_system() -> str:
     if ArgumentParser.args.no_color:
         return "monochrome"
@@ -206,7 +206,9 @@ def color_system() -> str:
             "truecolor": "truecolor",
             "windows": "legacy_windows",
         }
-        return lookup.get(Console().color_system, "standard")
+        cs = lookup.get(Console().color_system, "standard")
+        log.debug(f"Detected color system is: {cs}")
+        return cs
 
 
 def add_args(arg_parser: ArgumentParser) -> None:

--- a/resotoshell/resotoshell/__main__.py
+++ b/resotoshell/resotoshell/__main__.py
@@ -194,7 +194,7 @@ def handle_result(part: Union[Response, BodyPart], first: bool = True) -> None:
             handle_result(part, num == 0)
 
 
-@lru_cache()
+@lru_cache(maxsize=None)
 def color_system() -> str:
     if ArgumentParser.args.no_color:
         return "monochrome"


### PR DESCRIPTION
# Description

The cache directive is only available in python 3.9 or later.

