### PR TITLE
[resotocore][fix] ancestors should not hold a reference to the current node

### DIFF
--- a/resotocore/resotocore/model/graph_access.py
+++ b/resotocore/resotocore/model/graph_access.py
@@ -324,8 +324,10 @@ class GraphAccess:
             # search for ancestor that matches filter criteria
             anc = self.ancestor_of(node_id, EdgeType.default, resolver.kind)
             if anc:
+                on_self = anc.get("id") == node_id
                 for res in resolver.resolve:
-                    with_ancestor(anc, res)
+                    if not on_self or res.apply_on_self:
+                        with_ancestor(anc, res)
         return node
 
     def dump(self, node_id: str, node: Json) -> Json:

--- a/resotocore/resotocore/model/resolve_in_graph.py
+++ b/resotocore/resotocore/model/resolve_in_graph.py
@@ -35,6 +35,10 @@ class ResolveProp:
     # Path to write this property to
     to_path: List[str]
 
+    # If this resolver should apply, if the related node is the node itself.
+    # e.g.: the node is an account node and the ancestor of type account is requested.
+    apply_on_self: bool = False
+
     @property
     def to(self) -> str:
         return ".".join(self.to_path)
@@ -67,7 +71,7 @@ class GraphResolver:
             [
                 ResolveProp(NodePath.reported_name, ["ancestors", "cloud", "reported", "name"]),
                 ResolveProp(NodePath.reported_id, ["ancestors", "cloud", "reported", "id"]),
-                ResolveProp(NodePath.node_id, ["refs", "cloud_id"]),
+                ResolveProp(NodePath.node_id, ["refs", "cloud_id"], apply_on_self=True),
             ],
         ),
         ResolveAncestor(
@@ -75,7 +79,7 @@ class GraphResolver:
             [
                 ResolveProp(NodePath.reported_name, ["ancestors", "account", "reported", "name"]),
                 ResolveProp(NodePath.reported_id, ["ancestors", "account", "reported", "id"]),
-                ResolveProp(NodePath.node_id, ["refs", "account_id"]),
+                ResolveProp(NodePath.node_id, ["refs", "account_id"], apply_on_self=True),
             ],
         ),
         ResolveAncestor(
@@ -83,7 +87,7 @@ class GraphResolver:
             [
                 ResolveProp(NodePath.reported_name, ["ancestors", "region", "reported", "name"]),
                 ResolveProp(NodePath.reported_id, ["ancestors", "region", "reported", "id"]),
-                ResolveProp(NodePath.node_id, ["refs", "region_id"]),
+                ResolveProp(NodePath.node_id, ["refs", "region_id"], apply_on_self=True),
             ],
         ),
         ResolveAncestor(
@@ -91,7 +95,7 @@ class GraphResolver:
             [
                 ResolveProp(NodePath.reported_name, ["ancestors", "zone", "reported", "name"]),
                 ResolveProp(NodePath.reported_id, ["ancestors", "zone", "reported", "id"]),
-                ResolveProp(NodePath.node_id, ["refs", "zone_id"]),
+                ResolveProp(NodePath.node_id, ["refs", "zone_id"], apply_on_self=True),
             ],
         ),
     ]


### PR DESCRIPTION

# Description

Currently, the account node lists the current node under `/ancestors` as the account node.