### PR TITLE
[resotoshell][fix] Compare config checksum instead of ctime/mtime

### DIFF
--- a/resotolib/resotolib/utils.py
+++ b/resotolib/resotolib/utils.py
@@ -1,5 +1,6 @@
 import string
 import threading
+import hashlib
 import socket
 import re
 import os
@@ -462,6 +463,20 @@ def iec_size_format(byte_size: int) -> str:
             return f"{byte_size:.2f} {unit}"
         byte_size /= 1024.0
     return f"{byte_size:.2f} YiB"
+
+
+# via https://stackoverflow.com/a/44873382
+def sha256sum(filename: str, buffer_size: int = 128 * 1024) -> str:
+    h = hashlib.sha256()
+    buffer = bytearray(buffer_size)
+    buffer_view = memoryview(buffer)
+    with open(filename, "rb", buffering=0) as f:
+        while True:
+            n = f.readinto(buffer_view)
+            if not n:
+                break
+            h.update(buffer_view[:n])
+    return h.hexdigest()
 
 
 def json_default(o):

--- a/resotolib/test/test_utils.py
+++ b/resotolib/test/test_utils.py
@@ -2,7 +2,8 @@ import unittest
 import threading
 import time
 import copy
-from resotolib.utils import RWLock, ordinal
+from tempfile import TemporaryDirectory
+from resotolib.utils import RWLock, ordinal, sha256sum
 from resotolib.baseresources import BaseResource
 from dataclasses import dataclass
 from typing import ClassVar
@@ -217,3 +218,15 @@ def test_ordinal():
     assert ordinal(21) == "21st"
     assert ordinal(22) == "22nd"
     assert ordinal(23) == "23rd"
+
+
+def test_sha256sum():
+    test_string = b"Hello World!"
+    expected_sha256sum = (
+        "7f83b1657ff1fc53b92dc18148a1d65dfc2d4b1fa3d677284addd200126d9069"
+    )
+    with TemporaryDirectory() as tmp:
+        tmp_file = f"{tmp}/testfile"
+        with open(tmp_file, "wb") as f:
+            f.write(test_string)
+        assert sha256sum(tmp_file) == expected_sha256sum


### PR DESCRIPTION
# Description

Compare actual changes for tmpfs filesystems where ctime==mtime.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
