### PR TITLE
[resotocore][fix] Not should affect only the next simple term

### DIFF
--- a/resotocore/resotocore/query/query_parser.py
+++ b/resotocore/resotocore/query/query_parser.py
@@ -123,7 +123,7 @@ def function_term() -> Parser:
 @make_parser
 def not_term() -> Parser:
     yield not_p
-    term = yield filter_term_parser
+    term = yield simple_term_p  # negation should affect only the next simple term
     return NotTerm(term)
 
 

--- a/resotocore/tests/resotocore/query/query_parser_test.py
+++ b/resotocore/tests/resotocore/query/query_parser_test.py
@@ -29,6 +29,7 @@ from resotocore.query.model import (
     CombinedTerm,
     Predicate,
     Limit,
+    NotTerm,
 )
 from resotocore.model.graph_access import EdgeType, Direction
 from parsy import Parser, ParseError
@@ -113,6 +114,8 @@ def test_not() -> None:
     assert_round_trip(not_term, (P.with_id("foo") | P.of_kind("bla")).not_term())
     assert_round_trip(not_term, P.of_kind("bla").not_term())
     assert_round_trip(not_term, term_parser.parse("not(is(a) or not is(b) and not a>1 or not b<2 or not(a>1))"))
+    # make sure not only negates the simple term, not the combined term
+    assert term_parser.parse("not a==b and b==c") == CombinedTerm(NotTerm(P("a") == "b"), "and", P("b") == "c")
 
 
 def test_filter_term() -> None:


### PR DESCRIPTION
# Description

Reduce the effect of `not` to the next simple term expression.


Example with 2 terms `<a>` and `<b>`:
```
search not <a> and <b>
```

Before:
interpreted as `not( <a> and <b> )`

After:
interpreted as `(not <a>) and <b>`


<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`
