### PR TITLE
[resotoworker][fix] log turned off cleanup as debug not error

### DIFF
--- a/resotoworker/resotoworker/cleanup.py
+++ b/resotoworker/resotoworker/cleanup.py
@@ -42,7 +42,7 @@ class Cleaner:
     @metrics_cleanup.time()
     def cleanup(self) -> None:
         if not Config.resotoworker.cleanup:
-            log.error(
+            log.debug(
                 (
                     "Cleanup called but --cleanup flag not provided at startup"
                     " - ignoring call"


### PR DESCRIPTION
# Description

Log the notification "not running cleanup because cleanup is not turned on" as debug instead of error


# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
