### PR TITLE
[resotocore][feat] Enable external entities to validate config changes

### DIFF
--- a/resotocore/resotocore/__main__.py
+++ b/resotocore/resotocore/__main__.py
@@ -77,7 +77,7 @@ def run(arguments: List[str]) -> None:
     worker_task_queue = WorkerTaskQueue()
     model = ModelHandlerDB(db.get_model_db(), args.plantuml_server)
     template_expander = DBTemplateExpander(db.template_entity_db)
-    config_handler = ConfigHandlerService(db.config_entity_db, db.config_model_entity_db)
+    config_handler = ConfigHandlerService(db.config_entity_db, db.config_model_entity_db, worker_task_queue)
     cli_deps = CLIDependencies(
         message_bus=message_bus,
         event_sender=event_sender,

--- a/resotocore/resotocore/__main__.py
+++ b/resotocore/resotocore/__main__.py
@@ -77,7 +77,7 @@ def run(arguments: List[str]) -> None:
     worker_task_queue = WorkerTaskQueue()
     model = ModelHandlerDB(db.get_model_db(), args.plantuml_server)
     template_expander = DBTemplateExpander(db.template_entity_db)
-    config_handler = ConfigHandlerService(db.config_entity_db, db.config_model_entity_db, worker_task_queue)
+    config_handler = ConfigHandlerService(db.config_entity_db, db.config_validation_entity_db, worker_task_queue)
     cli_deps = CLIDependencies(
         message_bus=message_bus,
         event_sender=event_sender,

--- a/resotocore/resotocore/config/__init__.py
+++ b/resotocore/resotocore/config/__init__.py
@@ -3,7 +3,7 @@ from typing import Optional, AsyncIterator, List
 
 from dataclasses import dataclass
 
-from resotocore.model.model import Kind
+from resotocore.model.model import Kind, ComplexKind, Model
 from resotocore.types import Json
 
 
@@ -17,6 +17,11 @@ class ConfigEntity:
 class ConfigModel:
     id: str
     kinds: List[Kind]
+
+    @property
+    def complex_root(self) -> Optional[ComplexKind]:
+        md = Model.from_kinds(self.kinds)
+        return md.complex_roots[0] if len(md.complex_roots) == 1 else None
 
 
 class ConfigHandler(ABC):

--- a/resotocore/resotocore/config/__init__.py
+++ b/resotocore/resotocore/config/__init__.py
@@ -14,13 +14,13 @@ class ConfigEntity:
 
 
 @dataclass(order=True, unsafe_hash=True, frozen=True)
-class ConfigModel:
+class ConfigValidation:
     id: str
-    kinds: List[Kind]
+    kinds: Optional[List[Kind]] = None
+    external_validation: bool = False
 
-    @property
     def complex_root(self) -> Optional[ComplexKind]:
-        md = Model.from_kinds(self.kinds)
+        md = Model.from_kinds(self.kinds or [])
         return md.complex_roots[0] if len(md.complex_roots) == 1 else None
 
 
@@ -46,15 +46,15 @@ class ConfigHandler(ABC):
         pass
 
     @abstractmethod
-    def list_config_model_ids(self) -> AsyncIterator[str]:
+    def list_config_validation_ids(self) -> AsyncIterator[str]:
         pass
 
     @abstractmethod
-    async def get_config_model(self, cfg_id: str) -> Optional[ConfigModel]:
+    async def get_config_validation(self, cfg_id: str) -> Optional[ConfigValidation]:
         pass
 
     @abstractmethod
-    async def put_config_model(self, cfg_id: str, kinds: List[Kind]) -> ConfigModel:
+    async def put_config_validation(self, validation: ConfigValidation) -> ConfigValidation:
         pass
 
     @abstractmethod

--- a/resotocore/resotocore/db/configdb.py
+++ b/resotocore/resotocore/db/configdb.py
@@ -1,4 +1,4 @@
-from resotocore.config import ConfigEntity, ConfigModel
+from resotocore.config import ConfigEntity, ConfigValidation
 from resotocore.db.async_arangodb import AsyncArangoDB
 from resotocore.db.entitydb import EntityDb, EventEntityDb, ArangoEntityDb
 
@@ -13,9 +13,9 @@ def config_entity_db(db: AsyncArangoDB, collection: str) -> ArangoEntityDb[Confi
 
 
 # Database to store config entity models
-ConfigModelEntityDb = EntityDb[ConfigModel]
-EventConfigModelEntityDb = EventEntityDb[ConfigModel]
+ConfigValidationEntityDb = EntityDb[ConfigValidation]
+EventConfigValidationEntityDb = EventEntityDb[ConfigValidation]
 
 
-def config_model_entity_db(db: AsyncArangoDB, collection: str) -> ArangoEntityDb[ConfigModel]:
-    return ArangoEntityDb(db, collection, ConfigModel, lambda k: k.id)
+def config_validation_entity_db(db: AsyncArangoDB, collection: str) -> ArangoEntityDb[ConfigValidation]:
+    return ArangoEntityDb(db, collection, ConfigValidation, lambda k: k.id)

--- a/resotocore/resotocore/db/db_access.py
+++ b/resotocore/resotocore/db/db_access.py
@@ -14,7 +14,7 @@ from resotocore.analytics import AnalyticsEventSender
 from resotocore.db import SystemData
 from resotocore.db.arangodb_extensions import ArangoHTTPClient
 from resotocore.db.async_arangodb import AsyncArangoDB
-from resotocore.db.configdb import config_entity_db, config_model_entity_db
+from resotocore.db.configdb import config_entity_db, config_validation_entity_db
 from resotocore.db.entitydb import EventEntityDb
 from resotocore.db.graphdb import ArangoGraphDB, GraphDB, EventGraphDB
 from resotocore.db.jobdb import job_db
@@ -41,7 +41,7 @@ class DbAccess(ABC):
         running_task_name: str = "running_tasks",
         job_name: str = "jobs",
         config_entity: str = "configs",
-        config_model_entity: str = "config_models",
+        config_validation_entity: str = "config_validation",
         template_entity: str = "templates",
         update_outdated: timedelta = timedelta(hours=4),
     ):
@@ -54,7 +54,7 @@ class DbAccess(ABC):
         self.running_task_db = running_task_db(self.db, running_task_name)
         self.job_db = job_db(self.db, job_name)
         self.config_entity_db = config_entity_db(self.db, config_entity)
-        self.config_model_entity_db = config_model_entity_db(self.db, config_model_entity)
+        self.config_validation_entity_db = config_validation_entity_db(self.db, config_validation_entity)
         self.template_entity_db = template_entity_db(self.db, template_entity)
         self.graph_dbs: Dict[str, GraphDB] = {}
         self.update_outdated = update_outdated
@@ -66,7 +66,7 @@ class DbAccess(ABC):
         await self.running_task_db.create_update_schema()
         await self.job_db.create_update_schema()
         await self.config_entity_db.create_update_schema()
-        await self.config_model_entity_db.create_update_schema()
+        await self.config_validation_entity_db.create_update_schema()
         await self.template_entity_db.create_update_schema()
         for graph in self.database.graphs():
             log.info(f'Found graph: {graph["name"]}')

--- a/resotocore/resotocore/model/model.py
+++ b/resotocore/resotocore/model/model.py
@@ -199,7 +199,7 @@ class Kind(ABC):
         if "inner" in js:
             inner = Kind.from_json(js["inner"])
             return ArrayKind(inner)
-        elif "fqn" in js and "runtime_kind" in js and js["runtime_kind"] in SimpleKind.Kind_to_type:
+        elif "fqn" in js and "runtime_kind" in js and js["runtime_kind"] in simple_kind_to_type:
             fqn = js["fqn"]
             rk = js["runtime_kind"]
             if "source_fqn" in js and "converter" in js and "reverse_order" in js:
@@ -236,23 +236,24 @@ class Kind(ABC):
             raise JSONDecodeError("Given type can not be read.", json.dumps(js), 0)
 
 
+simple_kind_to_type: Dict[str, Type[Union[str, int, float, bool]]] = {
+    "string": str,
+    "int32": int,
+    "int64": int,
+    "float": float,
+    "double": float,
+    "boolean": bool,
+    "date": str,
+    "datetime": str,
+    "duration": str,
+}
+
+
 class SimpleKind(Kind, ABC):
     def __init__(self, fqn: str, runtime_kind: str, reverse_order: bool = False):
         super().__init__(fqn)
         self.runtime_kind = runtime_kind
         self.reverse_order = reverse_order
-
-    Kind_to_type: Dict[str, Type[Union[str, int, float, bool]]] = {
-        "string": str,
-        "int32": int,
-        "int64": int,
-        "float": float,
-        "double": float,
-        "boolean": bool,
-        "date": str,
-        "datetime": str,
-        "duration": str,
-    }
 
     # noinspection PyMethodMayBeStatic
     def coerce(self, value: object) -> Any:

--- a/resotocore/resotocore/static/api-doc.yaml
+++ b/resotocore/resotocore/static/api-doc.yaml
@@ -17,8 +17,8 @@ tags:
         description: Endpoints to maintain the schema and model of the entities inside a graph.
     -   name: config
         description: Endpoints to maintain configuration data.
-    -   name: config_model
-        description: Endpoints to maintain the model of configuration data.
+    -   name: config_validation
+        description: Endpoints to define how configs should be validated.
     -   name: cli
         description: Endpoints to evaluate and execute cli commands.
     -   name: subscriptions
@@ -1535,14 +1535,14 @@ paths:
                                 type: array
                                 items:
                                     type: string
-    /configs/model:
+    /configs/validation:
         get:
             summary: "Get all configuration keys that have a model defined."
             description: |
                 **Experimental**: This API is not stable and might be subject of change.<br/>
                 Get all configuration keys that have a model defined.
             tags:
-                - config_model
+                - config_validation
             responses:
                 "200":
                     description: All configuration keys that have a model.
@@ -1653,14 +1653,14 @@ paths:
                 "204":
                     description: Signals success of this operation.
 
-    /config/{config_id}/model:
+    /config/{config_id}/validation:
         get:
             summary: "Get a configuration by its id"
             description: |
                 **Experimental**: This API is not stable and might be subject of change.<br/>
                 Fetch the model of a configuration by id.
             tags:
-                - config_model
+                - config_validation
             parameters:
                 -   name: config_id
                     required: true
@@ -1674,10 +1674,10 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: "#/components/schemas/Kind"
+                                $ref: "#/components/schemas/ConfigValidation"
                         application/yaml:
                             schema:
-                                $ref: "#/components/schemas/Kind"
+                                $ref: "#/components/schemas/ConfigValidation"
                 "404":
                     description: No configuration model for this key.
 
@@ -1687,7 +1687,7 @@ paths:
                 **Experimental**: This API is not stable and might be subject of change.<br/>
                 Replace a configuration model identified by id with provided value.
             tags:
-                - config_model
+                - config_validation
             parameters:
                 -   name: config_id
                     required: true
@@ -1699,14 +1699,14 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: "#/components/schemas/Kind"
+                            $ref: "#/components/schemas/ConfigValidation"
             responses:
                 "200":
                     description: The configuration model.
                     content:
                         application/json:
                             schema:
-                                $ref: "#/components/schemas/Kind"
+                                $ref: "#/components/schemas/ConfigValidation"
     # endregion
 
     # region cli
@@ -2130,7 +2130,21 @@ components:
                 edges_deleted:
                     description: "The number of edges that have been deleted."
                     type: integer
-
+        ConfigValidation:
+            description: "The validation for this configuration value."
+            type: object
+            properties:
+                id:
+                    description: The identifier of the related configuration.
+                    type: string
+                kinds:
+                    $ref: "#/components/schemas/Kind"
+                external_validation:
+                    description: |
+                        True, if an external entity should validate a config change.
+                        In this case resotocore is emitting a task on the task queue of type validate_config.
+                        It expectes a listener to pickup this task and report back, if the configuration is valid or not.
+                    type: boolean
         Kind:
             description: "Definition of a kind"
             type: array

--- a/resotocore/resotocore/web/api.py
+++ b/resotocore/resotocore/web/api.py
@@ -48,7 +48,7 @@ from resotocore.cli.model import (
     CLICommand,
     InternalPart,
 )
-from resotocore.config import ConfigHandler
+from resotocore.config import ConfigHandler, ConfigValidation
 from resotocore.console_renderer import ConsoleColorSystem, ConsoleRenderer
 from resotocore.db.db_access import DbAccess
 from resotocore.db.graphdb import GraphDB
@@ -218,9 +218,9 @@ class Api:
                 web.patch("/config/{config_id}", self.patch_config),
                 web.delete("/config/{config_id}", self.delete_config),
                 # config model operations
-                web.get("/configs/model", self.list_config_models),
-                web.put("/config/{config_id}/model", self.put_config_model),
-                web.get("/config/{config_id}/model", self.get_config_model),
+                web.get("/configs/validation", self.list_config_models),
+                web.put("/config/{config_id}/validation", self.put_config_model),
+                web.get("/config/{config_id}/validation", self.get_config_model),
                 # ca operations
                 web.get("/ca/cert", self.certificate),
                 web.post("/ca/sign", self.sign_certificate),
@@ -306,23 +306,20 @@ class Api:
         return HTTPNoContent()
 
     async def list_config_models(self, request: Request) -> StreamResponse:
-        return await self.stream_response_from_gen(request, self.config_handler.list_config_model_ids())
+        return await self.stream_response_from_gen(request, self.config_handler.list_config_validation_ids())
 
     async def get_config_model(self, request: Request) -> StreamResponse:
         config_id = request.match_info["config_id"]
-        model = await self.config_handler.get_config_model(config_id)
-        return (
-            await single_result(request, to_js(model.kinds))
-            if model
-            else HTTPNotFound(text="No model for this config.")
-        )
+        model = await self.config_handler.get_config_validation(config_id)
+        return await single_result(request, to_js(model)) if model else HTTPNotFound(text="No model for this config.")
 
     async def put_config_model(self, request: Request) -> StreamResponse:
         config_id = request.match_info["config_id"]
         js = await self.json_from_request(request)
-        kinds = from_js(js, List[Kind])
-        model = await self.config_handler.put_config_model(config_id, kinds)
-        return await single_result(request, to_js(model.kinds))
+        js["id"] = config_id
+        config_model = from_js(js, ConfigValidation)
+        model = await self.config_handler.put_config_validation(config_model)
+        return await single_result(request, to_js(model))
 
     async def certificate(self, _: Request) -> StreamResponse:
         cert, fingerprint = self.cert_handler.authority_certificate

--- a/resotocore/tests/resotocore/config/config_handler_service_test.py
+++ b/resotocore/tests/resotocore/config/config_handler_service_test.py
@@ -1,5 +1,5 @@
 from textwrap import dedent
-from typing import List
+from typing import List, Any
 
 import pytest
 from pytest import fixture
@@ -7,14 +7,19 @@ from pytest import fixture
 from resotocore.config import ConfigHandler, ConfigEntity, ConfigModel
 from resotocore.config.config_handler_service import ConfigHandlerService
 from resotocore.model.model import Kind, ComplexKind, Property
+from resotocore.worker_task_queue import WorkerTaskQueue
 from tests.resotocore.db.entitydb import InMemoryDb
+
+# noinspection PyUnresolvedReferences
+from tests.resotocore.worker_task_queue_test import worker, task_queue, performed_by, incoming_tasks
 
 
 @fixture
-def config_handler() -> ConfigHandler:
+def config_handler(task_queue: WorkerTaskQueue, worker: Any) -> ConfigHandler:
+    # Note: the worker fixture is required, since it starts worker tasks
     cfg_db = InMemoryDb(ConfigEntity, lambda c: c.id)
     model_db = InMemoryDb(ConfigModel, lambda c: c.id)
-    return ConfigHandlerService(cfg_db, model_db)
+    return ConfigHandlerService(cfg_db, model_db, task_queue)
 
 
 @fixture
@@ -79,18 +84,32 @@ async def test_config_model(config_handler: ConfigHandler, config_model: List[Ki
     assert model.kinds == config_model  # type: ignore
 
     # valid
-    await config_handler.put_config("test", {"some_number": 32, "some_string": "test", "some_sub": {"num": 32}})
+    valid_config = {"some_number": 32, "some_string": "test", "some_sub": {"num": 32}}
+    await config_handler.put_config("test", valid_config)
 
     # invalid
     with pytest.raises(AttributeError) as reason:
         await config_handler.put_config("test", {"some_number": 32, "some_string": 32})
     assert "Property:some_string is not valid: Expected type string but got int" in str(reason)
 
+    # A config with name "invalid_config" is rejected by the configured worker
+    await config_handler.put_config_model("invalid_config", config_model)
+    with pytest.raises(AttributeError) as reason:
+        # The config is actually valid, but the external validation will fail
+        await config_handler.put_config("invalid_config", valid_config)
+    assert "Error executing task: Invalid Config ;)" in str(reason)
+
+    # A config model with more than one complex root is rejected
+    with pytest.raises(AttributeError) as reason:
+        await config_handler.put_config_model("test", [ComplexKind("a", [], []), ComplexKind("b", [], [])])
+    assert "Require exactly one config root kind, but got: a, b" in str(reason)
+
 
 @pytest.mark.asyncio
 async def test_config_yaml(config_handler: ConfigHandler, config_model: List[Kind]) -> None:
     await config_handler.put_config_model("test", config_model)
-    await config_handler.put_config("test", {"some_number": 32, "some_string": "test", "some_sub": {"num": 32}})
+    config = {"some_number": 32, "some_string": "test", "some_sub": {"num": 32}}
+    await config_handler.put_config("test", config)
     assert await config_handler.config_yaml("test") == dedent(
         """
         # Some number.
@@ -104,4 +123,17 @@ async def test_config_yaml(config_handler: ConfigHandler, config_model: List[Kin
         some_sub:\u0020
           # Some arbitrary number.
           num: 32"""
+    )
+    # same config values, but no attached model
+    await config_handler.put_config("no_model", config)
+    assert (
+        await config_handler.config_yaml("no_model")
+        == dedent(
+            """
+            some_number: 32
+            some_string: test
+            some_sub:
+              num: 32
+            """
+        ).lstrip()
     )


### PR DESCRIPTION
# Description

The `/config/model` endpoint is renamed to `/config/validation`.
It allows to define a schema model and/or control external validation.

The schema is used for 2 reasons:
- the generated yaml will hold the documentation from the model
- the resulting config is checked against this schema

In case of external validation: 
resotocore will expect a worker registered to the task queue.
A task is emitted to the queue on every config change.
Only if the task executes successfully, the config is accepted.
In case the task fails, the error is propagated to the user.


<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [ ] Wait for #702 to get merged and rebase on master
- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`

