### PR TITLE
[resoto][feat] Use json as logging output format

### DIFF
--- a/resotocore/resotocore/dependencies.py
+++ b/resotocore/resotocore/dependencies.py
@@ -12,6 +12,7 @@ from arango.database import StandardDatabase
 from parsy import Parser
 from resotolib.args import ArgumentParser
 from resotolib.jwt import add_args as jwt_add_args
+from resotolib.logging import setup_logger
 from resotolib.utils import iec_size_format
 
 from resotocore import async_extensions, version
@@ -26,8 +27,7 @@ from resotocore.util import utc
 log = logging.getLogger(__name__)
 
 SystemInfo = namedtuple(
-    "SystemInfo",
-    ["version", "git_hash", "cpus", "mem_available", "mem_total", "inside_docker", "started_at"],
+    "SystemInfo", ["version", "git_hash", "cpus", "mem_available", "mem_total", "inside_docker", "started_at"]
 )
 started_at = utc()
 
@@ -141,7 +141,12 @@ def parse_args(args: Optional[List[str]] = None, namespace: Optional[str] = None
         dest="graphdb_request_timeout",
         help="Request timeout in seconds (default: 900)",
     )
-    parser.add_argument("--no-tls", default=False, action="store_true", help="Disable TLS and use plain HTTP.")
+    parser.add_argument(
+        "--no-tls",
+        default=False,
+        action="store_true",
+        help="Disable TLS and use plain HTTP.",
+    )
     parser.add_argument(
         "--cert",
         type=is_file("can not parse --cert"),
@@ -254,14 +259,9 @@ def reconfigure_logging(config: CoreConfig) -> None:
 def configure_logging(log_level: str, verbose: bool) -> None:
     # Note: if another appender than the log appender is used, proper multiprocess logging needs to be enabled.
     # See https://docs.python.org/3/howto/logging-cookbook.html#logging-to-a-single-file-from-multiple-processes
-    log_format = "%(asctime)s|resotocore|%(levelname)5s|%(process)d|%(threadName)10s  %(message)s"
     level = log_level.upper()
-    logging.basicConfig(
-        format=log_format,
-        datefmt="%y-%m-%d %H:%M:%S",
-        level=logging.getLevelName(level),
-        force=True,
-    )
+    setup_logger("resotocore", level=level, verbose=verbose, force=True)
+
     # adjust log levels for specific loggers
     if verbose:
         logging.getLogger("resotocore").setLevel(logging.DEBUG)

--- a/resotolib/resotolib/logging.py
+++ b/resotolib/resotolib/logging.py
@@ -1,5 +1,6 @@
+import json
 from dataclasses import dataclass, field
-from typing import ClassVar, Optional
+from typing import ClassVar, Optional, Dict
 import sys
 import os
 from logging import (
@@ -10,7 +11,10 @@ from logging import (
     WARNING,
     ERROR,
     CRITICAL,
+    StreamHandler,
+    Formatter,
 )
+
 from resotolib.args import ArgumentParser
 
 
@@ -52,19 +56,89 @@ class LoggingConfig:
     )
 
 
-def setup_logger(proc: str, force: bool = True) -> None:
-    log_format = (
-        f"%(asctime)s|{proc}|%(levelname)5s|%(process)d|%(threadName)10s  %(message)s"
+class JsonFormatter(Formatter):
+    """
+    Simple json log formatter.
+    Inspired by: https://stackoverflow.com/questions/50144628/python-logging-into-file-as-a-dictionary-or-json
+    """
+
+    def __init__(
+        self,
+        fmt_dict: dict,
+        time_format: str = "%Y-%m-%dT%H:%M:%S",
+        static_values: Optional[Dict[str, str]] = None,
+    ):
+        super().__init__()
+        self.fmt_dict = fmt_dict
+        self.time_format = time_format
+        self.static_values = static_values or {}
+        self.__use_time = "asctime" in self.fmt_dict.values()
+
+    def usesTime(self) -> bool:  # noqa: N802
+        return self.__use_time
+
+    def formatMessage(self, record) -> dict:  # noqa: N802
+        return {
+            fmt_key: record.__dict__[fmt_val]
+            for fmt_key, fmt_val in self.fmt_dict.items()
+        }
+
+    def format(self, record) -> str:
+        record.message = record.getMessage()
+
+        if self.__use_time:
+            record.asctime = self.formatTime(record, self.time_format)
+
+        message_dict = self.formatMessage(record)
+        message_dict.update(self.static_values)
+
+        if record.exc_info:
+            if not record.exc_text:
+                record.exc_text = self.formatException(record.exc_info)
+
+        if record.exc_text:
+            message_dict["exception"] = record.exc_text
+
+        if record.stack_info:
+            message_dict["stack_info"] = self.formatStack(record.stack_info)
+
+        return json.dumps(message_dict, default=str)
+
+
+def setup_logger(
+    proc: str,
+    *,
+    force: bool = True,
+    verbose: bool = False,
+    quiet: bool = False,
+    level: Optional[str] = None,
+) -> None:
+    handler = StreamHandler()
+    formatter = JsonFormatter(
+        {
+            "timestamp": "asctime",
+            "level": "levelname",
+            "message": "message",
+            "pid": "process",
+            "thread": "threadName",
+        },
+        static_values={"process": proc},
     )
-    basicConfig(format=log_format, datefmt="%y-%m-%d %H:%M:%S", force=force)
+    handler.setFormatter(formatter)
+    basicConfig(handlers=[handler], force=force, level=level)
     argv = sys.argv[1:]
     if (
-        "-v" in argv
+        verbose
+        or "-v" in argv
         or "--verbose" in argv
         or os.environ.get("RESOTO_VERBOSE", "false").lower() == "true"
     ):
         getLogger("resoto").setLevel(DEBUG)
-    elif "--quiet" in argv or os.environ.get("RESOTO_QUIET", "false").lower() == "true":
+    elif (
+        quiet
+        or "--quiet" in argv
+        or os.environ.get("RESOTO_QUIET", "false").lower() == "true"
+    ):
         getLogger().setLevel(WARNING)
         getLogger("resoto").setLevel(CRITICAL)
 

--- a/resotolib/test/test_logging.py
+++ b/resotolib/test/test_logging.py
@@ -1,6 +1,14 @@
 import logging
-from resotolib.logging import log
+from resotolib.logging import log, JsonFormatter
 
 
 def test_logging():
     assert type(log) is logging.Logger
+
+
+def test_json_logging() -> None:
+    format = JsonFormatter({"level": "levelname", "message": "message"})
+    record = logging.getLogger().makeRecord(
+        "test", logging.INFO, "test", 1, "test message", (), None
+    )
+    assert format.format(record) == '{"level": "INFO", "message": "test message"}'


### PR DESCRIPTION
# Description

Use json as log output, while keeping all the information we had before.
```json
{"timestamp": "2022-04-27T14:26:39", "level": "INFO", "message": "Remove listener: resotocore.config.update", "pid": 49075, "thread": "MainThread", "process": "resotocore"}
{"timestamp": "2022-04-27T14:26:39", "level": "INFO", "message": "Remove worker: resotocore.config.validate", "pid": 49075, "thread": "MainThread", "process": "resotocore"}
{"timestamp": "2022-04-27T14:26:39", "level": "INFO", "message": "Remove listener: resotocore.task_handler", "pid": 49075, "thread": "MainThread", "process": "resotocore"}
{"timestamp": "2022-04-27T14:26:39", "level": "INFO", "message": "task has been cancelled", "pid": 49075, "thread": "MainThread", "process": "resotocore"}
{"timestamp": "2022-04-27T14:26:39", "level": "INFO", "message": "Analytics has been turned off. No insights can be created.", "pid": 49075, "thread": "MainThread", "process": "resotocore"}
{"timestamp": "2022-04-27T14:26:39", "level": "INFO", "message": "Clean up all running tasks.", "pid": 49075, "thread": "MainThread", "process": "resotocore"}
```
# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
