### PR TITLE
[resotocore][feat] Only update config on change + revision header

### DIFF
--- a/resotocore/resotocore/static/api-doc.yaml
+++ b/resotocore/resotocore/static/api-doc.yaml
@@ -1607,6 +1607,11 @@ paths:
             responses:
                 "200":
                     description: The configuration
+                    headers:
+                        Resoto-Config-Revision:
+                            description: The revision of this config
+                            schema:
+                                type: string
                     content:
                         application/json:
                             schema:
@@ -1646,6 +1651,11 @@ paths:
             responses:
                 "200":
                     description: The configuration
+                    headers:
+                        Resoto-Config-Revision:
+                            description: The revision of this config
+                            schema:
+                                type: string
                     content:
                         application/json:
                             schema:
@@ -1674,6 +1684,11 @@ paths:
             responses:
                 "200":
                     description: The configuration
+                    headers:
+                        Resoto-Config-Revision:
+                            description: The revision of this config
+                            schema:
+                                type: string
                     content:
                         application/json:
                             schema:


### PR DESCRIPTION
# Description

Config is only ipdayted if changed - also the event is also only emitted in this case.
The revision number comes as part of GET/PUT/PATCH requests.
