### PR TITLE
[resotocore][fix] The merge path should be interpreted relative to the defined section

### DIFF
--- a/resotocore/resotocore/query/model.py
+++ b/resotocore/resotocore/query/model.py
@@ -315,7 +315,7 @@ class MergeQuery:
         return f"{self.name}{arr}: {self.query}"
 
     def change_variable(self, fn: Callable[[str], str]) -> MergeQuery:
-        return replace(self, query=self.query.change_variable(fn))
+        return replace(self, name=fn(self.name), query=self.query.change_variable(fn))
 
 
 @dataclass(order=True, unsafe_hash=True, frozen=True)

--- a/resotocore/tests/resotocore/query/model_test.py
+++ b/resotocore/tests/resotocore/query/model_test.py
@@ -137,6 +137,16 @@ def test_rewrite_ancestors_descendants() -> None:
         str(parse_query('a<1 and ancestors.cloud.reported.name=="test"').on_section())
         == '(a < 1 and ancestors.cloud.reported.name == "test")'
     )
+    # the merge name is interpreted relative to the section
+    assert (
+        str(parse_query("a<1 {test: <-[1:]- is(account)}").on_section("reported"))
+        == 'reported.a < 1 {reported.test: all <-default[1:]- is("account")}'
+    )
+    # the merge name is not interpreted relative to the section, when defined absolute
+    assert (
+        str(parse_query("a<1 {/test: <-[1:]- is(account)}").on_section("reported"))
+        == 'reported.a < 1 {test: all <-default[1:]- is("account")}'
+    )
     # a query with unknown ancestor creates a merge query
     assert (
         str(parse_query('a<1 and ancestors.cloud.reported.kind=="cloud"').on_section())


### PR DESCRIPTION

# Description

<!-- Please describe the changes included in this PR here. -->

```
a<1 {test: <-[1:]- is(account)}" 
```
`test` will be interpreted relative to the current section.
By default this will yield: `/reported.test` - people need to prefix the merge path with a slash if it should be on root level.


# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`

