### PR TITLE
[plugins/k8s][feat] Add argument to collect all contexts in config file

### DIFF
--- a/plugins/k8s/README.md
+++ b/plugins/k8s/README.md
@@ -6,6 +6,7 @@ It is meant as a starting point for K8S work but not intended for production use
 ## Usage
 When the collector is enabled (`--collector k8s`) it will automatically collect the current active context if any exists.
 Optionally a list of contexts to collect can be supplied using `--k8s-context contextA contextB contextC ...`.
+To collect all contexts in the config file without having to specify each, use `--k8s-all-contexts`
 If a config file (`--k8s-config`) is supplied it will be used instead of the default `~/.kube/config`.
 
 Alternatively or in addition Kubernetes Clusters can be specified entirely on the commandline using e.g.
@@ -41,4 +42,5 @@ For example if `clusterC` is provided in third place using `--k8s-cluster firstc
   --k8s-pool-size K8S_POOL_SIZE
                         Kubernetes Thread Pool Size (default: 5)
   --k8s-fork            Kubernetes use forked process instead of threads (default: False)
+  --k8s-all-contexts    Kubernetes collect all contexts in kubeconfig file without needed to specify --k8s-context (default: False)
 ```

--- a/plugins/k8s/resoto_plugin_k8s/__init__.py
+++ b/plugins/k8s/resoto_plugin_k8s/__init__.py
@@ -174,3 +174,9 @@ class KubernetesCollectorPlugin(BaseCollectorPlugin):
             dest="k8s_fork",
             action="store_true",
         )
+        arg_parser.add_argument(
+            "--k8s-all-contexts",
+            help="Kubernetes collect all contexts in kubeconfig file without needed to specify --k8s-context",
+            dest="k8s_all_contexts",
+            action="store_true",
+        )

--- a/plugins/k8s/resoto_plugin_k8s/utils.py
+++ b/plugins/k8s/resoto_plugin_k8s/utils.py
@@ -46,7 +46,11 @@ def k8s_config() -> Dict:
         log.error(e)
     else:
         if contexts:
-            if (
+            if ArgumentParser.args.k8s_all_contexts:
+                log.debug(
+                    "importing all contexts in configuration file since --k8s-all-contexts was specified"
+                )
+            elif (
                 len(ArgumentParser.args.k8s_context) == 0
                 and len(ArgumentParser.args.k8s_cluster) == 0
             ):
@@ -54,16 +58,19 @@ def k8s_config() -> Dict:
                 log.debug(
                     (
                         "no --k8s-context or --k8s-cluster specified, defaulting to"
-                        f" active context {active_context}"
+                        f" active context {active_context}. To import all contexts"
+                        " in configuration file, use --k8s-all-contexts"
                     )
                 )
             else:
                 active_context = None
 
             contexts = [context["name"] for context in contexts]
+
             for context in contexts:
                 if (
-                    context not in ArgumentParser.args.k8s_context
+                    not ArgumentParser.args.k8s_all_contexts
+                    and context not in ArgumentParser.args.k8s_context
                     and context != active_context
                 ):
                     log.debug(

--- a/plugins/k8s/test/test_args.py
+++ b/plugins/k8s/test/test_args.py
@@ -16,3 +16,4 @@ def test_args():
     assert len(ArgumentParser.args.k8s_no_collect) == 0
     assert ArgumentParser.args.k8s_pool_size == 5
     assert ArgumentParser.args.k8s_fork is False
+    assert ArgumentParser.args.k8s_all_contexts is False


### PR DESCRIPTION
# Description

This avoids the need to specify every context in order to have it imported.

Added a new argument rather than a magic value like `all` for `--k8s-context` to avoid any potential conflicts.

# To-Dos

- [x] Add test coverage for new or updated functionality (to the extent that there's existing coverage to extend)
- [x] Lint and test with `tox`
- N/A ~Document new or updated functionality (someengineering/resoto.com#XXXX)~

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
