### PR TITLE
k8s plugin: Add horizontal_pod_autoscaler type

### DIFF
--- a/plugins/k8s/resoto_plugin_k8s/resources/__init__.py
+++ b/plugins/k8s/resoto_plugin_k8s/resources/__init__.py
@@ -6,6 +6,7 @@ from .stateful_set import KubernetesStatefulSet
 from .daemon_set import KubernetesDaemonSet
 from .controller_revision import KubernetesControllerRevision
 from .pod import KubernetesPod
+from .horizontal_pod_autoscaler import KubernetesHorizontalPodAutoscaler
 
 mandatory_collectors = {
     "nodes": KubernetesNode.collect,
@@ -19,6 +20,7 @@ global_collectors = {
     "controller_revision": KubernetesControllerRevision.collect,
     "daemon_set": KubernetesDaemonSet.collect,
     "pods": KubernetesPod.collect,
+    "horizontal_pod_autoscaler": KubernetesHorizontalPodAutoscaler.collect,
 }
 
 all_collectors = dict(mandatory_collectors)

--- a/plugins/k8s/resoto_plugin_k8s/resources/horizontal_pod_autoscaler.py
+++ b/plugins/k8s/resoto_plugin_k8s/resources/horizontal_pod_autoscaler.py
@@ -1,0 +1,22 @@
+from kubernetes import client
+from .common import KubernetesResource
+from resotolib.baseresources import (
+    BaseResource,
+)
+from typing import ClassVar, Dict
+from dataclasses import dataclass
+
+
+@dataclass(eq=False)
+class KubernetesHorizontalPodAutoscaler(KubernetesResource, BaseResource):
+    kind: ClassVar[str] = "kubernetes_horizontal_pod_autoscaler"
+    api: ClassVar[object] = client.AutoscalingV1Api
+    list_method: ClassVar[str] = "list_horizontal_pod_autoscaler_for_all_namespaces"
+
+    attr_map: ClassVar[Dict] = {
+        "max_replicas": lambda r: r.spec.max_replicas,
+        "min_replicas": lambda r: r.spec.min_replicas,
+    }
+
+    max_replicas: int = 0
+    min_replicas: int = 0


### PR DESCRIPTION
# Description

This adds horizontal_pod_autoscaler as a k8s resource, using the [V1 autoscaling API](https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1HorizontalPodAutoscaler.md). (V2 is the latest version but stable only as of 1.23, so V1 is better for broader compatibility IMO.)

Current fields are `max_replicas` and `min_replicas`.
# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [ ] Add test coverage for new or updated functionality - _Do you want this given the current alpha status of this plugin?_
- [x] Lint and test with `tox`
- [x] Document new or updated functionality (https://github.com/someengineering/resoto.com/pull/74)


# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
