### PR TITLE
[resotocore][fix] Only render edges where the nodes have been visited

### DIFF
--- a/resotocore/resotocore/db/async_arangodb.py
+++ b/resotocore/resotocore/db/async_arangodb.py
@@ -78,9 +78,9 @@ class AsyncCursor(AsyncIterator[Json]):
         vertex = None
         edge = None
         try:
-            _id = element["_id"]
-            if _id not in self.visited_node:
-                self.visited_node.add(_id)
+            _key = element["_key"]
+            if _key not in self.visited_node:
+                self.visited_node.add(_key)
                 vertex = self.trafo(element)
 
             from_id = element.get("_from")
@@ -129,7 +129,10 @@ class AsyncCursor(AsyncIterator[Json]):
 
     async def next_deferred_edge(self) -> Json:
         try:
-            return self.deferred_edges.pop()
+            while True:
+                e = self.deferred_edges.pop()
+                if e["from"] in self.visited_node and e["to"] in self.visited_node:
+                    return e
         except IndexError as ex:
             raise StopAsyncIteration from ex
 

--- a/resotocore/tests/resotocore/web/auth_test.py
+++ b/resotocore/tests/resotocore/web/auth_test.py
@@ -14,8 +14,8 @@ from aiohttp.pytest_plugin import aiohttp_client
 
 
 @pytest.fixture
-def loop() -> Any:
-    return asyncio.get_event_loop()
+async def loop() -> Any:
+    return asyncio.get_running_loop()
 
 
 @pytest.fixture


### PR DESCRIPTION
# Description

Edges are deferred when the nodes are not visited yet.
In the end, a final check is required to ensure both nodes have been visited.