### PR TITLE
[resotocore][feat] search: make parens in not optional

### DIFF
--- a/resotocore/resotocore/query/query_parser.py
+++ b/resotocore/resotocore/query/query_parser.py
@@ -100,9 +100,7 @@ def function_term() -> Parser:
 @make_parser
 def not_term() -> Parser:
     yield not_p
-    yield lparen_p
-    term = yield simple_term_p
-    yield rparen_p
+    term = yield filter_term_parser
     return NotTerm(term)
 
 

--- a/resotocore/tests/resotocore/query/query_parser_test.py
+++ b/resotocore/tests/resotocore/query/query_parser_test.py
@@ -106,7 +106,9 @@ def test_combined() -> None:
 
 
 def test_not() -> None:
-    assert_round_trip(not_term, (P.of_kind("foo") | P.of_kind("bla")).not_term())
+    assert_round_trip(not_term, (P.with_id("foo") | P.of_kind("bla")).not_term())
+    assert_round_trip(not_term, P.of_kind("bla").not_term())
+    assert_round_trip(not_term, term_parser.parse("not(is(a) or not is(b) and not a>1 or not b<2 or not(a>1))"))
 
 
 def test_filter_term() -> None:


### PR DESCRIPTION
# Description

Parens in `not` are now optional.
Now you can write this:
```js
> search not(not is(instance) and not /ancestors.account.reported.name=~eng)
```
<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`
- [x] Document new or updated functionality (someengineering/resoto.com#XXXX)
