### PR TITLE
[resotocore][feat] Allow singular and plural form for cli commands

### DIFF
--- a/resotocore/resotocore/cli/command.py
+++ b/resotocore/resotocore/cli/command.py
@@ -3571,4 +3571,19 @@ def all_commands(d: CLIDependencies) -> List[CLICommand]:
 
 def aliases() -> Dict[str, str]:
     # command alias -> command name
-    return {"match": "search", "query": "search", "https": "http", "kind": "kinds", "config": "configs"}
+    return {
+        "match": "search",
+        "query": "search",
+        "https": "http",
+        "kind": "kinds",
+        "config": "configs",
+        "tags": "tag",
+        "predecessor": "predecessors",
+        "successor": "successors",
+        "descendant": "descendants",
+        "ancestor": "ancestors",
+        "job": "jobs",
+        "lists": "list",
+        "template": "templates",
+        "workflow": "workflows",
+    }


### PR DESCRIPTION
# Description

Allow `workflow` and `workflows`, `tag` and `tags` etc.