### PR TITLE
[plugins/aws][feat] Add support for Cloudformation Stack Sets

### DIFF
--- a/plugins/aws/resoto_plugin_aws/accountcollector.py
+++ b/plugins/aws/resoto_plugin_aws/accountcollector.py
@@ -1,10 +1,10 @@
-from unicodedata import name
 import botocore.exceptions
 import concurrent.futures
 import socket
 import urllib3
 import json
 import re
+from datetime import datetime, timezone, timedelta
 from functools import lru_cache
 from threading import Lock
 from collections.abc import Mapping

--- a/plugins/aws/resoto_plugin_aws/accountcollector.py
+++ b/plugins/aws/resoto_plugin_aws/accountcollector.py
@@ -2245,17 +2245,21 @@ class AWSAccountCollector:
             )
             log.debug(f"Found Cloudformation Stack Set {s.name} ({s.id})")
             graph.add_resource(region, s)
-            response = client.list_stack_instances(StackName=s.name)
-            stack_instances = response.get("Summaries", [])
-            while response.get("NextToken") is not None:
-                response = client.list_stack_instances(
-                    StackName=s.name, NextToken=response["NextToken"]
-                )
-                stack_instances.extend(response.get("Summaries", []))
-            for stack_instance in stack_instances:
-                stack_instance_region = stack_instance.get("Region")
-                stack_instance_account = stack_instance.get("Account")
-                stack_instance_stack_id = stack_instance.get("StackId")
+            # The following requires a feature in the core that would
+            # allow to add edges between resources of different accounts.
+            #
+            # response = client.list_stack_instances(StackName=s.name)
+            # stack_instances = response.get("Summaries", [])
+            # while response.get("NextToken") is not None:
+            #     response = client.list_stack_instances(
+            #         StackName=s.name, NextToken=response["NextToken"]
+            #     )
+            #     stack_instances.extend(response.get("Summaries", []))
+            # for stack_instance in stack_instances:
+            #     stack_instance_region = stack_instance.get("Region")
+            #     stack_instance_account = stack_instance.get("Account")
+            #     stack_instance_stack_id = stack_instance.get("StackId")
+            # create a deferred connection that's being resolved core side
 
     @metrics_collect_eks_clusters.time()
     def collect_eks_clusters(self, region: AWSRegion, graph: Graph) -> None:

--- a/plugins/aws/resoto_plugin_aws/accountcollector.py
+++ b/plugins/aws/resoto_plugin_aws/accountcollector.py
@@ -2247,6 +2247,7 @@ class AWSAccountCollector:
             graph.add_resource(region, s)
             # The following requires a feature in the core that would
             # allow to add edges between resources of different accounts.
+            # https://github.com/someengineering/resoto/issues/693
             #
             # response = client.list_stack_instances(StackName=s.name)
             # stack_instances = response.get("Summaries", [])

--- a/plugins/aws/resoto_plugin_aws/resources.py
+++ b/plugins/aws/resoto_plugin_aws/resources.py
@@ -1135,3 +1135,25 @@ class AWSCloudwatchAlarm(AWSResource, BaseResource):
         client = aws_client(self, "cloudwatch")
         client.untag_resource(ResourceARN=self.arn, TagKeys=[key])
         return True
+
+
+@dataclass(eq=False)
+class AWSCloudFormationStackSet(AWSResource, BaseResource):
+    kind: ClassVar[str] = "aws_cloudformation_stack_set"
+    description: Optional[str] = None
+    stack_set_status: Optional[str] = None
+    stack_set_parameters: Dict = field(default_factory=dict)
+    stack_set_capabilities: Optional[List] = field(default_factory=list)
+    stack_set_administration_role_arn: Optional[str] = None
+    stack_set_execution_role_name: Optional[str] = None
+    stack_set_drift_detection_details: Optional[Dict] = field(default_factory=dict)
+    stack_set_last_drift_check_timestamp: Optional[datetime] = None
+    stack_set_auto_deployment: Optional[Dict] = field(default_factory=dict)
+    stack_set_permission_model: Optional[str] = None
+    stack_set_organizational_unit_ids: Optional[List] = field(default_factory=list)
+    stack_set_managed_execution_active: Optional[bool] = None
+
+    def delete(self, graph: Graph) -> bool:
+        cf = aws_client(self, "cloudformation", graph)
+        cf.delete_stack_set(StackSetName=self.name)
+        return True

--- a/plugins/aws/resoto_plugin_aws/resources.py
+++ b/plugins/aws/resoto_plugin_aws/resources.py
@@ -6,7 +6,7 @@ from resotolib.baseresources import *
 from resotolib.graph import Graph
 from resotolib.utils import make_valid_timestamp
 from .utils import aws_client, aws_resource
-from typing import ClassVar
+from typing import ClassVar, Any
 from dataclasses import dataclass
 from resotolib.logging import log
 
@@ -1143,14 +1143,16 @@ class AWSCloudFormationStackSet(AWSResource, BaseResource):
     description: Optional[str] = None
     stack_set_status: Optional[str] = None
     stack_set_parameters: Dict = field(default_factory=dict)
-    stack_set_capabilities: Optional[List] = field(default_factory=list)
+    stack_set_capabilities: Optional[List[str]] = field(default_factory=list)
     stack_set_administration_role_arn: Optional[str] = None
     stack_set_execution_role_name: Optional[str] = None
-    stack_set_drift_detection_details: Optional[Dict] = field(default_factory=dict)
+    stack_set_drift_detection_details: Optional[Dict[str, Any]] = field(
+        default_factory=dict
+    )
     stack_set_last_drift_check_timestamp: Optional[datetime] = None
-    stack_set_auto_deployment: Optional[Dict] = field(default_factory=dict)
+    stack_set_auto_deployment: Optional[Dict[str, bool]] = field(default_factory=dict)
     stack_set_permission_model: Optional[str] = None
-    stack_set_organizational_unit_ids: Optional[List] = field(default_factory=list)
+    stack_set_organizational_unit_ids: Optional[List[str]] = field(default_factory=list)
     stack_set_managed_execution_active: Optional[bool] = None
 
     def delete(self, graph: Graph) -> bool:

--- a/plugins/gcp/resoto_plugin_gcp/collector.py
+++ b/plugins/gcp/resoto_plugin_gcp/collector.py
@@ -679,14 +679,15 @@ class GCPProjectCollector:
                                         values = value
                                         for value in values:
                                             r.add_deferred_connection(
-                                                attr,
-                                                value,
+                                                {attr: value},
                                                 is_parent,
                                                 edge_type=edge_type,
                                             )
                                     elif isinstance(value, str):
                                         r.add_deferred_connection(
-                                            attr, value, is_parent, edge_type=edge_type
+                                            {attr: value},
+                                            is_parent,
+                                            edge_type=edge_type,
                                         )
                                     else:
                                         log.error(

--- a/plugins/k8s/resoto_plugin_k8s/resources/common.py
+++ b/plugins/k8s/resoto_plugin_k8s/resources/common.py
@@ -90,11 +90,11 @@ class KubernetesResource:
                                     values = value
                                     for value in values:
                                         resource.add_deferred_connection(
-                                            attr, value, is_parent
+                                            {attr: value}, is_parent
                                         )
                                 elif isinstance(value, str):
                                     resource.add_deferred_connection(
-                                        attr, value, is_parent
+                                        {attr: value}, is_parent
                                     )
                                 else:
                                     log.error(

--- a/resotolib/resotolib/baseresources.py
+++ b/resotolib/resotolib/baseresources.py
@@ -493,10 +493,10 @@ class BaseResource(ABC):
         return self.__repr__()
 
     def add_deferred_connection(
-        self, attr, value, parent: bool = True, edge_type: EdgeType = EdgeType.default
+        self, search: Dict, parent: bool = True, edge_type: EdgeType = EdgeType.default
     ) -> None:
         self._deferred_connections.append(
-            {"attr": attr, "value": value, "parent": parent, "edge_type": edge_type}
+            {"search": search, "parent": parent, "edge_type": edge_type}
         )
 
     def resolve_deferred_connections(self, graph) -> None:
@@ -504,7 +504,7 @@ class BaseResource(ABC):
             graph = self._graph
         while self._deferred_connections:
             dc = self._deferred_connections.pop(0)
-            node = graph.search_first(dc["attr"], dc["value"])
+            node = graph.search_first_all(dc["search"])
             edge_type = dc["edge_type"]
             if node:
                 if dc["parent"]:


### PR DESCRIPTION
# Description

Add support for Cloudformation Stack Sets. This is part 1 of a 2 part PR. Part 2 is for the commented code that requires support in resotocore for creating edges between accounts, after all accounts have been collected. We could already implement this on the collector level in the form of a deferred_connection but that would only work for `--graph-merge-kind cloud` and break if a user collects two different accounts on two different workers.

# Issues Fixed

<!-- If this PR will fix/resolve an open issue on the repository, please reference it below. -->
<!-- (Otherwise, feel free to delete this section.) -->

- Fixes #651

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
