### PR TITLE
[resotocore][feat] Improve kinds command output

### DIFF
--- a/resotocore/tests/resotocore/cli/command_test.py
+++ b/resotocore/tests/resotocore/cli/command_test.py
@@ -26,7 +26,7 @@ from resotocore.cli.model import CLIDependencies, CLIContext
 from resotocore.console_renderer import ConsoleRenderer, ConsoleColorSystem
 from resotocore.db.jobdb import JobDb
 from resotocore.error import CLIParseError
-from resotocore.model.model import predefined_kinds
+from resotocore.model.model import Model, ComplexKind
 from resotocore.model.typed_model import to_js
 from resotocore.query.model import Template, Query
 from resotocore.task.task_description import TimeTrigger, Workflow, EventTrigger
@@ -495,10 +495,11 @@ async def test_tag_command(
 
 
 @pytest.mark.asyncio
-async def test_kind_command(cli: CLI) -> None:
+async def test_kind_command(cli: CLI, foo_model: Model) -> None:
     result = await cli.execute_cli_command("kind", stream.list)
-    for kind in predefined_kinds:
-        assert kind.fqn in result[0]
+    for kind in foo_model.kinds.values():
+        if isinstance(kind, ComplexKind):
+            assert kind.fqn in result[0]
     result = await cli.execute_cli_command("kind string", stream.list)
     assert result[0][0] == {"name": "string", "runtime_kind": "string"}
     result = await cli.execute_cli_command("kind -p reported.ctime", stream.list)


### PR DESCRIPTION
# Description

Command has been renamed from `kind` to `kinds`. 
Alias `kind` is available for backward compatibility.

- only complex kinds are listed
- a property of a complex kind is listed in one line: name: kind

<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
