### PR TITLE
[resotocore][fix] Multiple head/tail commands can be combined

### DIFF
--- a/resotocore/resotocore/cli/cli.py
+++ b/resotocore/resotocore/cli/cli.py
@@ -176,7 +176,7 @@ class HelpCommand(CLICommand):
 
 CLIArg = Tuple[CLICommand, Optional[str]]
 # If no sort is defined in the part, we use this default sort order
-DefaultSort = [Sort("/reported.kind"), Sort("/reported.id")]
+DefaultSort = [Sort("/reported.kind"), Sort("/reported.name"), Sort("/reported.id")]
 
 
 class CLI:

--- a/resotocore/resotocore/db/graphdb.py
+++ b/resotocore/resotocore/db/graphdb.py
@@ -815,7 +815,7 @@ class ArangoGraphDB(GraphDB):
         db = self.db
 
         # Edge Definition dependency was renamed to default in 2.0.0a13
-        # This method can be removed before 2.0 is released
+        # TODO: This method can be removed before 2.0 is released
         def rename_edge_dependency_to_default(graph_name: str, vertex_name: str, edge_name: str) -> None:
             ddb = db.db
             gdb = ddb.graph(graph_name)
@@ -834,7 +834,7 @@ class ArangoGraphDB(GraphDB):
                 gdb.create_edge_definition(edge_name, [vertex_name], [vertex_name])
 
         # The view index was created using a default analyzer
-        # This method can be removed before 2.0 is released.
+        # TODO: This method can be removed before 2.0 is released.
         def delete_wrong_index_view() -> None:
             db.db.delete_view(f"search_{self.vertex_name}", ignore_missing=True)
 
@@ -865,8 +865,17 @@ class ArangoGraphDB(GraphDB):
                     sparse=False,
                     name="update_nodes_ref_id",
                 )
-            if "kinds" not in node_idxes:
-                nodes.add_persistent_index(["kinds[*]"], sparse=False, name="kinds")
+
+            # One index only for kinds was not sufficient and got extended.
+            # TODO: This statement can be removed before 2.0 is released.
+            if "kinds" in node_idxes:
+                nodes.delete_index("kinds")
+            if "kinds_id_name_ctime" not in node_idxes:
+                nodes.add_persistent_index(
+                    ["kinds[*]", "reported.id", "reported.name", "reported.ctime"],
+                    sparse=False,
+                    name="kinds_id_name_ctime",
+                )
             progress_idxes = {idx["name"]: idx for idx in progress.indexes()}
             if "parent_nodes" not in progress_idxes:
                 progress.add_persistent_index(["parent_nodes[*]"], name="parent_nodes")

--- a/resotocore/resotocore/query/model.py
+++ b/resotocore/resotocore/query/model.py
@@ -486,7 +486,7 @@ class Part:
     def __str__(self) -> str:
         with_clause = f" {self.with_clause}" if self.with_clause is not None else ""
         tag = f"#{self.tag}" if self.tag else ""
-        sort = " sort " + (",".join(f"{a.name} {a.order}" for a in self.sort)) if self.sort else ""
+        sort = " sort " + (", ".join(f"{a.name} {a.order}" for a in self.sort)) if self.sort else ""
         limit = str(self.limit) if self.limit else ""
         nav = f" {self.navigation}" if self.navigation is not None else ""
         reverse = " reversed " if self.reverse_result else ""

--- a/resotocore/resotocore/query/model.py
+++ b/resotocore/resotocore/query/model.py
@@ -824,6 +824,9 @@ class Query:
         aggregate = Aggregate(variables, funcs)
         return replace(self, aggregate=aggregate)
 
+    def set_sort(self, sort: List[Sort]) -> Query:
+        return self.__change_current_part(lambda p: replace(p, sort=sort))
+
     def add_sort(self, name: str, order: str = SortOrder.Asc) -> Query:
         return self.__change_current_part(lambda p: replace(p, sort=[*p.sort, Sort(name, order)]))
 

--- a/resotocore/tests/resotocore/cli/cli_test.py
+++ b/resotocore/tests/resotocore/cli/cli_test.py
@@ -237,3 +237,17 @@ async def test_create_query_parts(cli: CLI) -> None:
         commands[0].executable_commands[0].arg
         == "aggregate(reported.foo, reported.bla as bla: sum(reported.bar)):reported.some_int == 0"
     )
+
+    # multiple head/tail commands are combined correctly
+    commands = await cli.evaluate_cli_command("search is(volume) | head -10 | tail -5 | head -3")
+    assert commands[0].executable_commands[0].arg == 'is("volume") limit 5, 3'
+    commands = await cli.evaluate_cli_command("search is(volume) sort name asc | head -10 | tail -5 | head -3")
+    assert commands[0].executable_commands[0].arg == 'is("volume") sort reported.name asc limit 5, 3'
+    commands = await cli.evaluate_cli_command("search is(volume) | head -10 | tail -5 | head -3 | tail 10 | head 100")
+    assert commands[0].executable_commands[0].arg == 'is("volume") limit 5, 3'
+    commands = await cli.evaluate_cli_command("search is(volume) | tail -10")
+    assert commands[0].executable_commands[0].arg == 'is("volume") sort _key desc limit 10'
+    commands = await cli.evaluate_cli_command("search is(volume) sort name | tail -10 | head 5")
+    assert commands[0].executable_commands[0].arg == 'is("volume") sort reported.name desc limit 5, 5 reversed '
+    commands = await cli.evaluate_cli_command("search is(volume) sort name | tail -10 | head 5 | head 3 | tail 2")
+    assert commands[0].executable_commands[0].arg == 'is("volume") sort reported.name desc limit 7, 2 reversed '

--- a/resotocore/tests/resotocore/cli/cli_test.py
+++ b/resotocore/tests/resotocore/cli/cli_test.py
@@ -206,7 +206,7 @@ def test_parse_predecessor_successor_ancestor_descendant_args() -> None:
 @pytest.mark.asyncio
 async def test_create_query_parts(cli: CLI) -> None:
     commands = await cli.evaluate_cli_command('search some_int==0 | search identifier=~"9_" | descendants')
-    sort = "sort reported.kind asc,reported.id asc"
+    sort = "sort reported.kind asc, reported.name asc, reported.id asc"
     assert len(commands) == 1
     assert len(commands[0].commands) == 1
     assert commands[0].commands[0].name == "execute_search"
@@ -249,7 +249,7 @@ async def test_create_query_parts(cli: CLI) -> None:
     commands = await cli.evaluate_cli_command("search is(volume) | tail -10")
     assert (
         commands[0].executable_commands[0].arg
-        == f'is("volume") sort reported.kind desc,reported.id desc limit 10 reversed '
+        == f'is("volume") sort reported.kind desc, reported.name desc, reported.id desc limit 10 reversed '
     )
     commands = await cli.evaluate_cli_command("search is(volume) sort name | tail -10 | head 5")
     assert commands[0].executable_commands[0].arg == 'is("volume") sort reported.name desc limit 5, 5 reversed '

--- a/resotocore/tests/resotocore/query/__init__.py
+++ b/resotocore/tests/resotocore/query/__init__.py
@@ -32,6 +32,7 @@ from resotocore.query.model import (
     AggregateVariableCombined,
     AggregateVariable,
     AggregateFunction,
+    Limit,
 )
 
 
@@ -49,6 +50,7 @@ preamble_props = lists(preamble_prop, min_size=0, max_size=1).map(dict)  # type:
 is_term = builds(IsTerm, lists(kind, min_size=1, max_size=2))
 predicate_term = builds(Predicate, query_property, query_operations, query_values, just({}))
 leaf_term: SearchStrategy[Term] = is_term | predicate_term
+limit_gen = builds(Limit, integers(min_value=0), integers(min_value=1))
 
 
 @composite
@@ -98,13 +100,11 @@ part = builds(
     optional(any_string),
     with_clause(),
     lists(sort, min_size=0, max_size=3),
-    optional(integers(min_value=1)),
+    optional(limit_gen),
     navigation(),
 )
 
-only_filter_part = builds(
-    Part, term, just(None), just(None), lists(sort, min_size=0, max_size=1), optional(integers(min_value=1))
-)
+only_filter_part = builds(Part, term, just(None), just(None), lists(sort, min_size=0, max_size=1), optional(limit_gen))
 
 
 @composite

--- a/resotocore/tests/resotocore/query/model_test.py
+++ b/resotocore/tests/resotocore/query/model_test.py
@@ -17,6 +17,7 @@ from resotocore.query.model import (
     Predicate,
     NotTerm,
     FunctionTerm,
+    Limit,
 )
 from resotocore.query.query_parser import parse_query
 
@@ -103,7 +104,7 @@ def test_combine() -> None:
     )
     assert str(query3) == 'test == true -default-> is("boo") -default-> ((is("bar") and is("foo")) and is("bla"))'
     query4 = Query.by("a").with_limit(10).combine(Query.by("b").with_limit(2))
-    assert query4.current_part.limit == 2  # minimum is taken
+    assert query4.current_part.limit == Limit(0, 2)  # minimum is taken
     with pytest.raises(AttributeError):
         # can not combine 2 aggregations
         parse_query("aggregate(sum(1)): is(a)").combine(parse_query("aggregate(sum(1)): is(a)"))

--- a/resotocore/tests/resotocore/query/query_parser_test.py
+++ b/resotocore/tests/resotocore/query/query_parser_test.py
@@ -28,6 +28,7 @@ from resotocore.query.model import (
     FulltextTerm,
     CombinedTerm,
     Predicate,
+    Limit,
 )
 from resotocore.model.graph_access import EdgeType, Direction
 from parsy import Parser, ParseError
@@ -279,7 +280,8 @@ def test_sort_order() -> None:
 
 
 def test_limit() -> None:
-    assert limit_parser.parse("limit 23") == 23
+    assert limit_parser.parse("limit 23") == Limit(0, 23)
+    assert limit_parser.parse("limit 3, 23") == Limit(3, 23)
     assert_round_trip(query_parser, Query.by("test").with_limit(23))
 
 


### PR DESCRIPTION

# Description

This PR introduces 2 changes to the search syntax:
- limit now allows defining two values: offset and limit
  if only one value is provided, the offset defaults to 0
- the keyword `reversed` can be used after the limit, which will reverse the limited sorted result.

All subsequent head/tail combinations are now computed into a single limit with offset and length.
In case the result is sorted, the sort order is reserved for `tail`, limited, and reversed again.
If no sort order is defined, a sort is injected (global identifier).

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`

# Issues Fixed

<!-- If this PR will fix/resolve an open issue on the repository, please reference it below. -->
<!-- (Otherwise, feel free to delete this section.) -->

- Fixes #683 

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
