### PR TITLE
[resotoshell][fix] handle wrong PSK

### DIFF
--- a/resotoshell/resotoshell/__main__.py
+++ b/resotoshell/resotoshell/__main__.py
@@ -40,9 +40,19 @@ def main() -> None:
         custom_ca_cert_path=args.ca_cert,
         verify=args.verify_certs,
     )
+
+    def check_system_info() -> None:
+        try:
+            list(client.cli_execute("system info"))
+        except Exception as e:
+            log.error(f"resotocore is not accessible: {e}")
+            raise e
+
     try:
         client.start()
+        check_system_info()
     except Exception:
+        client.shutdown()
         sys.exit(1)
     if args.stdin or not sys.stdin.isatty():
         handle_from_stdin(client)


### PR DESCRIPTION
# Description

<!-- Please describe the changes included in this PR here. -->
Resotoshell now quits when no PSK is supplied but core was started with a PSK

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`
- [x] Document new or updated functionality (someengineering/resoto.com#XXXX)


# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
