### PR TITLE
[resotoshell][fix] Add debug output containing the http error code on resh error

### DIFF
--- a/resotoshell/resotoshell/shell.py
+++ b/resotoshell/resotoshell/shell.py
@@ -108,6 +108,7 @@ class Shell:
                         )
                         handle_response(mp, True)
                     else:
+                        log.debug(f"HTTP error, code: {response.status_code}")
                         print(response.text, file=sys.stderr)
                         return
 


### PR DESCRIPTION
# Description

Add debug output containing the http error code on resh error.
This is in aiding debugging of an error where currently the core returns a 400 but the shell does not receive any content containing an error message.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
