### PR TITLE
[resotolib][fix] close fds more targeted during restart

### DIFF
--- a/resotolib/resotolib/config.py
+++ b/resotolib/resotolib/config.py
@@ -162,7 +162,7 @@ class Config(metaclass=MetaConfig):
                         )
                         new_value = getattr(config_data, field.name, None)
                         if new_value != old_value:
-                            log.debug(
+                            log.info(
                                 f"Changed config {config_id}.{field.name} requires restart"
                             )
                             return True

--- a/resotolib/resotolib/signal.py
+++ b/resotolib/resotolib/signal.py
@@ -44,31 +44,36 @@ def delayed_exit(delay: int = 3) -> None:
 
 
 def close_fds() -> None:
-    try:
-        open_max = os.sysconf("SC_OPEN_MAX")
-    except AttributeError:
-        open_max = 1024
-
+    open_max = 0
     if sys.platform == "linux":
-        proc = "/proc"
-        pid = str(os.getpid())
         try:
-            for entry in os.listdir(os.path.join(proc, pid, "fd")):
-                entry_path = os.path.join(proc, pid, "fd", entry)
-                if os.path.islink(entry_path) and entry.isnumeric():
-                    fd = int(entry)
-                    if fd >= 3:
-                        try:
-                            fd_cloexec(fd)
-                        except Exception:
-                            log.error(f"Failed to FD_CLOEXEC {fd}")
-        except (PermissionError, FileNotFoundError):
-            pass
+            for fd in os.listdir(os.path.join("/proc", str(os.getpid()), "fd")):
+                if not fd.isnumeric():
+                    continue
+                fd = int(fd)
+                if fd > open_max:
+                    open_max = fd
+            # We have a race between reading /proc and setting
+            # FD_CLOEXEC so we're adding some safety margin in
+            # case some thread opened new fds in between.
+            open_max += 1024
+        except Exception:
+            open_max = 1024
     else:
-        if open_max > 65536:
-            log.warning(f"High SC_OPEN_MAX: {open_max}, restart will take longer")
-        for fd in range(3, open_max):
-            fd_cloexec(fd)
+        try:
+            # This can return really big numbers so it's better to have
+            # an OS specific implementation like the Linux one above.
+            open_max = os.sysconf("SC_OPEN_MAX")
+        except AttributeError:
+            open_max = 1024
+
+    if open_max > 65536:
+        # SC_OPEN_MAX can be 1 billion or more. In that case we log a warning
+        # but still try to close all possible file descriptors rather than leaking
+        # them. This can delay restarting by several minutes.
+        log.warning(f"High SC_OPEN_MAX: {open_max}, restart will take longer")
+    for fd in range(3, open_max):
+        fd_cloexec(fd)
 
 
 def fd_cloexec(fd: int) -> None:


### PR DESCRIPTION
# Description

Close FDs more targeted so restarts on systems with 1 billion allowed open fds don't take several minutes to complete.
Also increase severity for config change based restarts from debug to info so the user knows why a component was restarted based on a config change.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
