### PR TITLE
[resotocore][feat] Improve AliasTemplate handling

### DIFF
--- a/resotocore/resotocore/cli/__init__.py
+++ b/resotocore/resotocore/cli/__init__.py
@@ -65,11 +65,11 @@ args_parts_parser = (
 ).sep_by(space_dp, min=1)
 
 
-def strip_quotes(string: str, strip: str = "'\"") -> str:
+def strip_quotes(string: str) -> str:
     res = string.strip()
     if res:
         first = res[0]
-        if first in strip:
+        if first in "'\"":
             res = res[1 : len(res) - 1] if res.startswith(first) and res.endswith(first) else res  # noqa: E203
     return res
 

--- a/resotocore/resotocore/cli/__init__.py
+++ b/resotocore/resotocore/cli/__init__.py
@@ -65,10 +65,13 @@ args_parts_parser = (
 ).sep_by(space_dp, min=1)
 
 
-def strip_quotes(string: str, strip: str = '"') -> str:
-    s = string.strip()
-    ls = len(strip)
-    return s[ls : len(s) - ls] if s.startswith(strip) and s.endswith(strip) else s  # noqa: E203
+def strip_quotes(string: str, strip: str = "'\"") -> str:
+    res = string.strip()
+    if res:
+        first = res[0]
+        if first in strip:
+            res = res[1 : len(res) - 1] if res.startswith(first) and res.endswith(first) else res  # noqa: E203
+    return res
 
 
 # check if a is a json node element

--- a/resotocore/resotocore/cli/cli.py
+++ b/resotocore/resotocore/cli/cli.py
@@ -530,6 +530,5 @@ class CLI:
         )
 
     @staticmethod
-    def replace_placeholder(cli_input: str, replacements: Optional[Dict[str, Any]] = None, **env: str) -> str:
-        repls = replacements or CLI.replacements(**env)
-        return render_template(cli_input, repls, tags=("@", "@"))
+    def replace_placeholder(cli_input: str, **env: str) -> str:
+        return render_template(cli_input, CLI.replacements(**env), tags=("@", "@"))

--- a/resotocore/resotocore/cli/cli.py
+++ b/resotocore/resotocore/cli/cli.py
@@ -8,7 +8,6 @@ from asyncio import Task
 from contextlib import suppress
 from dataclasses import replace
 from datetime import timedelta
-from functools import reduce
 from itertools import takewhile
 from operator import attrgetter
 from textwrap import dedent
@@ -74,6 +73,7 @@ from resotocore.query.model import (
     Sort,
 )
 from resotocore.query.query_parser import aggregate_parameter_parser
+from resotocore.query.template_expander import render_template
 from resotocore.util import utc_str, utc, from_utc
 
 log = logging.getLogger(__name__)
@@ -195,6 +195,21 @@ class HelpCommand(CLICommand):
 CLIArg = Tuple[CLICommand, Optional[str]]
 # If no sort is defined in the part, we use this default sort order
 DefaultSort = [Sort("/reported.kind"), Sort("/reported.name"), Sort("/reported.id")]
+
+
+class CIKeyDict(Dict[str, Any]):
+    """
+    Special purpose dict used to lookup replacement values:
+    - the dict should be case-insensitive: so now and NOW does not matter
+    - if no replacement value is found, the key is returned.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__({k.lower(): v for k, v in kwargs.items()})
+
+    def __getitem__(self, item: str) -> Any:
+        key = item.lower()
+        return super().__getitem__(key) if key in self else item
 
 
 class CLI:
@@ -450,8 +465,10 @@ class CLI:
             )
 
         def replace_placeholders(parsed: ParsedCommands) -> ParsedCommands:
+            cmd_env = {**self.cli_env, **context.env, **parsed.env}
+
             def replace_command(cmd: ParsedCommand) -> ParsedCommand:
-                args = cmd.args if cmd.args is None else self.replace_placeholder(cmd.args, **parsed.env)
+                args = cmd.args if cmd.args is None else self.replace_placeholder(cmd.args, **cmd_env)
                 return ParsedCommand(cmd.cmd, args)
 
             return ParsedCommands([replace_command(cmd) for cmd in parsed.commands], parsed.env)
@@ -480,30 +497,30 @@ class CLI:
             n = ut.astimezone(get_localzone())
         except Exception:
             n = ut
-        return {
-            "UTC": utc_str(ut),
-            "NOW": utc_str(n),
-            "TODAY": t.strftime("%Y-%m-%d"),
-            "TOMORROW": (t + timedelta(days=1)).isoformat(),
-            "YESTERDAY": (t + timedelta(days=-1)).isoformat(),
-            "YEAR": t.strftime("%Y"),
-            "MONTH": t.strftime("%m"),
-            "DAY": t.strftime("%d"),
-            "TIME": n.strftime("%H:%M:%S"),
-            "HOUR": n.strftime("%H"),
-            "MINUTE": n.strftime("%M"),
-            "SECOND": n.strftime("%S"),
-            "TZ_OFFSET": n.strftime("%z"),
-            "TZ": n.strftime("%Z"),
-            "MONDAY": (t + timedelta((calendar.MONDAY - t.weekday()) % 7)).isoformat(),
-            "TUESDAY": (t + timedelta((calendar.TUESDAY - t.weekday()) % 7)).isoformat(),
-            "WEDNESDAY": (t + timedelta((calendar.WEDNESDAY - t.weekday()) % 7)).isoformat(),
-            "THURSDAY": (t + timedelta((calendar.THURSDAY - t.weekday()) % 7)).isoformat(),
-            "FRIDAY": (t + timedelta((calendar.FRIDAY - t.weekday()) % 7)).isoformat(),
-            "SATURDAY": (t + timedelta((calendar.SATURDAY - t.weekday()) % 7)).isoformat(),
-            "SUNDAY": (t + timedelta((calendar.SUNDAY - t.weekday()) % 7)).isoformat(),
-        }
+        return CIKeyDict(
+            UTC=utc_str(ut),
+            NOW=utc_str(n),
+            TODAY=t.strftime("%Y-%m-%d"),
+            TOMORROW=(t + timedelta(days=1)).isoformat(),
+            YESTERDAY=(t + timedelta(days=-1)).isoformat(),
+            YEAR=t.strftime("%Y"),
+            MONTH=t.strftime("%m"),
+            DAY=t.strftime("%d"),
+            TIME=n.strftime("%H:%M:%S"),
+            HOUR=n.strftime("%H"),
+            MINUTE=n.strftime("%M"),
+            SECOND=n.strftime("%S"),
+            TZ_OFFSET=n.strftime("%z"),
+            TZ=n.strftime("%Z"),
+            MONDAY=(t + timedelta((calendar.MONDAY - t.weekday()) % 7)).isoformat(),
+            TUESDAY=(t + timedelta((calendar.TUESDAY - t.weekday()) % 7)).isoformat(),
+            WEDNESDAY=(t + timedelta((calendar.WEDNESDAY - t.weekday()) % 7)).isoformat(),
+            THURSDAY=(t + timedelta((calendar.THURSDAY - t.weekday()) % 7)).isoformat(),
+            FRIDAY=(t + timedelta((calendar.FRIDAY - t.weekday()) % 7)).isoformat(),
+            SATURDAY=(t + timedelta((calendar.SATURDAY - t.weekday()) % 7)).isoformat(),
+            SUNDAY=(t + timedelta((calendar.SUNDAY - t.weekday()) % 7)).isoformat(),
+        )
 
     @staticmethod
     def replace_placeholder(cli_input: str, **env: str) -> str:
-        return reduce(lambda res, kv: res.replace(f"@{kv[0]}@", kv[1]), CLI.replacements(**env).items(), cli_input)
+        return render_template(cli_input, CLI.replacements(**env), tags=("@", "@"))

--- a/resotocore/resotocore/cli/cli.py
+++ b/resotocore/resotocore/cli/cli.py
@@ -6,6 +6,7 @@ import logging
 import os
 from asyncio import Task
 from contextlib import suppress
+from copy import copy
 from dataclasses import replace
 from datetime import timedelta
 from itertools import takewhile
@@ -441,7 +442,7 @@ class CLI:
         def expand_aliases(line: ParsedCommands) -> ParsedCommands:
             def expand_alias(alias_cmd: ParsedCommand) -> List[ParsedCommand]:
                 alias: AliasTemplate = self.alias_templates[alias_cmd.cmd]
-                props: Dict[str, JsonElement] = replacements.copy()  # type: ignore
+                props: Dict[str, JsonElement] = copy(replacements)  # type: ignore
                 for p in alias.parameters:
                     props[p.name] = p.default
                 props.update(key_values_parser.parse(alias_cmd.args or ""))

--- a/resotocore/resotocore/cli/cli.py
+++ b/resotocore/resotocore/cli/cli.py
@@ -499,7 +499,7 @@ class CLI:
             n = ut
         return CIKeyDict(
             UTC=utc_str(ut),
-            NOW=utc_str(n),
+            NOW=n.strftime("%Y-%m-%dT%H:%M:%S%z"),
             TODAY=t.strftime("%Y-%m-%d"),
             TOMORROW=(t + timedelta(days=1)).isoformat(),
             YESTERDAY=(t + timedelta(days=-1)).isoformat(),

--- a/resotocore/resotocore/cli/command.py
+++ b/resotocore/resotocore/cli/command.py
@@ -3154,7 +3154,7 @@ class HttpCommand(CLICommand):
 
         async def perform_request(e: JsonElement) -> int:
             nonlocal retries_left
-            data = None if template.no_body else (JsonPayload(e) if isinstance(e, dict) else e)
+            data = None if template.no_body else (JsonPayload(e) if isinstance(e, (dict, list)) else e)
             log.debug(f"Perform request with this template={template} and data={data}")
             try:
                 async with self.dependencies.http_session.request(

--- a/resotocore/resotocore/cli/command.py
+++ b/resotocore/resotocore/cli/command.py
@@ -1235,13 +1235,13 @@ class UniqCommand(CLICommand):
 
 class JqCommand(CLICommand, OutputTransformer):
     """
-     ```
-     jq [--no-rewrite] <filter>
-     ```
+    ```
+    jq [--no-rewrite] <filter>
+    ```
 
-     Use the well known jq JSON processor to manipulate incoming json.
-     Every element from the incoming stream is passed to jq.
-     See: https://stedolan.github.io/jq/ for a list of possible jq filter definitions.
+    Use the well known jq JSON processor to manipulate incoming json.
+    Every element from the incoming stream is passed to jq.
+    See: https://stedolan.github.io/jq/ for a list of possible jq filter definitions.
 
     Resoto will rewrite attribute paths to match the defined section.
     Example:
@@ -1254,32 +1254,32 @@ class JqCommand(CLICommand, OutputTransformer):
 
     If you find yourself fighting with this rewrite mechanism, you can turn it off with the `--no-rewrite` option.
 
-     ## Options
-     - `--no-rewrite` When this option is enabled, the jq filter is not preprocessed by Resoto and given as is to Jq.
+    ## Options
+    - `--no-rewrite` When this option is enabled, the jq filter is not preprocessed by Resoto and given as is to Jq.
 
-     ## Parameters
-     - `filter` the filter definition to create a jq program.
+    ## Parameters
+    - `filter` the filter definition to create a jq program.
 
-     ## Examples
+    ## Examples
 
-     ```shell
-     # Search ec2 instances and extract only the name property
-     > search is(aws_ec2_instance) limit 2| jq .name
-     build-node-1
-     prod-23
+    ```shell
+    # Search ec2 instances and extract only the name property
+    > search is(aws_ec2_instance) limit 2| jq .name
+    build-node-1
+    prod-23
 
-     # Search ec2 instances and create a new json object for each entry with name and owner.
-     > search is(aws_ec2_instance) limit 2 | jq {name: .name, owner: .tags.owner}
-     name: build-node-1
-     owner: frosty
-     ---
-     name: prod-23
-     owner: bog-team
-     ```
+    # Search ec2 instances and create a new json object for each entry with name and owner.
+    > search is(aws_ec2_instance) limit 2 | jq {name: .name, owner: .tags.owner}
+    name: build-node-1
+    owner: frosty
+    ---
+    name: prod-23
+    owner: bog-team
+    ```
 
-     ## Related
-     - `format` - to format incoming objects to a defined string.
-     - `list` - create list output for every element.
+    ## Related
+    - `format` - to format incoming objects to a defined string.
+    - `list` - create list output for every element.
     """
 
     @property

--- a/resotocore/resotocore/task/task_handler.py
+++ b/resotocore/resotocore/task/task_handler.py
@@ -118,7 +118,7 @@ class TaskHandlerService(TaskHandler):
         def evaluate(step: Step) -> Step:
             if isinstance(step.action, ExecuteCommand):
                 update = copy(step)
-                update.action = ExecuteCommand(self.cli.replace_placeholder(step.action.command, None, **env))
+                update.action = ExecuteCommand(self.cli.replace_placeholder(step.action.command, **env))
                 return update
             else:
                 return step

--- a/resotocore/resotocore/task/task_handler.py
+++ b/resotocore/resotocore/task/task_handler.py
@@ -549,11 +549,11 @@ class TaskHandlerService(TaskHandler):
                 raise ValueError(f"Invalid job {stripped}")
             wait: Optional[Tuple[EventTrigger, timedelta]] = None
             trigger = TimeTrigger(" ".join(parts[0:5]))
-            command = strip_quotes(parts[5], "'")
+            command = strip_quotes(parts[5])
             # check if we also need to wait for an event: name_of_event : command
             if self.event_re.match(command):
                 event, command = re.split("\\s*:\\s*", command, 1)
-                command = strip_quotes(command, "'")
+                command = strip_quotes(command)
                 wait = EventTrigger(event), wait_timeout
             await self.cli.evaluate_cli_command(command, ctx, replace_place_holder=False)
             uid = uuid_str(f"{command}{trigger}{wait}")[0:8]
@@ -561,7 +561,7 @@ class TaskHandlerService(TaskHandler):
 
         async def parse_event() -> Job:
             event, command = re.split("\\s*:\\s*", stripped, 1)
-            command = strip_quotes(command, "'")
+            command = strip_quotes(command)
             await self.cli.evaluate_cli_command(command, ctx, replace_place_holder=False)
             uid = uuid_str(f"{command}{event}")[0:8]
             return Job(uid, ExecuteCommand(command), timeout, EventTrigger(event), None, ctx.env, mutable)

--- a/resotocore/resotocore/task/task_handler.py
+++ b/resotocore/resotocore/task/task_handler.py
@@ -118,7 +118,7 @@ class TaskHandlerService(TaskHandler):
         def evaluate(step: Step) -> Step:
             if isinstance(step.action, ExecuteCommand):
                 update = copy(step)
-                update.action = ExecuteCommand(self.cli.replace_placeholder(step.action.command, **env))
+                update.action = ExecuteCommand(self.cli.replace_placeholder(step.action.command, None, **env))
                 return update
             else:
                 return step

--- a/resotocore/tests/resotocore/cli/cli_test.py
+++ b/resotocore/tests/resotocore/cli/cli_test.py
@@ -304,5 +304,6 @@ def test_ci_dict() -> None:
     assert d.keys() == {"a", "b"}
     d["c"] = 3
     d["C"] = 4
-    assert d["c"] == 4
-    assert d.keys() == {"a", "b", "c"}
+    assert d == dict(a=1, b=2, c=4)
+    d.update({"a": 2, "c": 5})
+    assert d == dict(a=2, b=2, c=5)

--- a/resotocore/tests/resotocore/cli/cli_test.py
+++ b/resotocore/tests/resotocore/cli/cli_test.py
@@ -8,7 +8,7 @@ from pytest import fixture
 
 from resotocore.analytics import InMemoryEventSender
 from resotocore.cli import strip_quotes
-from resotocore.cli.cli import CLI, multi_command_parser
+from resotocore.cli.cli import CLI, multi_command_parser, CIKeyDict
 from resotocore.cli.command import (
     ExecuteSearchCommand,
     ChunkCommand,
@@ -296,3 +296,13 @@ async def test_replacements(cli: CLI) -> None:
 
     # replacement is not touched if flag is set
     assert await execute("@today@", False) == "@today@"
+
+
+def test_ci_dict() -> None:
+    d = CIKeyDict(A=1, B=2)
+    # keys are lower case
+    assert d.keys() == {"a", "b"}
+    d["c"] = 3
+    d["C"] = 4
+    assert d["c"] == 4
+    assert d.keys() == {"a", "b", "c"}

--- a/resotocore/tests/resotocore/cli/cli_test.py
+++ b/resotocore/tests/resotocore/cli/cli_test.py
@@ -7,6 +7,7 @@ from aiostream import stream
 from pytest import fixture
 
 from resotocore.analytics import InMemoryEventSender
+from resotocore.cli import strip_quotes
 from resotocore.cli.cli import CLI, multi_command_parser
 from resotocore.cli.command import (
     ExecuteSearchCommand,
@@ -95,6 +96,11 @@ async def cli_deps(
 def cli(cli_deps: CLIDependencies) -> CLI:
     env = {"graph": "ns", "section": "reported"}
     return CLI(cli_deps, all_commands(cli_deps), env, alias_names())
+
+
+def test_strip() -> None:
+    assert strip_quotes("'test'") == "test"
+    assert strip_quotes('"test"') == "test"
 
 
 def test_command_line_parser() -> None:


### PR DESCRIPTION
# Description

While experimenting with AliasTemplates I realized a couple of possible improvements:

- The analytics event should show commands and aliases separately
- Jq needs an option to get rid  of preprocessing
- More clever templates might be required (something like: in 3 hours)
- Replace parameters are case insensitive   

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`

# Issues Fixed

<!-- If this PR will fix/resolve an open issue on the repository, please reference it below. -->
<!-- (Otherwise, feel free to delete this section.) -->

- Fixes #XXXX

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
