### PR TITLE
[resotocore][feat] Use the last path part of an aggregation variable

### DIFF
--- a/resotocore/resotocore/query/model.py
+++ b/resotocore/resotocore/query/model.py
@@ -580,7 +580,10 @@ class AggregateVariable:
         return f"{self.name}{with_as}"
 
     def get_as_name(self) -> str:
-        return self.as_name if self.as_name else str(self.name)
+        def from_name() -> str:
+            return self.name.name.rsplit(".", 1)[-1] if isinstance(self.name, AggregateVariableName) else str(self.name)
+
+        return self.as_name if self.as_name else from_name()
 
     def change_variable(self, fn: Callable[[str], str]) -> AggregateVariable:
         return replace(self, name=self.name.change_variable(fn))

--- a/resotocore/tests/resotocore/cli/command_test.py
+++ b/resotocore/tests/resotocore/cli/command_test.py
@@ -204,7 +204,7 @@ async def test_search_source(cli: CLI) -> None:
         "with(any, --> /metadata!=null) sort /reported.name asc limit 1",
         stream.list,
     )
-    assert result5 == [[{"group": {"reported.kind": "foo"}, "si": 0}]]
+    assert result5 == [[{"group": {"kind": "foo"}, "si": 0}]]
 
 
 @pytest.mark.asyncio

--- a/resotocore/tests/resotocore/db/graphdb_test.py
+++ b/resotocore/tests/resotocore/db/graphdb_test.py
@@ -421,7 +421,7 @@ async def test_query_graph(filled_graph_db: ArangoGraphDB, foo_model: Model) -> 
 async def test_query_aggregate(filled_graph_db: ArangoGraphDB, foo_model: Model) -> None:
     agg_query = parse_query("aggregate(kind: count(identifier) as instances): is(foo)").on_section("reported")
     async with await filled_graph_db.search_aggregation(QueryModel(agg_query, foo_model)) as gen:
-        assert [x async for x in gen] == [{"group": {"reported.kind": "foo"}, "instances": 11}]
+        assert [x async for x in gen] == [{"group": {"kind": "foo"}, "instances": 11}]
 
     agg_combined_var_query = parse_query(
         'aggregate("test_{kind}_{some_int}_{does_not_exist}" as kind: count(identifier) as instances): is("foo")'


### PR DESCRIPTION
# Description

When no `as` clause is provided for the variable name, use the last part of the path, not the complete path.

Before:
```bash
> query is(instance) and age > 3y | aggregate instance_status: sum(1) as count
group:
  reported.instance_status: running
count: 1
```

After:
```bash
> query is(instance) and age > 3y | aggregate instance_status: sum(1) as count
group:
  instance_status: running
count: 1
```


<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [ ] Add test coverage for new or updated functionality
- [ ] Lint and test with `tox`
- [ ] Document new or updated functionality (someengineering/resoto.com#XXXX)

# Issues Fixed

<!-- If this PR will fix/resolve an open issue on the repository, please reference it below. -->
<!-- (Otherwise, feel free to delete this section.) -->

- Fixes #XXXX

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
