### PR TITLE
[resotocore][fix] TaskHandler need to handle failing  task commands

### DIFF
--- a/resotocore/resotocore/task/task_description.py
+++ b/resotocore/resotocore/task/task_description.py
@@ -530,7 +530,11 @@ class ExecuteCommandState(StepState):
     def handle_command_results(self, results: Dict[TaskCommand, Any]) -> None:
         found = first(lambda r: isinstance(r, ExecuteOnCLI) and r.command == self.execute.command, results.keys())
         if found:
-            log.info(f"Result of command {self.execute.command} is {results[found]}")
+            result = results[found]
+            if isinstance(result, Exception):
+                log.warning(f"Command {self.execute.command} failed with error: {result}")
+            else:
+                log.info(f"Result of command {self.execute.command} is {result}")
             self.execution_done = True
 
     def current_step_done(self) -> bool:

--- a/resotocore/tests/resotocore/task/task_handler_test.py
+++ b/resotocore/tests/resotocore/task/task_handler_test.py
@@ -1,8 +1,9 @@
+import logging
 from datetime import timedelta
 from typing import AsyncGenerator, List
 
 import pytest
-from pytest import fixture
+from pytest import fixture, LogCaptureFixture
 
 from resotocore.analytics import AnalyticsEventSender
 from resotocore.cli.cli import CLI
@@ -24,6 +25,7 @@ from resotocore.task.task_description import (
     TimeTrigger,
     Job,
     TaskSurpassBehaviour,
+    ExecuteCommand,
 )
 from resotocore.task.task_handler import TaskHandlerService
 
@@ -233,3 +235,21 @@ async def test_wait_for_running_job(
     assert len(running_after) == 1
     t_before, t_after = running_before[0], running_after[0]
     assert t_before.descriptor.id == t_after.descriptor.id and t_before.id != t_after.id
+
+
+@pytest.mark.asyncio
+async def test_handle_failing_task_command(task_handler: TaskHandlerService, caplog: LogCaptureFixture) -> None:
+    caplog.set_level(logging.WARN)
+    # This job will fail. Take a very long timeout - to avoid a timeout
+    job = Job("fail", ExecuteCommand("non_existing_command"), timedelta(hours=4))
+    task_handler.task_descriptions = [job]
+    assert len(await task_handler.running_tasks()) == 0
+    await task_handler.start_task(job, "test fail")
+    assert len(await task_handler.running_tasks()) == 1
+    # The task is executed async - let's wait here directly
+    await (next(iter(task_handler.tasks.values()))).update_task
+    await task_handler.check_overdue_tasks()
+    assert len(await task_handler.running_tasks()) == 0
+    # One warning has been emitted
+    assert len(caplog.records) == 1
+    assert "Command non_existing_command failed with error" in caplog.records[0].message


### PR DESCRIPTION
# Description

If a task command throws an exception, the related task kept running and was only removed after the timeout.
Exceptions are now handled as one possible result.
<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`

# Issues Fixed

<!-- If this PR will fix/resolve an open issue on the repository, please reference it below. -->
<!-- (Otherwise, feel free to delete this section.) -->

- Fixes #733

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
