### PR TITLE
[resotocore/resotolib][chore] Bump black==22.3.0

### DIFF
--- a/resotocore/requirements-dev.txt
+++ b/resotocore/requirements-dev.txt
@@ -7,4 +7,4 @@ tox==3.24.5
 coverage==6.3.2
 setuptools==60.10.0
 pylint==2.12.2
-black==22.1.0
+black==22.3.0

--- a/resotolib/requirements-test.txt
+++ b/resotolib/requirements-test.txt
@@ -5,7 +5,7 @@ tox==3.24.5
 coverage==6.3.2
 setuptools==60.10.0
 pylint==2.12.2
-black==22.1.0
+black==22.3.0
 pytest==7.1.1
 pytest-cov==3.0.0
 pytest-runner==6.0.0


### PR DESCRIPTION
# Description

Fix CI by updating black from 22.1.0 to 22.3.0
https://github.com/psf/black/issues/2964

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
