### PR TITLE
[resotoworker/resotometrics][feat] Wait for the core to be online

### DIFF
--- a/resotolib/resotolib/core/__init__.py
+++ b/resotolib/resotolib/core/__init__.py
@@ -1,3 +1,7 @@
+import time
+import requests
+import warnings
+from resotolib.logging import log
 from resotolib.args import ArgumentParser
 from urllib.parse import urlparse, ParseResult
 
@@ -9,6 +13,29 @@ def add_args(arg_parser: ArgumentParser) -> None:
         default="https://localhost:8900",
         dest="resotocore_uri",
     )
+
+
+def wait_for_resotocore(resotocore_uri: str, timeout: int = 300) -> None:
+    ready_uri = f"{resotocore_uri}/system/ready"
+    start_time = time.time()
+    core_up = False
+    wait_time = -1
+    while wait_time < timeout:
+        wait_time = time.time() - start_time
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                log.debug(f"Waiting for resotocore to come online at {resotocore_uri}")
+                response = requests.get(ready_uri, timeout=5, verify=False)
+                if response.status_code == 200:
+                    log.debug("resotocore is ready")
+                    core_up = True
+                    break
+        except Exception:
+            pass
+        time.sleep(5)
+    if not core_up:
+        raise TimeoutError(f"resotocore not ready after {timeout} seconds")
 
 
 class ResotocoreURI:

--- a/resotometrics/resotometrics/__main__.py
+++ b/resotometrics/resotometrics/__main__.py
@@ -5,7 +5,11 @@ import resotolib.signal
 from resotolib.logging import log, setup_logger, add_args as logging_add_args
 from resotolib.jwt import add_args as jwt_add_args
 from resotolib.config import Config
-from resotolib.core import add_args as resotocore_add_args, resotocore
+from resotolib.core import (
+    add_args as resotocore_add_args,
+    resotocore,
+    wait_for_resotocore,
+)
 from resotolib.core.ca import TLSData
 from .config import ResotoMetricsConfig
 from functools import partial
@@ -56,6 +60,8 @@ def main() -> None:
     jwt_add_args(arg_parser)
     TLSData.add_args(arg_parser)
     arg_parser.parse_args()
+
+    wait_for_resotocore(resotocore.http_uri)
 
     tls_data = None
     if resotocore.is_secure:

--- a/resotoworker/resotoworker/__main__.py
+++ b/resotoworker/resotoworker/__main__.py
@@ -13,7 +13,7 @@ from resotolib.web import WebServer
 from resotolib.web.metrics import WebApp
 from resotolib.utils import log_stats, increase_limits
 from resotolib.args import ArgumentParser
-from resotolib.core import add_args as core_add_args, resotocore
+from resotolib.core import add_args as core_add_args, resotocore, wait_for_resotocore
 from resotolib.core.ca import TLSData
 from resotolib.core.actions import CoreActions
 from resotolib.core.tasks import CoreTasks
@@ -62,6 +62,8 @@ def main() -> None:
     # At this point the CLI, all Plugins as well as the WebServer have
     # added their args to the arg parser
     arg_parser.parse_args()
+
+    wait_for_resotocore(resotocore.http_uri)
 
     tls_data = None
     if resotocore.is_secure:


### PR DESCRIPTION
# Description

Adds a wait function at resotoworker/resotometrics startup to wait for resotocore to be online. This way esp. in a Docker environment the user isn't greeted with hundreds of exceptions while the core is starting up.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
