### PR TITLE
[resotocore][fix] Allow simple and list values as override parameters

### DIFF
--- a/resotocore/resotocore/__main__.py
+++ b/resotocore/resotocore/__main__.py
@@ -95,7 +95,8 @@ def run_process(args: Namespace) -> None:
 
 def with_config(created: bool, system_data: SystemData, sdb: StandardDatabase, config: CoreConfig) -> None:
     reconfigure_logging(config)  # based on the config, logging might have changed
-    log.debug(f"Starting with config: {config}")
+    # only lg the editable config - to not log any passwords
+    log.debug(f"Starting with config: {config.editable}")
     info = system_info()
     event_sender = NoEventSender() if config.runtime.analytics_opt_out else PostHogEventSender(system_data)
     db = db_access(config, sdb, event_sender)

--- a/resotocore/resotocore/cli/command.py
+++ b/resotocore/resotocore/cli/command.py
@@ -65,7 +65,6 @@ from resotocore.cli.model import (
 )
 from resotocore.config import ConfigEntity
 from resotocore.db.model import QueryModel
-from resotocore.dependencies import path_values_parser
 from resotocore.dependencies import system_info
 from resotocore.error import CLIParseError, ClientError, CLIExecutionError
 from resotocore.model.graph_access import Section, EdgeType
@@ -79,6 +78,9 @@ from resotocore.parse_util import (
     variable_dp,
     literal_dp,
     comma_p,
+    variable_p,
+    equals_p,
+    json_value_p,
 )
 from resotocore.query.model import Query, P, Template, NavigateUntilRoot, IsTerm
 from resotocore.query.query_parser import parse_query
@@ -3373,6 +3375,17 @@ class WorkflowsCommand(CLICommand):
             return CLISource(list_workflows)
         else:
             return CLISource.single(lambda: stream.just(self.rendered_help(ctx)))
+
+
+@make_parser
+def path_value_parser() -> Parser:
+    key = yield variable_p
+    yield equals_p
+    value = yield json_value_p
+    return key, value
+
+
+path_values_parser = path_value_parser.sep_by(comma_p)
 
 
 class ConfigsCommand(CLICommand):

--- a/resotocore/resotocore/dependencies.py
+++ b/resotocore/resotocore/dependencies.py
@@ -196,7 +196,7 @@ def parse_args(args: Optional[List[str]] = None, namespace: Optional[str] = None
         help="Override configuration parameters. Format: path.to.property=value. "
         "The existing configuration will be patched with the provided values. "
         "A value can be a simple value or a comma separated list of values if a list is required. "
-        "Note: this argument allows multiple overrides separated by comma. "
+        "Note: this argument allows multiple overrides separated by space. "
         "Example: --override resotocore.api.web_hosts=localhost,some.domain resotocore.api.web_port=12345",
     )
     parser.add_argument(

--- a/resotocore/resotocore/parse_util.py
+++ b/resotocore/resotocore/parse_util.py
@@ -196,15 +196,8 @@ def json_object_pair() -> Parser:
 
 
 json_object_p = l_curly_dp >> json_object_pair.sep_by(comma_dp).map(dict) << r_curly_dp
-json_value_dp = (
-    double_quoted_string_dp
-    | json_array_parser
-    | json_object_p
-    | true_dp
-    | false_dp
-    | null_dp
-    | unquoted_string_dp
-    | float_dp
-    | integer_dp
+simple_json_value_dp = (
+    double_quoted_string_dp | true_dp | false_dp | null_dp | unquoted_string_dp | float_dp | integer_dp
 )
+json_value_dp = json_array_parser | json_object_p | simple_json_value_dp
 json_value_p = lexeme(json_value_dp)

--- a/resotocore/tests/resotocore/dependencies_test.py
+++ b/resotocore/tests/resotocore/dependencies_test.py
@@ -1,0 +1,15 @@
+from typing import Tuple, List
+
+from resotocore.dependencies import parse_args
+from resotocore.types import JsonElement
+
+
+def test_parse_override() -> None:
+    def parse(args: str) -> List[Tuple[str, JsonElement]]:
+        return parse_args(args.split()).config_override  # type: ignore
+
+    assert parse(f"--override a=foo") == [("a", "foo")]
+    assert parse(f"--override a=foo,bla") == [("a", ["foo", "bla"])]
+    assert parse(f"--override a=foo,bla b=a,b,c") == [("a", ["foo", "bla"]), ("b", ["a", "b", "c"])]
+    assert parse(f'--override a="value,with,comma,in,quotes"') == [("a", "value,with,comma,in,quotes")]
+    assert parse(f'--override a=some,value,"with,comma"') == [("a", ["some", "value", "with,comma"])]


### PR DESCRIPTION
# Description

Allows defining simple and list override parameters.
Example:
```
resotocore --override resotocore.api.web_hosts=localhost,case resotocore.api.web_port=12345
```
Would bind to localhost and case with port 12345

