### PR TITLE
[resotocore][fix] write ca bundle periodically to tmp

### DIFF
--- a/resotocore/resotocore/__main__.py
+++ b/resotocore/resotocore/__main__.py
@@ -181,6 +181,7 @@ def with_config(
         await cli.start()
         await task_handler.start()
         await core_config_handler.start()
+        await cert_handler.start()
         await api.start()
         if created:
             await event_sender.core_event(CoreEvent.SystemInstalled)
@@ -201,6 +202,7 @@ def with_config(
     async def on_stop() -> None:
         duration = utc() - info.started_at
         await api.stop()
+        await cert_handler.stop()
         await core_config_handler.stop()
         await task_handler.stop()
         await cli.stop()


### PR DESCRIPTION
# Description

On some OS the tmp folder is cleaned for files that are not touched.
This PR will rewrite the ca cert bundle periodically that is used for requests done by the requests library.
<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
