### PR TITLE
[resotocore][fix] Send ModelInfo event after one hour uptime

### DIFF
--- a/resotocore/resotocore/__main__.py
+++ b/resotocore/resotocore/__main__.py
@@ -106,7 +106,7 @@ def run(arguments: List[str]) -> None:
         args,
     )
     event_emitter = emit_recurrent_events(
-        event_sender, model, subscriptions, worker_task_queue, message_bus, timedelta(hours=1)
+        event_sender, model, subscriptions, worker_task_queue, message_bus, timedelta(hours=1), timedelta(hours=1)
     )
 
     async def on_start() -> None:

--- a/resotocore/resotocore/analytics/recurrent_events.py
+++ b/resotocore/resotocore/analytics/recurrent_events.py
@@ -15,7 +15,7 @@ def emit_recurrent_events(
     worker_task_queue: WorkerTaskQueue,
     message_bus: MessageBus,
     frequency: timedelta,
-    first_run: timedelta = timedelta(minutes=1),
+    first_run: timedelta,
 ) -> Periodic:
     async def emit_events() -> None:
         # information about the model


### PR DESCRIPTION
# Description

Only sent this event after one hour. Installations that will start and stop under one hour will not send this event.
