### PR TITLE
[plugins][fix] Remove _ from plugin package names

### DIFF
--- a/plugins/cleanup_aws_alarms/setup.py
+++ b/plugins/cleanup_aws_alarms/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 setup(
-    name="resoto-plugin-cleanup_aws_alarms",
+    name="resoto-plugin-cleanup-aws-alarms",
     version="2.2.0a0",
     description="AWS Cloudwatch Alarms Cleaner Plugin",
     license="Apache 2.0",

--- a/plugins/cleanup_aws_loadbalancers/setup.py
+++ b/plugins/cleanup_aws_loadbalancers/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 setup(
-    name="resoto-plugin-cleanup_aws_loadbalancers",
+    name="resoto-plugin-cleanup-aws-loadbalancers",
     version="2.2.0a0",
     description="AWS Loadbalancers Cleaner Plugin",
     license="Apache 2.0",

--- a/plugins/cleanup_aws_vpcs/setup.py
+++ b/plugins/cleanup_aws_vpcs/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 setup(
-    name="resoto-plugin-cleanup_aws_vpcs",
+    name="resoto-plugin-cleanup-aws-vpcs",
     version="2.2.0a0",
     description="AWS VPC Cleaner Plugin",
     license="Apache 2.0",

--- a/plugins/cleanup_expired/setup.py
+++ b/plugins/cleanup_expired/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 setup(
-    name="resoto-plugin-cleanup_expired",
+    name="resoto-plugin-cleanup-expired",
     version="2.2.0a0",
     description="Resoto Expired Resource Cleanup Plugin",
     license="Apache 2.0",

--- a/plugins/cleanup_untagged/setup.py
+++ b/plugins/cleanup_untagged/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 setup(
-    name="resoto-plugin-cleanup_untagged",
+    name="resoto-plugin-cleanup-untagged",
     version="2.2.0a0",
     description="Resoto Cleanup Untagged Plugin",
     license="Apache 2.0",

--- a/plugins/cleanup_volumes/setup.py
+++ b/plugins/cleanup_volumes/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 setup(
-    name="resoto-plugin-cleanup_volumes",
+    name="resoto-plugin-cleanup-volumes",
     version="2.2.0a0",
     description="Volume Cleaner Plugin",
     license="Apache 2.0",

--- a/plugins/example_collector/setup.py
+++ b/plugins/example_collector/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 
 setup(
-    name="resoto-plugin-example_collector",
+    name="resoto-plugin-example-collector",
     version="2.2.0a0",
     description="Resoto Example Collector Plugin",
     license="Apache 2.0",


### PR DESCRIPTION
# Description

Use of `_` in package name is discouraged. This replaces it with `-` in source which is what pip/pypi does automatically anyways.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
