### PR TITLE
[resotoshell][feat] select mode if stdin is not a tty

### DIFF
--- a/resotoshell/resotoshell/__main__.py
+++ b/resotoshell/resotoshell/__main__.py
@@ -40,7 +40,7 @@ def main() -> None:
         custom_ca_cert_path=args.ca_cert,
         verify=args.verify_certs,
     )
-    if args.stdin:
+    if args.stdin or not sys.stdin.isatty():
         handle_from_stdin(client)
     else:
         repl(client, args)


### PR DESCRIPTION
# Description

Detect if stdin is a tty and read from stdin if not.
This allows:
```sh
echo "search is(instance) limit 3" | resh
```
without providing extra options.

