### PR TITLE
[plugins][fix] Fix aws excluded accounts default and update gcp severity

### DIFF
--- a/plugins/aws/resoto_plugin_aws/__init__.py
+++ b/plugins/aws/resoto_plugin_aws/__init__.py
@@ -108,7 +108,9 @@ class AWSCollectorPlugin(BaseCollectorPlugin):
     @property
     def regions(self) -> List:
         if len(self.__regions) == 0:
-            if not Config.aws.region:
+            if not Config.aws.region or (
+                isinstance(Config.aws.region, list) and len(Config.aws.region) == 0
+            ):
                 log.debug("AWS region not specified, assuming all regions")
                 self.__regions = all_regions()
             else:

--- a/plugins/aws/resoto_plugin_aws/config.py
+++ b/plugins/aws/resoto_plugin_aws/config.py
@@ -44,8 +44,8 @@ class AwsConfig:
         default=True,
         metadata={"description": "Fork collector process instead of using threads"},
     )
-    scrape_exclude_account: Optional[List[str]] = field(
-        default=None,
+    scrape_exclude_account: List[str] = field(
+        default_factory=list,
         metadata={"description": "List of accounts to exclude when scraping the org"},
     )
     assume_current: bool = field(

--- a/plugins/aws/test/test_config.py
+++ b/plugins/aws/test/test_config.py
@@ -15,7 +15,7 @@ def test_args():
     assert Config.aws.region is None
     assert Config.aws.scrape_org is False
     assert Config.aws.fork_process is True
-    assert Config.aws.scrape_exclude_account is None
+    assert Config.aws.scrape_exclude_account == []
     assert Config.aws.assume_current is False
     assert Config.aws.do_not_scrape_current is False
     assert Config.aws.account_pool_size == num_default_threads()

--- a/plugins/gcp/resoto_plugin_gcp/collector.py
+++ b/plugins/gcp/resoto_plugin_gcp/collector.py
@@ -846,7 +846,7 @@ class GCPProjectCollector:
                 resource.region(graph).name == "undefined"
                 and resource.zone(graph).name == "undefined"
             ):
-                log.error(
+                log.debug(
                     f"Resource {resource.rtdname} has no region or zone"
                     " - removing from graph"
                 )
@@ -1052,7 +1052,7 @@ class GCPProjectCollector:
             resource.region(graph).name == "undefined"
             and resource.zone(graph).name == "undefined"
         ):
-            log.error(
+            log.debug(
                 f"Resource {resource.rtdname} has no region or zone"
                 " - removing from graph"
             )


### PR DESCRIPTION
# Description

Fix AWS `scrape_exclude_account` default and update GCP severity for machine and instance types with no region removal.


# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
