### PR TITLE
[resotolib][fix] Change severity of auto-recovering info and error messages

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,6 +30,7 @@ services:
       - 8900:8900
     environment:
       - PSK
+      - RESOTO_VERBOSE
       - RESOTOCORE_GRAPHDB_SERVER=http://graphdb:8529
       - RESOTOCORE_GRAPHDB_PASSWORD=changeme
     command:
@@ -50,6 +51,7 @@ services:
       - 9956:9956
     environment:
       - PSK
+      - RESOTO_VERBOSE
       - RESOTOWORKER_RESOTOCORE_URI=https://resotocore:8900
     restart: always
     stop_grace_period: 2m
@@ -61,6 +63,7 @@ services:
       - 9955:9955
     environment:
       - PSK
+      - RESOTO_VERBOSE
       - RESOTOMETRICS_RESOTOCORE_URI=https://resotocore:8900
     restart: always
     stop_grace_period: 2m

--- a/resotolib/resotolib/core/actions.py
+++ b/resotolib/resotolib/core/actions.py
@@ -138,8 +138,8 @@ class CoreActions(threading.Thread):
             except Exception:
                 log.exception(f"Something went wrong while processing {message}")
 
-    def on_error(self, ws, error):
-        log.debug(f"{self.identifier} message bus error: {error}")
+    def on_error(self, ws, e):
+        log.debug(f"{self.identifier} message bus error: {e!r}")
 
     def on_close(self, ws, close_status_code, close_msg):
         log.debug(f"{self.identifier} disconnected from resotocore message bus")

--- a/resotolib/resotolib/core/actions.py
+++ b/resotolib/resotolib/core/actions.py
@@ -42,7 +42,7 @@ class CoreActions(threading.Thread):
             try:
                 self.connect()
             except Exception as e:
-                log.debug(e)
+                log.error(e)
             time.sleep(1)
 
     def connect(self) -> None:

--- a/resotolib/resotolib/core/actions.py
+++ b/resotolib/resotolib/core/actions.py
@@ -38,12 +38,12 @@ class CoreActions(threading.Thread):
         self.name = self.identifier
         add_event_listener(EventType.SHUTDOWN, self.shutdown)
         while not self.shutdown_event.is_set():
-            log.info("Connecting to resotocore message bus")
+            log.debug("Connecting to resotocore message bus")
             try:
                 self.connect()
             except Exception as e:
-                log.error(e)
-            time.sleep(10)
+                log.debug(e)
+            time.sleep(1)
 
     def connect(self) -> None:
         for event, data in self.actions.items():
@@ -139,7 +139,7 @@ class CoreActions(threading.Thread):
                 log.exception(f"Something went wrong while processing {message}")
 
     def on_error(self, ws, error):
-        log.error(f"{self.identifier} message bus error: {error}")
+        log.debug(f"{self.identifier} message bus error: {error}")
 
     def on_close(self, ws, close_status_code, close_msg):
         log.debug(f"{self.identifier} disconnected from resotocore message bus")

--- a/resotolib/resotolib/core/events.py
+++ b/resotolib/resotolib/core/events.py
@@ -86,8 +86,8 @@ class CoreEvents(threading.Thread):
             except Exception:
                 log.exception(f"Something went wrong while processing {message}")
 
-    def on_error(self, ws, error):
-        log.debug(f"Event bus error: {error}")
+    def on_error(self, ws, e):
+        log.debug(f"Event bus error: {e!r}")
 
     def on_close(self, ws, close_status_code, close_msg):
         log.debug("Disconnected from resotocore event bus")

--- a/resotolib/resotolib/core/events.py
+++ b/resotolib/resotolib/core/events.py
@@ -36,12 +36,12 @@ class CoreEvents(threading.Thread):
         self.name = "eventbus-listener"
         add_event_listener(EventType.SHUTDOWN, self.shutdown)
         while not self.shutdown_event.is_set():
-            log.info("Connecting to resotocore event bus")
+            log.debug("Connecting to resotocore event bus")
             try:
                 self.connect()
             except Exception as e:
-                log.error(e)
-            time.sleep(10)
+                log.debug(e)
+            time.sleep(1)
 
     def connect(self) -> None:
         log.debug(f"Connecting to {self.ws_uri}")
@@ -87,7 +87,7 @@ class CoreEvents(threading.Thread):
                 log.exception(f"Something went wrong while processing {message}")
 
     def on_error(self, ws, error):
-        log.error(f"Event bus error: {error}")
+        log.debug(f"Event bus error: {error}")
 
     def on_close(self, ws, close_status_code, close_msg):
         log.debug("Disconnected from resotocore event bus")

--- a/resotolib/resotolib/core/events.py
+++ b/resotolib/resotolib/core/events.py
@@ -40,7 +40,7 @@ class CoreEvents(threading.Thread):
             try:
                 self.connect()
             except Exception as e:
-                log.debug(e)
+                log.error(e)
             time.sleep(1)
 
     def connect(self) -> None:

--- a/resotolib/resotolib/core/tasks.py
+++ b/resotolib/resotolib/core/tasks.py
@@ -117,8 +117,8 @@ class CoreTasks(threading.Thread):
             return
         self.queue.put(message)
 
-    def on_error(self, ws, error):
-        log.debug(f"{self.identifier} event bus error: {error}")
+    def on_error(self, ws, e):
+        log.debug(f"{self.identifier} event bus error: {e!r}")
 
     def on_close(self, ws, close_status_code, close_msg):
         log.debug(f"{self.identifier} disconnected from resotocore task queue")

--- a/resotolib/resotolib/core/tasks.py
+++ b/resotolib/resotolib/core/tasks.py
@@ -50,12 +50,12 @@ class CoreTasks(threading.Thread):
             ).start()
 
         while not self.shutdown_event.is_set():
-            log.info("Connecting to resotocore task queue")
+            log.debug("Connecting to resotocore task queue")
             try:
                 self.connect()
             except Exception as e:
-                log.error(e)
-            time.sleep(10)
+                log.debug(e)
+            time.sleep(1)
 
     def worker(self) -> None:
         while not self.shutdown_event.is_set():
@@ -118,7 +118,7 @@ class CoreTasks(threading.Thread):
         self.queue.put(message)
 
     def on_error(self, ws, error):
-        log.error(f"{self.identifier} event bus error: {error}")
+        log.debug(f"{self.identifier} event bus error: {error}")
 
     def on_close(self, ws, close_status_code, close_msg):
         log.debug(f"{self.identifier} disconnected from resotocore task queue")

--- a/resotolib/resotolib/core/tasks.py
+++ b/resotolib/resotolib/core/tasks.py
@@ -54,7 +54,7 @@ class CoreTasks(threading.Thread):
             try:
                 self.connect()
             except Exception as e:
-                log.debug(e)
+                log.error(e)
             time.sleep(1)
 
     def worker(self) -> None:


### PR DESCRIPTION
# Description

Changes the severity of auto-recovering message bus errors and info messages.
Anything that is not helpful to the user of where the user can't really do anything to fix the situation shouldn't be exposed as an error and instead silently recover.
Also allows setting RESOTO_VERBOSE as an env and propagate to each container.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
