### PR TITLE
[resotocore][fix] Allow secure access to arangodb

### DIFF
--- a/resotocore/resotocore/core_config.py
+++ b/resotocore/resotocore/core_config.py
@@ -6,7 +6,7 @@ from contextlib import suppress
 from dataclasses import dataclass, field
 from datetime import timedelta
 from pathlib import Path
-from typing import Optional, List, ClassVar
+from typing import Optional, List, ClassVar, Union
 
 from arango.database import StandardDatabase
 from cerberus import schema_registry
@@ -288,6 +288,12 @@ schema_registry.add(
 
 
 @dataclass()
+class RunConfig(ConfigObject):
+    temp_dir: Path = Path("/tmp")  # set to random temp directory during start of process
+    verify: Union[bool, str, None] = None
+
+
+@dataclass()
 class CoreConfig(ConfigObject):
     api: ApiConfig
     cli: CLIConfig
@@ -296,6 +302,7 @@ class CoreConfig(ConfigObject):
     db: DatabaseConfig
     custom_commands: CustomCommandsConfig
     args: Namespace
+    run: RunConfig
 
     @property
     def editable(self) -> "EditableConfig":
@@ -403,6 +410,7 @@ def parse_config(args: Namespace, core_config: Json, command_templates: Optional
         runtime=ed.runtime,
         custom_commands=commands_config,
         args=args,
+        run=RunConfig(),  # overridden for each run
     )
 
 

--- a/resotocore/resotocore/model/db_updater.py
+++ b/resotocore/resotocore/model/db_updater.py
@@ -145,7 +145,7 @@ class DbUpdaterProcess(Process):
 
     async def setup_and_merge(self) -> GraphUpdate:
         sender = InMemoryEventSender()
-        _, _, sdb = DbAccess.connect(self.config.args, timedelta(seconds=3))
+        _, _, sdb = DbAccess.connect(self.config.args, timedelta(seconds=3), verify=self.config.run.verify)
         db = db_access(self.config, sdb, sender)
         result = await self.merge_graph(db)
         for event in sender.events:

--- a/resotocore/resotocore/web/certificate_handler.py
+++ b/resotocore/resotocore/web/certificate_handler.py
@@ -25,6 +25,7 @@ from resotolib.x509 import (
     write_cert_to_file,
     load_key_from_file,
     load_cert_from_file,
+    write_ca_bundle,
 )
 
 from resotocore.core_config import CoreConfig, CertificateConfig
@@ -33,7 +34,7 @@ log = logging.getLogger(__name__)
 
 
 class CertificateHandler:
-    def __init__(self, config: CoreConfig, ca_key: RSAPrivateKey, ca_cert: Certificate) -> None:
+    def __init__(self, config: CoreConfig, ca_key: RSAPrivateKey, ca_cert: Certificate, temp_dir: Path) -> None:
         self.config = config
         self._ca_key = ca_key
         self._ca_cert = ca_cert
@@ -42,6 +43,16 @@ class CertificateHandler:
         self._host_key, self._host_cert = self.__create_host_certificate(config.api.host_certificate, ca_key, ca_cert)
         self._host_context = self.__create_host_context(config, self._host_cert, self._host_key)
         self._client_context = self.__create_client_context(config, ca_cert)
+        self._ca_bundle = temp_dir / "ca-bundle.crt"
+        write_ca_bundle(self._ca_cert, str(self._ca_bundle), rename=False)
+
+    @property
+    def ca_cert(self) -> Certificate:
+        return self._ca_cert
+
+    @property
+    def ca_bundle(self) -> Path:
+        return self._ca_bundle
 
     @property
     def authority_certificate(self) -> Tuple[bytes, str]:
@@ -64,7 +75,7 @@ class CertificateHandler:
             discover_local_dns_names=False,
             discover_local_ip_addresses=False,
         )
-        cert = sign_csr(csr, key, self._ca_cert, days_valid)
+        cert = sign_csr(csr, self._ca_key, self._ca_cert, days_valid)
         return key, cert
 
     def sign(self, csr_bytes: bytes) -> Tuple[bytes, str]:
@@ -140,13 +151,14 @@ class CertificateHandler:
         return ctx
 
     @staticmethod
-    def lookup(config: CoreConfig, db: StandardDatabase) -> CertificateHandler:
+    def lookup(config: CoreConfig, db: StandardDatabase, temp_dir: Path) -> CertificateHandler:
         args = config.args
         # if we get a ca certificate from the command line, use it
         if args.ca_cert and args.ca_cert_key:
             ca_key = load_key_from_file(args.ca_cert_key, args.ca_cert_key_pass)
             ca_cert = load_cert_from_file(args.ca_cert_cert)
-            return CertificateHandler(config, ca_key, ca_cert)
+            log.info(f"Using CA certificate from command line: {cert_fingerprint(ca_cert)}")
+            return CertificateHandler(config, ca_key, ca_cert, temp_dir)
 
         # otherwise, load from database or create it
         sd = db.collection("system_data")
@@ -155,12 +167,13 @@ class CertificateHandler:
             log.debug("Found existing certificate in data store.")
             key = load_key_from_bytes(maybe_ca["key"].encode("utf-8"))
             certificate = load_cert_from_bytes(maybe_ca["certificate"].encode("utf-8"))
-            return CertificateHandler(config, key, certificate)
+            log.info(f"Using CA certificate from database: {cert_fingerprint(certificate)}")
+            return CertificateHandler(config, key, certificate, temp_dir)
         else:
             wo = "with" if args.ca_cert_key_pass else "without"
-            log.info(f"No ca certificate found - create a new one {wo} passphrase.")
             key, certificate = bootstrap_ca()
+            log.info(f"No ca certificate found - create a new one {wo} passphrase: {cert_fingerprint(certificate)}")
             key_string = key_to_bytes(key, args.ca_cert_key_pass).decode("utf-8")
             certificate_string = cert_to_bytes(certificate).decode("utf-8")
             sd.insert({"_key": "ca", "key": key_string, "certificate": certificate_string})
-            return CertificateHandler(config, key, certificate)
+            return CertificateHandler(config, key, certificate, temp_dir)

--- a/resotocore/resotocore/web/certificate_handler.py
+++ b/resotocore/resotocore/web/certificate_handler.py
@@ -157,7 +157,7 @@ class CertificateHandler:
         if args.ca_cert and args.ca_cert_key:
             ca_key = load_key_from_file(args.ca_cert_key, args.ca_cert_key_pass)
             ca_cert = load_cert_from_file(args.ca_cert_cert)
-            log.info(f"Using CA certificate from command line: {cert_fingerprint(ca_cert)}")
+            log.info(f"Using CA certificate from command line. fingerprint:{cert_fingerprint(ca_cert)}")
             return CertificateHandler(config, ca_key, ca_cert, temp_dir)
 
         # otherwise, load from database or create it
@@ -167,12 +167,14 @@ class CertificateHandler:
             log.debug("Found existing certificate in data store.")
             key = load_key_from_bytes(maybe_ca["key"].encode("utf-8"))
             certificate = load_cert_from_bytes(maybe_ca["certificate"].encode("utf-8"))
-            log.info(f"Using CA certificate from database: {cert_fingerprint(certificate)}")
+            log.info(f"Using CA certificate from database. fingerprint:{cert_fingerprint(certificate)}")
             return CertificateHandler(config, key, certificate, temp_dir)
         else:
             wo = "with" if args.ca_cert_key_pass else "without"
             key, certificate = bootstrap_ca()
-            log.info(f"No ca certificate found - create a new one {wo} passphrase: {cert_fingerprint(certificate)}")
+            log.info(
+                f"No ca certificate found - create new one {wo} passphrase. fingerprint:{cert_fingerprint(certificate)}"
+            )
             key_string = key_to_bytes(key, args.ca_cert_key_pass).decode("utf-8")
             certificate_string = cert_to_bytes(certificate).decode("utf-8")
             sd.insert({"_key": "ca", "key": key_string, "certificate": certificate_string})

--- a/resotocore/tests/resotocore/core_config_test.py
+++ b/resotocore/tests/resotocore/core_config_test.py
@@ -16,6 +16,7 @@ from resotocore.core_config import (
     config_model,
     EditableConfig,
     CustomCommandsConfig,
+    RunConfig,
 )
 from resotocore.dependencies import parse_args
 from resotocore.model.typed_model import to_js
@@ -169,4 +170,5 @@ def default_config() -> CoreConfig:
         runtime=RuntimeConfig(analytics_opt_out=True),
         custom_commands=CustomCommandsConfig(),
         args=parse_args(["--analytics-opt-out"]),
+        run=RunConfig(),
     )

--- a/resotocore/tests/resotocore/web/certificate_handler_test.py
+++ b/resotocore/tests/resotocore/web/certificate_handler_test.py
@@ -1,3 +1,7 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Iterator
+
 from arango.database import StandardDatabase
 from pytest import fixture
 from resotolib.x509 import bootstrap_ca, load_cert_from_bytes, cert_fingerprint, csr_to_bytes, gen_csr, gen_rsa_key
@@ -10,10 +14,12 @@ from tests.resotocore.db.graphdb_test import test_db, system_db, local_client
 
 
 @fixture
-def cert_handler() -> CertificateHandler:
+def cert_handler() -> Iterator[CertificateHandler]:
     config = empty_config()
     key, certificate = bootstrap_ca()
-    return CertificateHandler(config, key, certificate)
+    temp = TemporaryDirectory()
+    yield CertificateHandler(config, key, certificate, Path(temp.name))
+    temp.cleanup()
 
 
 def test_ca_certificate(cert_handler: CertificateHandler) -> None:
@@ -29,18 +35,20 @@ def test_sign(cert_handler: CertificateHandler) -> None:
 
 
 def test_bootstrap(test_db: StandardDatabase) -> None:
-    sd = test_db.collection("system_data")
-    config = empty_config()
-    # Delete any existing entry, so a new certificate needs to be created
-    sd.delete("ca", ignore_missing=True)
-    handler = CertificateHandler.lookup(config, test_db)
-    ca = sd.get("ca")
-    assert ca is not None
-    # ensure the certificate in the database is the same as exposed by the handler
-    ca_bytes, fingerprint = handler.authority_certificate
-    assert ca_bytes == ca["certificate"].encode("utf-8")
-    # a new handler will use the existing certificate
-    handler2 = CertificateHandler.lookup(config, test_db)
-    assert handler.authority_certificate == handler2.authority_certificate
-    # but the host certificate will be different
-    assert handler.host_certificate != handler2.host_certificate
+    with TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        sd = test_db.collection("system_data")
+        config = empty_config()
+        # Delete any existing entry, so a new certificate needs to be created
+        sd.delete("ca", ignore_missing=True)
+        handler = CertificateHandler.lookup(config, test_db, tmp)
+        ca = sd.get("ca")
+        assert ca is not None
+        # ensure the certificate in the database is the same as exposed by the handler
+        ca_bytes, fingerprint = handler.authority_certificate
+        assert ca_bytes == ca["certificate"].encode("utf-8")
+        # a new handler will use the existing certificate
+        handler2 = CertificateHandler.lookup(config, test_db, tmp)
+        assert handler.authority_certificate == handler2.authority_certificate
+        # but the host certificate will be different
+        assert handler.host_certificate != handler2.host_certificate


### PR DESCRIPTION
# Description

Make the ca bundle available to the request context of arangodb client. 
This allows creating/securing the access to arangodb.
Since the certificate is stored inside the database - an untrusted call is required first.

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
