### PR TITLE
[resotocore][fix] Escape aql keywords in property names

### DIFF
--- a/resotocore/tests/resotocore/db/arango_query_test.py
+++ b/resotocore/tests/resotocore/db/arango_query_test.py
@@ -86,3 +86,10 @@ def test_ancestors_kind_lookup(foo_model: Model, graph_db: GraphDB) -> None:
     # 1234 is coerced to a string
     query = "ancestors.account.reported.name==1234"
     assert to_query(graph_db, QueryModel(parse_query(query), foo_model))[1] == {"b0": "1234"}
+
+
+def test_escape_property_path(foo_model: Model, graph_db: GraphDB) -> None:
+    raw = "metadata.replace.with.filter.sort.bla==true"
+    query = to_query(graph_db, QueryModel(parse_query(raw), foo_model))[0]
+    # aql keywords are escaped with backslashes
+    assert "m0.metadata.`replace`.`with`.`filter`.`sort`.bla" in query


### PR DESCRIPTION
# Description

A search like `/metdata.replace==true` failed, since `replace` is an aql keyword.
Suck keywords need to be escaped with backslashes.

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`

