### PR TITLE
[ci][chore] Fix release CI

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -388,7 +388,7 @@ jobs:
       - name: Format
         working-directory: ./resoto.com
         env:
-          HUSKY_SKIP_INSTALL: 1
+          HUSKY: 0
         run: |
           yarn install --frozen-lockfile
           yarn format

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -398,7 +398,7 @@ jobs:
         with:
           path: resoto.com
           commit-message: "feat: v${{ steps.release_notes.outputs.tag }} release notes"
-          title: "feat: v${{ steps.release_notes.outputs.tag }} release notes"
+          title: "feat(news): v${{ steps.release_notes.outputs.tag }} release notes"
           body: |
             Adds automatically generated release notes for [v${{ steps.release_notes.outputs.tag }}](https://github.com/someengineering/resoto/releases/tag/${{ steps.release_notes.outputs.tag }}).
           labels: |

--- a/tools/release_notes.py
+++ b/tools/release_notes.py
@@ -71,7 +71,9 @@ def show_log(from_tag: str, to_tag: str):
         ],
     )
 
-    print(f"# v{to_tag}")
+    print("---\ntags: [release notes]\n---")
+
+    print(f"\n# v{to_tag}")
 
     print("\n## What's Changed")
     for group, commits in grouped.items():


### PR DESCRIPTION
# Description

Husky changed the env var to disable/skip hooks in a recent release, and this is causing the release note generation part of the CI to fail.

(Going to manually create the release shortly.)

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
