### PR TITLE
[ci][chore] Commit resotocore API YAML to website repo on release

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -375,9 +375,15 @@ jobs:
           file="resoto.com/news/$(date +'%Y-%m-%d')-v${tags[0]}.md"
           link="https://resoto.com/news/$(date +'%Y/%m/%d')/v${tags[0]}"
           python tools/release_notes.py ${tags[1]} ${tags[0]} > $file
+          cp resotocore/core/static/api-doc.yaml resoto.com/openapi/resotocore.yml
           echo ::set-output name=tag::${tags[0]}
           echo ::set-output name=file::$file
           echo ::set-output name=link::$link
+
+      - name: Modify resotocore API YAML
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq e -i '.servers[0].url = "http://localhost:8900" | del(.servers[0].description)' resoto.com/openapi/resotocore.yml
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -375,7 +375,7 @@ jobs:
           file="resoto.com/news/$(date +'%Y-%m-%d')-v${tags[0]}.md"
           link="https://resoto.com/news/$(date +'%Y/%m/%d')/v${tags[0]}"
           python tools/release_notes.py ${tags[1]} ${tags[0]} > $file
-          cp resotocore/core/static/api-doc.yaml resoto.com/openapi/resotocore.yml
+          cp resotocore/resotocore/static/api-doc.yaml resoto.com/openapi/resotocore.yml
           echo ::set-output name=tag::${tags[0]}
           echo ::set-output name=file::$file
           echo ::set-output name=link::$link

--- a/resotocore/resotocore/static/api-doc.yaml
+++ b/resotocore/resotocore/static/api-doc.yaml
@@ -3,9 +3,8 @@ servers:
     -   url: ../
         description: current system
 info:
-    description: API provided by resotocore
+    title: Resoto Core REST API
     version: V1
-    title: resotocore REST API
 tags:
     -   name: graph_search
         description: Endpoints to search all sections of the graph.


### PR DESCRIPTION
# Description

Writes a modified version of the resotocore OpenAPI YAML spec to the [someengineering/resoto.com](https://github.com/someengineering/resoto.com) repository upon each release.  The modifications are necessary so that the server path appears as expected on the website API docs. (I have manually copied and committed the current state of the spec to the resoto.com repo already.)

Also removes the description, which does not add any additional information not provided by the title.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
