### PR TITLE
[ci][chore] remove individual Docker images from generated release notes

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -420,12 +420,6 @@ jobs:
 
             ### Docker Images
 
-            #### All-in-One
-
-            - `somecr.io/someengineering/resoto:${{ steps.release_notes.outputs.tag }}`
-
-            #### Components
-
             - `somecr.io/someengineering/resotocore:${{ steps.release_notes.outputs.tag }}`
             - `somecr.io/someengineering/resotoworker:${{ steps.release_notes.outputs.tag }}`
             - `somecr.io/someengineering/resotoshell:${{ steps.release_notes.outputs.tag }}`

--- a/tools/release_notes.py
+++ b/tools/release_notes.py
@@ -86,10 +86,7 @@ def show_log(from_tag: str, to_tag: str):
             )
 
     print("\n<!--truncate-->")
-    print("\n## Docker Images")
-    print("\n### All-in-One\n")
-    print(f"- `somecr.io/someengineering/resoto:{to_tag}`")
-    print("\n### Components\n")
+    print("\n## Docker Images\n")
     for image in ["resotocore", "resotoworker", "resotoshell", "resotometrics"]:
         print(f"- `somecr.io/someengineering/{image}:{to_tag}`")
 


### PR DESCRIPTION
# Description

Remove all-in-one Docker image from release notes going forward.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
