### PR TITLE
[resoto][feat] Add possible successors to the model

### DIFF
--- a/plugins/aws/resoto_plugin_aws/resources.py
+++ b/plugins/aws/resoto_plugin_aws/resources.py
@@ -18,6 +18,11 @@ default_ctime = make_valid_timestamp(date(2006, 3, 19))  # AWS public launch dat
 @dataclass(eq=False)
 class AWSAccount(BaseAccount):
     kind: ClassVar[str] = "aws_account"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["aws_region"],
+        "delete": [],
+    }
+
     account_alias: Optional[str] = ""
     role: Optional[str] = None
     users: Optional[int] = 0
@@ -49,6 +54,50 @@ class AWSAccount(BaseAccount):
 @dataclass(eq=False)
 class AWSRegion(BaseRegion):
     kind: ClassVar[str] = "aws_region"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": [
+            "aws_vpc_quota",
+            "aws_vpc_peering_connection",
+            "aws_vpc_endpoint",
+            "aws_vpc",
+            "aws_s3_bucket_quota",
+            "aws_s3_bucket",
+            "aws_rds_instance",
+            "aws_iam_server_certificate_quota",
+            "aws_iam_server_certificate",
+            "aws_iam_role",
+            "aws_iam_policy",
+            "aws_iam_instance_profile",
+            "aws_iam_group",
+            "aws_elb_quota",
+            "aws_elb",
+            "aws_eks_cluster",
+            "aws_ec2_volume_type",
+            "aws_ec2_volume",
+            "aws_iam_user",
+            "aws_ec2_subnet",
+            "aws_ec2_snapshot",
+            "aws_ec2_security_group",
+            "aws_ec2_route_table",
+            "aws_ec2_network_interface",
+            "aws_ec2_network_acl",
+            "aws_ec2_nat_gateway",
+            "aws_ec2_keypair",
+            "aws_ec2_internet_gateway_quota",
+            "aws_ec2_internet_gateway",
+            "aws_ec2_instance_type",
+            "aws_ec2_instance_quota",
+            "aws_ec2_instance",
+            "aws_ec2_elastic_ip",
+            "aws_cloudwatch_alarm",
+            "aws_cloudformation_stack",
+            "aws_autoscaling_group",
+            "aws_alb_target_group",
+            "aws_alb_quota",
+            "aws_alb",
+        ],
+        "delete": [],
+    }
     ctime: Optional[datetime] = default_ctime
 
     def delete(self, graph) -> bool:
@@ -67,16 +116,34 @@ class AWSResource:
 @dataclass(eq=False)
 class AWSEC2InstanceType(AWSResource, BaseInstanceType):
     kind: ClassVar[str] = "aws_ec2_instance_type"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["aws_ec2_instance"],
+        "delete": [],
+    }
 
 
 @dataclass(eq=False)
 class AWSEC2InstanceQuota(AWSResource, BaseInstanceQuota):
     kind: ClassVar[str] = "aws_ec2_instance_quota"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["aws_ec2_instance_type"],
+        "delete": [],
+    }
 
 
 @dataclass(eq=False)
 class AWSEC2Instance(AWSResource, BaseInstance):
     kind: ClassVar[str] = "aws_ec2_instance"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": [
+            "aws_ec2_volume",
+            "aws_ec2_network_interface",
+            "aws_ec2_keypair",
+            "aws_ec2_elastic_ip",
+            "aws_cloudwatch_alarm",
+        ],
+        "delete": ["aws_elb", "aws_autoscaling_group", "aws_alb_target_group"],
+    }
 
     instance_status_map: ClassVar[Dict[str, InstanceStatus]] = {
         "pending": InstanceStatus.BUSY,
@@ -133,6 +200,10 @@ AWSEC2Instance.instance_status = property(
 @dataclass(eq=False)
 class AWSEC2KeyPair(AWSResource, BaseKeyPair):
     kind: ClassVar[str] = "aws_ec2_keypair"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": [],
+        "delete": ["aws_ec2_instance"],
+    }
 
     def delete(self, graph: Graph) -> bool:
         ec2 = aws_client(self, "ec2", graph)
@@ -153,11 +224,20 @@ class AWSEC2KeyPair(AWSResource, BaseKeyPair):
 @dataclass(eq=False)
 class AWSEC2VolumeType(AWSResource, BaseVolumeType):
     kind: ClassVar[str] = "aws_ec2_volume_type"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["aws_ec2_volume"],
+        "delete": [],
+    }
 
 
 @dataclass(eq=False)
 class AWSEC2Volume(AWSResource, BaseVolume):
     kind: ClassVar[str] = "aws_ec2_volume"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["aws_ec2_snapshot"],
+        "delete": ["aws_ec2_instance"],
+    }
+
     volume_kms_key_id: Optional[str] = None
     volume_multi_attach_enabled: Optional[bool] = None
     volume_outpost_arn: Optional[str] = None
@@ -271,6 +351,24 @@ class AWSEC2Snapshot(AWSResource, BaseSnapshot):
 @dataclass(eq=False)
 class AWSEC2Subnet(AWSResource, BaseSubnet):
     kind: ClassVar[str] = "aws_ec2_subnet"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": [
+            "aws_vpc_endpoint",
+            "aws_rds_instance",
+            "aws_elb",
+            "aws_ec2_network_interface",
+            "aws_ec2_network_acl",
+            "aws_ec2_nat_gateway",
+            "aws_alb",
+        ],
+        "delete": [
+            "aws_vpc_endpoint",
+            "aws_rds_instance",
+            "aws_elb",
+            "aws_ec2_network_interface",
+            "aws_alb",
+        ],
+    }
 
     def delete(self, graph: Graph) -> bool:
         ec2 = aws_resource(self, "ec2", graph)
@@ -292,6 +390,11 @@ class AWSEC2Subnet(AWSResource, BaseSubnet):
 @dataclass(eq=False)
 class AWSEC2ElasticIP(AWSResource, BaseIPAddress):
     kind: ClassVar[str] = "aws_ec2_elastic_ip"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": [],
+        "delete": ["aws_ec2_network_interface", "aws_ec2_instance"],
+    }
+
     instance_id: Optional[str] = None
     public_ip: Optional[str] = None
     allocation_id: Optional[str] = None
@@ -328,6 +431,36 @@ class AWSEC2ElasticIP(AWSResource, BaseIPAddress):
 @dataclass(eq=False)
 class AWSVPC(AWSResource, BaseNetwork):
     kind: ClassVar[str] = "aws_vpc"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": [
+            "aws_vpc_peering_connection",
+            "aws_vpc_endpoint",
+            "aws_rds_instance",
+            "aws_elb",
+            "aws_ec2_subnet",
+            "aws_ec2_security_group",
+            "aws_ec2_route_table",
+            "aws_ec2_network_interface",
+            "aws_ec2_network_acl",
+            "aws_ec2_nat_gateway",
+            "aws_ec2_internet_gateway",
+            "aws_alb_target_group",
+        ],
+        "delete": [
+            "aws_vpc_peering_connection",
+            "aws_vpc_endpoint",
+            "aws_rds_instance",
+            "aws_elb",
+            "aws_ec2_subnet",
+            "aws_ec2_security_group",
+            "aws_ec2_route_table",
+            "aws_ec2_network_interface",
+            "aws_ec2_network_acl",
+            "aws_ec2_nat_gateway",
+            "aws_ec2_internet_gateway",
+            "aws_alb_target_group",
+        ],
+    }
     is_default: bool = False
 
     def delete(self, graph: Graph) -> bool:
@@ -359,6 +492,10 @@ class AWSVPC(AWSResource, BaseNetwork):
 @dataclass(eq=False)
 class AWSVPCQuota(AWSResource, BaseNetworkQuota):
     kind: ClassVar[str] = "aws_vpc_quota"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["aws_vpc"],
+        "delete": [],
+    }
 
 
 @dataclass(eq=False)
@@ -376,11 +513,19 @@ class AWSS3Bucket(AWSResource, BaseBucket):
 @dataclass(eq=False)
 class AWSS3BucketQuota(AWSResource, BaseBucketQuota):
     kind: ClassVar[str] = "aws_s3_bucket_quota"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["aws_s3_bucket"],
+        "delete": [],
+    }
 
 
 @dataclass(eq=False)
 class AWSELB(AWSResource, BaseLoadBalancer):
     kind: ClassVar[str] = "aws_elb"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["aws_ec2_instance"],
+        "delete": [],
+    }
 
     def delete(self, graph: Graph) -> bool:
         client = aws_client(self, "elb", graph)
@@ -404,6 +549,10 @@ class AWSELB(AWSResource, BaseLoadBalancer):
 @dataclass(eq=False)
 class AWSALB(AWSResource, BaseLoadBalancer):
     kind: ClassVar[str] = "aws_alb"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["aws_iam_server_certificate", "aws_alb_target_group"],
+        "delete": [],
+    }
 
     def delete(self, graph: Graph) -> bool:
         client = aws_client(self, "elbv2", graph)
@@ -425,29 +574,12 @@ class AWSALB(AWSResource, BaseLoadBalancer):
 @dataclass(eq=False)
 class AWSALBTargetGroup(AWSResource, BaseResource):
     kind: ClassVar[str] = "aws_alb_target_group"
-
-    metrics_description = {
-        "aws_alb_target_groups_total": {
-            "help": "Number of AWS ALB Target Groups",
-            "labels": ["cloud", "account", "region"],
-        },
-        "cleaned_aws_alb_target_groups_total": {
-            "help": "Cleaned number of AWS ALB Target Groups",
-            "labels": ["cloud", "account", "region"],
-        },
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["aws_ec2_instance"],
+        "delete": ["aws_alb"],
     }
-    target_type: str = ""
 
-    def metrics(self, graph) -> Dict:
-        metrics_keys = (
-            self.cloud(graph).name,
-            self.account(graph).dname,
-            self.region(graph).name,
-        )
-        self._metrics["aws_alb_target_groups_total"][metrics_keys] = 1
-        if self._cleaned:
-            self._metrics["cleaned_aws_alb_target_groups_total"][metrics_keys] = 1
-        return self._metrics
+    target_type: str = ""
 
     def delete(self, graph: Graph) -> bool:
         client = aws_client(self, "elbv2", graph)
@@ -469,11 +601,19 @@ class AWSALBTargetGroup(AWSResource, BaseResource):
 @dataclass(eq=False)
 class AWSELBQuota(AWSResource, BaseLoadBalancerQuota):
     kind: ClassVar[str] = "aws_elb_quota"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["aws_elb"],
+        "delete": [],
+    }
 
 
 @dataclass(eq=False)
 class AWSALBQuota(AWSResource, BaseLoadBalancerQuota):
     kind: ClassVar[str] = "aws_alb_quota"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["aws_alb"],
+        "delete": [],
+    }
 
 
 @dataclass(eq=False)
@@ -511,6 +651,11 @@ class AWSEC2InternetGateway(AWSResource, BaseGateway):
 @dataclass(eq=False)
 class AWSEC2NATGateway(AWSResource, BaseGateway):
     kind: ClassVar[str] = "aws_ec2_nat_gateway"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["aws_ec2_network_interface"],
+        "delete": [],
+    }
+
     nat_gateway_status: str = ""
 
     def delete(self, graph: Graph) -> bool:
@@ -532,11 +677,24 @@ class AWSEC2NATGateway(AWSResource, BaseGateway):
 @dataclass(eq=False)
 class AWSEC2InternetGatewayQuota(AWSResource, BaseGatewayQuota):
     kind: ClassVar[str] = "aws_ec2_internet_gateway_quota"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["aws_ec2_internet_gateway"],
+        "delete": [],
+    }
 
 
 @dataclass(eq=False)
 class AWSEC2SecurityGroup(AWSResource, BaseSecurityGroup):
     kind: ClassVar[str] = "aws_ec2_security_group"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": [
+            "aws_vpc_endpoint",
+            "aws_rds_instance",
+            "aws_elb",
+            "aws_ec2_network_interface",
+        ],
+        "delete": ["aws_vpc_endpoint", "aws_rds_instance"],
+    }
 
     def pre_delete(self, graph: Graph) -> bool:
         ec2 = aws_resource(self, "ec2", graph)
@@ -594,6 +752,10 @@ class AWSEC2SecurityGroup(AWSResource, BaseSecurityGroup):
 @dataclass(eq=False)
 class AWSEC2RouteTable(AWSResource, BaseRoutingTable):
     kind: ClassVar[str] = "aws_ec2_route_table"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["aws_vpc_endpoint"],
+        "delete": ["aws_vpc_endpoint"],
+    }
 
     def pre_delete(self, graph: Graph) -> bool:
         ec2 = aws_resource(self, "ec2", graph)
@@ -647,6 +809,10 @@ class AWSVPCPeeringConnection(AWSResource, BasePeeringConnection):
 @dataclass(eq=False)
 class AWSVPCEndpoint(AWSResource, BaseEndpoint):
     kind: ClassVar[str] = "aws_vpc_endpoint"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["aws_ec2_network_interface"],
+        "delete": [],
+    }
     vpc_endpoint_type: str = ""
     vpc_endpoint_status: str = ""
 
@@ -669,6 +835,10 @@ class AWSVPCEndpoint(AWSResource, BaseEndpoint):
 @dataclass(eq=False)
 class AWSEC2NetworkAcl(AWSResource, BaseNetworkAcl):
     kind: ClassVar[str] = "aws_ec2_network_acl"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": [],
+        "delete": ["aws_ec2_subnet"],
+    }
     is_default: bool = False
 
     def delete(self, graph: Graph) -> bool:
@@ -690,6 +860,10 @@ class AWSEC2NetworkAcl(AWSResource, BaseNetworkAcl):
 @dataclass(eq=False)
 class AWSEC2NetworkInterface(AWSResource, BaseNetworkInterface):
     kind: ClassVar[str] = "aws_ec2_network_interface"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["aws_ec2_elastic_ip"],
+        "delete": ["aws_vpc_endpoint", "aws_ec2_nat_gateway", "aws_ec2_instance"],
+    }
 
     def delete(self, graph: Graph) -> bool:
         ec2 = aws_resource(self, "ec2", graph)
@@ -717,6 +891,10 @@ class AWSRDSInstance(AWSResource, BaseDatabase):
 @dataclass(eq=False)
 class AWSIAMUser(AWSResource, BaseUser):
     kind: ClassVar[str] = "aws_iam_user"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["aws_iam_access_key"],
+        "delete": ["aws_iam_policy"],
+    }
     user_policies: List = field(default_factory=list)
 
     def pre_delete(self, graph: Graph) -> bool:
@@ -750,6 +928,10 @@ class AWSIAMUser(AWSResource, BaseUser):
 @dataclass(eq=False)
 class AWSIAMGroup(AWSResource, BaseGroup):
     kind: ClassVar[str] = "aws_iam_group"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["aws_iam_user"],
+        "delete": ["aws_iam_policy"],
+    }
     group_policies: List = field(default_factory=list)
 
     def pre_delete(self, graph: Graph) -> bool:
@@ -783,6 +965,11 @@ class AWSIAMGroup(AWSResource, BaseGroup):
 @dataclass(eq=False)
 class AWSIAMRole(AWSResource, BaseRole):
     kind: ClassVar[str] = "aws_iam_role"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["aws_iam_policy", "aws_iam_instance_profile"],
+        "delete": ["aws_iam_policy", "aws_iam_instance_profile", "aws_eks_cluster"],
+    }
+
     role_policies: List = field(default_factory=list)
 
     def pre_delete(self, graph: Graph) -> bool:
@@ -816,6 +1003,10 @@ class AWSIAMRole(AWSResource, BaseRole):
 @dataclass(eq=False)
 class AWSIAMPolicy(AWSResource, BasePolicy):
     kind: ClassVar[str] = "aws_iam_policy"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["aws_iam_user", "aws_iam_group"],
+        "delete": [],
+    }
 
     def delete(self, graph: Graph) -> bool:
         iam = aws_resource(self, "iam", graph)
@@ -827,6 +1018,10 @@ class AWSIAMPolicy(AWSResource, BasePolicy):
 @dataclass(eq=False)
 class AWSIAMInstanceProfile(AWSResource, BaseInstanceProfile):
     kind: ClassVar[str] = "aws_iam_instance_profile"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["aws_ec2_instance"],
+        "delete": [],
+    }
 
     def pre_delete(self, graph: Graph) -> bool:
         iam = aws_resource(self, "iam", graph)
@@ -849,6 +1044,7 @@ class AWSIAMInstanceProfile(AWSResource, BaseInstanceProfile):
 @dataclass(eq=False)
 class AWSIAMAccessKey(AWSResource, BaseAccessKey):
     kind: ClassVar[str] = "aws_iam_access_key"
+
     user_name: Optional[str] = None
     access_key_last_used_region: Optional[str] = None
     access_key_last_used_service_name: Optional[str] = None
@@ -863,6 +1059,10 @@ class AWSIAMAccessKey(AWSResource, BaseAccessKey):
 @dataclass(eq=False)
 class AWSIAMServerCertificate(AWSResource, BaseCertificate):
     kind: ClassVar[str] = "aws_iam_server_certificate"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": [],
+        "delete": ["aws_alb"],
+    }
     path: str = None
 
     def delete(self, graph: Graph) -> bool:
@@ -875,6 +1075,10 @@ class AWSIAMServerCertificate(AWSResource, BaseCertificate):
 @dataclass(eq=False)
 class AWSIAMServerCertificateQuota(AWSResource, BaseCertificateQuota):
     kind: ClassVar[str] = "aws_iam_server_certificate_quota"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["aws_iam_server_certificate"],
+        "delete": [],
+    }
 
 
 @dataclass(eq=False)
@@ -955,29 +1159,12 @@ class AWSCloudFormationStack(AWSResource, BaseStack):
 @dataclass(eq=False)
 class AWSEKSCluster(AWSResource, BaseResource):
     kind: ClassVar[str] = "aws_eks_cluster"
-    metrics_description: ClassVar[Dict] = {
-        "aws_eks_clusters_total": {
-            "help": "Number of AWS EKS Clusters",
-            "labels": ["cloud", "account", "region"],
-        },
-        "cleaned_aws_eks_clusters_total": {
-            "help": "Cleaned number of AWS EKS Clusters",
-            "labels": ["cloud", "account", "region"],
-        },
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["aws_iam_role", "aws_eks_nodegroup"],
+        "delete": ["aws_eks_nodegroup"],
     }
     cluster_status: str = ""
     cluster_endpoint: str = ""
-
-    def metrics(self, graph) -> Dict:
-        metrics_keys = (
-            self.cloud(graph).name,
-            self.account(graph).dname,
-            self.region(graph).name,
-        )
-        self._metrics["aws_eks_clusters_total"][metrics_keys] = 1
-        if self._cleaned:
-            self._metrics["cleaned_aws_eks_clusters_total"][metrics_keys] = 1
-        return self._metrics
 
     def delete(self, graph: Graph) -> bool:
         eks = aws_client(self, "eks", graph)
@@ -998,29 +1185,13 @@ class AWSEKSCluster(AWSResource, BaseResource):
 @dataclass(eq=False)
 class AWSEKSNodegroup(AWSResource, BaseResource):
     kind: ClassVar[str] = "aws_eks_nodegroup"
-    metrics_description: ClassVar[Dict] = {
-        "aws_eks_nodegroups_total": {
-            "help": "Number of AWS EKS Nodegroups",
-            "labels": ["cloud", "account", "region"],
-        },
-        "cleaned_aws_eks_nodegroups_total": {
-            "help": "Cleaned number of AWS EKS Nodegroups",
-            "labels": ["cloud", "account", "region"],
-        },
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["aws_autoscaling_group"],
+        "delete": [],
     }
+
     cluster_name: str = ""
     nodegroup_status: str = ""
-
-    def metrics(self, graph) -> Dict:
-        metrics_keys = (
-            self.cloud(graph).name,
-            self.account(graph).dname,
-            self.region(graph).name,
-        )
-        self._metrics["aws_eks_nodegroups_total"][metrics_keys] = 1
-        if self._cleaned:
-            self._metrics["cleaned_aws_eks_nodegroups_total"][metrics_keys] = 1
-        return self._metrics
 
     def delete(self, graph: Graph) -> bool:
         eks = aws_client(self, "eks", graph)
@@ -1041,6 +1212,10 @@ class AWSEKSNodegroup(AWSResource, BaseResource):
 @dataclass(eq=False)
 class AWSAutoScalingGroup(AWSResource, BaseAutoScalingGroup):
     kind: ClassVar[str] = "aws_autoscaling_group"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["aws_ec2_instance"],
+        "delete": ["aws_eks_nodegroup"],
+    }
 
     def delete(self, graph: Graph, force_delete: bool = True) -> bool:
         client = aws_client(self, "autoscaling", graph)
@@ -1083,16 +1258,11 @@ class AWSAutoScalingGroup(AWSResource, BaseAutoScalingGroup):
 @dataclass(eq=False)
 class AWSCloudwatchAlarm(AWSResource, BaseResource):
     kind: ClassVar[str] = "aws_cloudwatch_alarm"
-    metrics_description: ClassVar[Dict] = {
-        "aws_cloudwatch_alarms_total": {
-            "help": "Number of AWS Cloudwatch Alarms",
-            "labels": ["cloud", "account", "region", "state"],
-        },
-        "cleaned_aws_cloudwatch_alarms_total": {
-            "help": "Cleaned number of AWS Cloudwatch Alarms",
-            "labels": ["cloud", "account", "region", "state"],
-        },
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": [],
+        "delete": ["aws_ec2_instance"],
     }
+
     actions_enabled: bool = False
     alarm_description: Optional[str] = None
     alarm_actions: Optional[List] = field(default_factory=list)
@@ -1107,18 +1277,6 @@ class AWSCloudwatchAlarm(AWSResource, BaseResource):
     state_value: Optional[str] = None
     statistic: Optional[str] = None
     threshold: Optional[float] = 0.0
-
-    def metrics(self, graph) -> Dict:
-        metrics_keys = (
-            self.cloud(graph).name,
-            self.account(graph).dname,
-            self.region(graph).name,
-            self.state_value,
-        )
-        self._metrics["aws_cloudwatch_alarms_total"][metrics_keys] = 1
-        if self._cleaned:
-            self._metrics["cleaned_aws_cloudwatch_alarms_total"][metrics_keys] = 1
-        return self._metrics
 
     def delete(self, graph: Graph) -> bool:
         cloudwatch = aws_resource(self, "cloudwatch", graph)

--- a/plugins/aws/resoto_plugin_aws/resources.py
+++ b/plugins/aws/resoto_plugin_aws/resources.py
@@ -1,7 +1,7 @@
 import time
 import copy
 from datetime import date
-from enum import Enum, auto
+from enum import auto
 from resotolib.baseresources import *
 from resotolib.graph import Graph
 from resotolib.utils import make_valid_timestamp
@@ -91,6 +91,7 @@ class AWSRegion(BaseRegion):
             "aws_ec2_elastic_ip",
             "aws_cloudwatch_alarm",
             "aws_cloudformation_stack",
+            "aws_cloudformation_stack_set",
             "aws_autoscaling_group",
             "aws_alb_target_group",
             "aws_alb_quota",

--- a/plugins/digitalocean/resoto_plugin_digitalocean/resources.py
+++ b/plugins/digitalocean/resoto_plugin_digitalocean/resources.py
@@ -147,6 +147,37 @@ class DigitalOceanTeam(DigitalOceanResource, BaseAccount):  # type: ignore
     """DigitalOcean Team"""
 
     kind: ClassVar[str] = "digitalocean_team"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": [
+            "digitalocean_alert_policy",
+            "digitalocean_app",
+            "digitalocean_cdn_endpoint",
+            "digitalocean_certificate",
+            "digitalocean_container_registry",
+            "digitalocean_container_registry_repository",
+            "digitalocean_container_registry_repository_tag",
+            "digitalocean_database",
+            "digitalocean_domain",
+            "digitalocean_domain_record",
+            "digitalocean_droplet",
+            "digitalocean_firewall",
+            "digitalocean_floating_ip",
+            "digitalocean_image",
+            "digitalocean_kubernetes_cluster",
+            "digitalocean_load_balancer",
+            "digitalocean_network",
+            "digitalocean_project",
+            "digitalocean_region",
+            "digitalocean_resource",
+            "digitalocean_snapshot",
+            "digitalocean_space",
+            "digitalocean_ssh_key",
+            "digitalocean_tag",
+            "digitalocean_team",
+            "digitalocean_volume",
+        ],
+        "delete": [],
+    }
 
 
 @dataclass(eq=False)
@@ -154,6 +185,22 @@ class DigitalOceanRegion(DigitalOceanResource, BaseRegion):  # type: ignore
     """DigitalOcean region"""
 
     kind: ClassVar[str] = "digitalocean_region"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": [
+            "digitalocean_app",
+            "digitalocean_container_registry",
+            "digitalocean_database",
+            "digitalocean_droplet",
+            "digitalocean_floating_ip",
+            "digitalocean_image",
+            "digitalocean_kubernetes_cluster",
+            "digitalocean_load_balancer",
+            "digitalocean_network",
+            "digitalocean_snapshot",
+            "digitalocean_space",
+        ],
+        "delete": [],
+    }
 
     do_region_slug: Optional[str] = None
     do_region_features: Optional[List[str]] = None
@@ -166,6 +213,29 @@ class DigitalOceanProject(DigitalOceanResource, BaseResource):  # type: ignore
     """DigitalOcean project"""
 
     kind: ClassVar[str] = "digitalocean_project"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": [
+            "digitalocean_database",
+            "digitalocean_domain",
+            "digitalocean_droplet",
+            "digitalocean_floating_ip",
+            "digitalocean_kubernetes_cluster",
+            "digitalocean_load_balancer",
+            "digitalocean_space",
+            "digitalocean_volume",
+        ],
+        "delete": [
+            "digitalocean_database",
+            "digitalocean_domain",
+            "digitalocean_droplet",
+            "digitalocean_floating_ip",
+            "digitalocean_kubernetes_cluster",
+            "digitalocean_load_balancer",
+            "digitalocean_space",
+            "digitalocean_volume",
+        ],
+    }
+
     owner_uuid: Optional[str] = None
     owner_id: Optional[str] = None
     description: Optional[str] = None
@@ -187,6 +257,15 @@ class DigitalOceanDroplet(DigitalOceanResource, BaseInstance):  # type: ignore
     """
 
     kind: ClassVar[str] = "digitalocean_droplet"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": [
+            "digitalocean_floating_ip",
+            "digitalocean_snapshot",
+            "digitalocean_volume",
+        ],
+        "delete": [],
+    }
+
     instance_status_map: ClassVar[Dict[str, InstanceStatus]] = {
         "new": InstanceStatus.BUSY,
         "active": InstanceStatus.RUNNING,
@@ -230,6 +309,10 @@ class DigitalOceanKubernetesCluster(DigitalOceanResource, BaseResource):  # type
     """DigitalOcean Kubernetes Cluster"""
 
     kind: ClassVar[str] = "digitalocean_kubernetes_cluster"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["digitalocean_droplet"],
+        "delete": [],
+    }
 
     k8s_version: Optional[str] = None
     k8s_cluster_subnet: Optional[str] = None
@@ -249,6 +332,10 @@ class DigitalOceanKubernetesCluster(DigitalOceanResource, BaseResource):  # type
 @dataclass(eq=False)
 class DigitalOceanVolume(DigitalOceanResource, BaseVolume):  # type: ignore
     kind: ClassVar[str] = "digitalocean_volume"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["digitalocean_snapshot"],
+        "delete": ["digitalocean_droplet"],
+    }
 
     volume_status_map: ClassVar[Dict[str, VolumeStatus]] = {
         "creating": VolumeStatus.BUSY,
@@ -282,6 +369,10 @@ DigitalOceanVolume.volume_status = property(
 @dataclass(eq=False)
 class DigitalOceanDatabase(DigitalOceanResource, BaseDatabase):  # type: ignore
     kind: ClassVar[str] = "digitalocean_database"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["digitalocean_app"],
+        "delete": [],
+    }
 
     def delete_uri_path(self) -> Optional[str]:
         return "/databases"
@@ -298,6 +389,20 @@ class DigitalOceanNetwork(DigitalOceanResource, BaseNetwork):  # type: ignore
     """
 
     kind: ClassVar[str] = "digitalocean_network"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": [
+            "digitalocean_load_balancer",
+            "digitalocean_kubernetes_cluster",
+            "digitalocean_droplet",
+            "digitalocean_network",
+            "digitalocean_database",
+        ],
+        "delete": [
+            "digitalocean_database",
+            "digitalocean_droplet",
+            "digitalocean_kubernetes_cluster",
+        ],
+    }
 
     ip_range: Optional[str] = None
     description: Optional[str] = None
@@ -328,6 +433,10 @@ class DigitalOceanLoadBalancer(DigitalOceanResource, BaseLoadBalancer):  # type:
     """DigitalOcean load balancer"""
 
     kind: ClassVar[str] = "digitalocean_load_balancer"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["digitalocean_droplet"],
+        "delete": [],
+    }
 
     nr_nodes: Optional[int] = None
     loadbalancer_status: Optional[str] = None
@@ -373,6 +482,10 @@ class DigitalOceanImage(DigitalOceanResource, BaseResource):  # type: ignore
     """DigitalOcean image"""
 
     kind: ClassVar[str] = "digitalocean_image"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["digitalocean_droplet"],
+        "delete": [],
+    }
 
     distribution: Optional[str] = None
     image_slug: Optional[str] = None
@@ -464,6 +577,11 @@ class DigitalOceanContainerRegistry(DigitalOceanResource, BaseResource):  # type
     """DigitalOcean container registry"""
 
     kind = "digitalocean_container_registry"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["digitalocean_container_registry_repository"],
+        "delete": [],
+    }
+
     storage_usage_bytes: Optional[int] = None
     is_read_only: Optional[bool] = None
 
@@ -492,6 +610,10 @@ class DigitalOceanContainerRegistryRepository(DigitalOceanResource, BaseResource
     """DigitalOcean container registry repository"""
 
     kind = "digitalocean_container_registry_repository"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["digitalocean_container_registry_repository_tag"],
+        "delete": [],
+    }
 
     tag_count: Optional[int] = None
     manifest_count: Optional[int] = None
@@ -541,6 +663,10 @@ class DigitalOceanDomain(DigitalOceanResource, BaseDomain):  # type: ignore
     """DigitalOcean domain"""
 
     kind = "digitalocean_domain"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["digitalocean_domain_record"],
+        "delete": [],
+    }
 
     def delete_uri_path(self) -> Optional[str]:
         return "/domains"
@@ -562,6 +688,11 @@ class DigitalOceanFirewall(DigitalOceanResource, BaseResource):  # type: ignore
     """DigitalOcean firewall"""
 
     kind = "digitalocean_firewall"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["digitalocean_droplet"],
+        "delete": [],
+    }
+
     firewall_status: Optional[str] = None
 
     def delete_uri_path(self) -> Optional[str]:

--- a/plugins/digitalocean/resoto_plugin_digitalocean/resources.py
+++ b/plugins/digitalocean/resoto_plugin_digitalocean/resources.py
@@ -173,7 +173,6 @@ class DigitalOceanTeam(DigitalOceanResource, BaseAccount):  # type: ignore
             "digitalocean_space",
             "digitalocean_ssh_key",
             "digitalocean_tag",
-            "digitalocean_team",
             "digitalocean_volume",
         ],
         "delete": [],
@@ -394,7 +393,6 @@ class DigitalOceanNetwork(DigitalOceanResource, BaseNetwork):  # type: ignore
             "digitalocean_load_balancer",
             "digitalocean_kubernetes_cluster",
             "digitalocean_droplet",
-            "digitalocean_network",
             "digitalocean_database",
         ],
         "delete": [

--- a/plugins/gcp/resoto_plugin_gcp/resources.py
+++ b/plugins/gcp/resoto_plugin_gcp/resources.py
@@ -114,12 +114,44 @@ class GCPResource:
 @dataclass(eq=False)
 class GCPProject(GCPResource, BaseAccount):
     kind: ClassVar[str] = "gcp_project"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": [
+            "gcp_target_tcp_proxy",
+            "gcp_subnetwork",
+            "gcp_ssl_certificate",
+            "gcp_snapshot",
+            "gcp_service",
+            "gcp_route",
+            "gcp_region",
+            "gcp_network",
+            "gcp_https_health_check",
+            "gcp_http_health_check",
+            "gcp_health_check",
+            "gcp_forwarding_rule",
+            "gcp_bucket",
+            "gcp_backend_service",
+        ],
+        "delete": [],
+    }
     api_identifier: ClassVar[str] = "project"
 
 
 @dataclass(eq=False)
 class GCPZone(GCPResource, BaseZone):
     kind: ClassVar[str] = "gcp_zone"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": [
+            "gcp_network_endpoint_group",
+            "gcp_machine_type",
+            "gcp_instance_group",
+            "gcp_instance",
+            "gcp_disk_type",
+            "gcp_disk",
+            "gcp_database",
+        ],
+        "delete": [],
+    }
+
     api_identifier: ClassVar[str] = "zone"
     zone_status: Optional[str] = None
 
@@ -127,6 +159,19 @@ class GCPZone(GCPResource, BaseZone):
 @dataclass(eq=False)
 class GCPRegion(GCPResource, BaseRegion):
     kind: ClassVar[str] = "gcp_region"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": [
+            "gcp_zone",
+            "gcp_vpn_tunnel",
+            "gcp_target_vpn_gateway",
+            "gcp_target_pool",
+            "gcp_subnetwork",
+            "gcp_router",
+            "gcp_quota",
+            "gcp_forwarding_rule",
+        ],
+        "delete": [],
+    }
     api_identifier: ClassVar[str] = "region"
     region_status: Optional[str] = None
     quotas: InitVar[List[str]] = None
@@ -142,12 +187,20 @@ class GCPRegion(GCPResource, BaseRegion):
 @dataclass(eq=False)
 class GCPDiskType(GCPResource, BaseVolumeType):
     kind: ClassVar[str] = "gcp_disk_type"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["gcp_disk"],
+        "delete": [],
+    }
     api_identifier: ClassVar[str] = "diskType"
 
 
 @dataclass(eq=False)
 class GCPDisk(GCPResource, BaseVolume):
     kind: ClassVar[str] = "gcp_disk"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["gcp_snapshot"],
+        "delete": ["gcp_instance"],
+    }
     api_identifier: ClassVar[str] = "disk"
 
     volume_status_map: ClassVar[Dict[str, VolumeStatus]] = {
@@ -206,6 +259,10 @@ GCPDisk.volume_status = property(
 @dataclass(eq=False)
 class GCPInstance(GCPResource, BaseInstance):
     kind: ClassVar[str] = "gcp_instance"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["gcp_disk"],
+        "delete": ["gcp_target_pool", "gcp_instance_group"],
+    }
     api_identifier: ClassVar[str] = "instance"
 
     instance_status_map: ClassVar[Dict[str, InstanceStatus]] = {
@@ -263,18 +320,47 @@ GCPInstance.instance_status = property(
 @dataclass(eq=False)
 class GCPNetwork(GCPResource, BaseNetwork):
     kind: ClassVar[str] = "gcp_network"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": [
+            "gcp_target_vpn_gateway",
+            "gcp_subnetwork",
+            "gcp_router",
+            "gcp_route",
+            "gcp_network_endpoint_group",
+            "gcp_instance_group",
+            "gcp_instance",
+        ],
+        "delete": [
+            "gcp_target_vpn_gateway",
+            "gcp_subnetwork",
+            "gcp_router",
+            "gcp_route",
+            "gcp_network_endpoint_group",
+            "gcp_instance_group",
+            "gcp_instance",
+        ],
+    }
     api_identifier: ClassVar[str] = "network"
 
 
 @dataclass(eq=False)
 class GCPSubnetwork(GCPResource, BaseSubnet):
     kind: ClassVar[str] = "gcp_subnetwork"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["gcp_network_endpoint_group", "gcp_instance_group", "gcp_instance"],
+        "delete": ["gcp_network_endpoint_group", "gcp_instance_group", "gcp_instance"],
+    }
     api_identifier: ClassVar[str] = "subnetwork"
 
 
 @dataclass(eq=False)
 class GCPVPNTunnel(GCPResource, BaseTunnel):
     kind: ClassVar[str] = "gcp_vpn_tunnel"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["gcp_target_vpn_gateway"],
+        "delete": ["gcp_target_vpn_gateway"],
+    }
+
     api_identifier: ClassVar[str] = "vpnTunnel"
 
 
@@ -287,6 +373,10 @@ class GCPVPNGateway(GCPResource, BaseGateway):
 @dataclass(eq=False)
 class GCPTargetVPNGateway(GCPResource, BaseGateway):
     kind: ClassVar[str] = "gcp_target_vpn_gateway"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": [],
+        "delete": ["gcp_forwarding_rule"],
+    }
     api_identifier: ClassVar[str] = "targetVpnGateway"
 
 
@@ -346,6 +436,10 @@ class GCPSSLCertificate(GCPResource, BaseCertificate):
 @dataclass(eq=False)
 class GCPMachineType(GCPResource, BaseInstanceType):
     kind: ClassVar[str] = "gcp_machine_type"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["gcp_instance"],
+        "delete": [],
+    }
     api_identifier: ClassVar[str] = "machineType"
 
     def __post_init__(self) -> None:
@@ -374,6 +468,10 @@ class GCPGlobalNetworkEndpointGroup(GCPResource, BaseResource):
 @dataclass(eq=False)
 class GCPInstanceGroup(GCPResource, BaseResource):
     kind: ClassVar[str] = "gcp_instance_group"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["gcp_instance"],
+        "delete": ["gcp_backend_service"],
+    }
     api_identifier: ClassVar[str] = "instanceGroup"
 
 
@@ -392,6 +490,10 @@ class GCPAutoscaler(GCPResource, BaseAutoScalingGroup):
 @dataclass(eq=False)
 class GCPHealthCheck(GCPResource, BaseHealthCheck):
     kind: ClassVar[str] = "gcp_health_check"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": [],
+        "delete": ["gcp_target_pool"],
+    }
     api_identifier: ClassVar[str] = "healthCheck"
 
 
@@ -420,6 +522,10 @@ class GCPUrlMap(GCPResource, BaseResource):
 @dataclass(eq=False)
 class GCPTargetPool(GCPResource, BaseResource):
     kind: ClassVar[str] = "gcp_target_pool"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["gcp_instance", "gcp_http_health_check"],
+        "delete": ["gcp_forwarding_rule"],
+    }
     api_identifier: ClassVar[str] = "targetPool"
 
     session_affinity: str = ""
@@ -461,6 +567,10 @@ class GCPTargetSslProxy(GCPResource, BaseResource):
 @dataclass(eq=False)
 class GCPTargetTcpProxy(GCPResource, BaseResource):
     kind: ClassVar[str] = "gcp_target_tcp_proxy"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["gcp_backend_service"],
+        "delete": ["gcp_forwarding_rule"],
+    }
     api_identifier: ClassVar[str] = "targetTcpProxy"
 
     def __post_init__(self) -> None:
@@ -493,12 +603,25 @@ class GCPQuota(GCPResource, BaseQuota):
 @dataclass(eq=False)
 class GCPBackendService(GCPResource, BaseResource):
     kind: ClassVar[str] = "gcp_backend_service"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["gcp_instance_group", "gcp_health_check"],
+        "delete": ["gcp_target_tcp_proxy"],
+    }
+
     api_identifier: ClassVar[str] = "backendService"
 
 
 @dataclass(eq=False)
 class GCPForwardingRule(GCPResource, BaseLoadBalancer):
     kind: ClassVar[str] = "gcp_forwarding_rule"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": [
+            "gcp_target_vpn_gateway",
+            "gcp_target_tcp_proxy",
+            "gcp_target_pool",
+        ],
+        "delete": [],
+    }
     api_identifier: ClassVar[str] = "forwardingRule"
 
     ip_address: str = ""
@@ -593,6 +716,11 @@ class GCPDatabase(GCPResource, BaseDatabase):
 @dataclass(eq=False)
 class GCPService(GCPResource, PhantomBaseResource):
     kind: ClassVar[str] = "gcp_service"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["gcp_service_sku"],
+        "delete": [],
+    }
+
     api_identifier: ClassVar[str] = "service"
     client: ClassVar[str] = "cloudbilling"
     api_version: ClassVar[str] = "v1"
@@ -602,6 +730,10 @@ class GCPService(GCPResource, PhantomBaseResource):
 @dataclass(eq=False)
 class GCPServiceSKU(GCPResource, PhantomBaseResource):
     kind: ClassVar[str] = "gcp_service_sku"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["gcp_machine_type", "gcp_disk_type"],
+        "delete": [],
+    }
     api_identifier: ClassVar[str] = "service"
     client: ClassVar[str] = "cloudbilling"
     api_version: ClassVar[str] = "v1"

--- a/plugins/gcp/resoto_plugin_gcp/resources.py
+++ b/plugins/gcp/resoto_plugin_gcp/resources.py
@@ -461,7 +461,12 @@ class GCPSSLCertificate(GCPResource, BaseCertificate):
     kind: ClassVar[str] = "gcp_ssl_certificate"
     successor_kinds: ClassVar[Dict[str, List[str]]] = {
         "default": [],
-        "delete": ["gcp_instance", "gcp_target_https_proxy", "gcp_target_ssl_proxy", "gcp_target_grpc_proxy"],
+        "delete": [
+            "gcp_instance",
+            "gcp_target_https_proxy",
+            "gcp_target_ssl_proxy",
+            "gcp_target_grpc_proxy",
+        ],
     }
     api_identifier: ClassVar[str] = "sslCertificate"
 
@@ -577,7 +582,11 @@ class GCPHTTPSHealthCheck(GCPHTTPHealthCheck):
     kind: ClassVar[str] = "gcp_https_health_check"
     successor_kinds: ClassVar[Dict[str, List[str]]] = {
         "default": [],
-        "delete": ["gcp_backend_service", "gcp_instance_group_manager", "gcp_target_pool"],
+        "delete": [
+            "gcp_backend_service",
+            "gcp_instance_group_manager",
+            "gcp_target_pool",
+        ],
     }
     api_identifier: ClassVar[str] = "httpsHealthCheck"
 
@@ -629,7 +638,11 @@ class GCPTargetHttpsProxy(GCPResource, BaseResource):
     kind: ClassVar[str] = "gcp_target_https_proxy"
     successor_kinds: ClassVar[Dict[str, List[str]]] = {
         "default": ["gcp_url_map", "gcp_ssl_certificate"],
-        "delete": ["gcp_forwarding_rule", "gcp_global_forwarding_rule", "gcp_backend_service"],
+        "delete": [
+            "gcp_forwarding_rule",
+            "gcp_global_forwarding_rule",
+            "gcp_backend_service",
+        ],
     }
     api_identifier: ClassVar[str] = "targetHttpsProxy"
 

--- a/plugins/gcp/resoto_plugin_gcp/resources.py
+++ b/plugins/gcp/resoto_plugin_gcp/resources.py
@@ -141,13 +141,15 @@ class GCPZone(GCPResource, BaseZone):
     kind: ClassVar[str] = "gcp_zone"
     successor_kinds: ClassVar[Dict[str, List[str]]] = {
         "default": [
-            "gcp_network_endpoint_group",
-            "gcp_machine_type",
-            "gcp_instance_group",
-            "gcp_instance",
-            "gcp_disk_type",
-            "gcp_disk",
             "gcp_database",
+            "gcp_disk",
+            "gcp_disk_type",
+            "gcp_instance",
+            "gcp_instance_group",
+            "gcp_machine_type",
+            "gcp_network_endpoint_group",
+            "gcp_security_policy",
+            "gcp_gke_cluster",
         ],
         "delete": [],
     }
@@ -161,14 +163,16 @@ class GCPRegion(GCPResource, BaseRegion):
     kind: ClassVar[str] = "gcp_region"
     successor_kinds: ClassVar[Dict[str, List[str]]] = {
         "default": [
-            "gcp_zone",
-            "gcp_vpn_tunnel",
-            "gcp_target_vpn_gateway",
-            "gcp_target_pool",
-            "gcp_subnetwork",
-            "gcp_router",
-            "gcp_quota",
+            "gcp_database",
             "gcp_forwarding_rule",
+            "gcp_gke_cluster",
+            "gcp_quota",
+            "gcp_router",
+            "gcp_subnetwork",
+            "gcp_target_pool",
+            "gcp_target_vpn_gateway",
+            "gcp_vpn_tunnel",
+            "gcp_zone",
         ],
         "delete": [],
     }
@@ -260,8 +264,8 @@ GCPDisk.volume_status = property(
 class GCPInstance(GCPResource, BaseInstance):
     kind: ClassVar[str] = "gcp_instance"
     successor_kinds: ClassVar[Dict[str, List[str]]] = {
-        "default": ["gcp_disk"],
-        "delete": ["gcp_target_pool", "gcp_instance_group"],
+        "default": ["gcp_disk", "gcp_ssl_certificate"],
+        "delete": ["gcp_target_pool", "gcp_instance_group", "gcp_target_instance"],
     }
     api_identifier: ClassVar[str] = "instance"
 
@@ -322,22 +326,26 @@ class GCPNetwork(GCPResource, BaseNetwork):
     kind: ClassVar[str] = "gcp_network"
     successor_kinds: ClassVar[Dict[str, List[str]]] = {
         "default": [
-            "gcp_target_vpn_gateway",
-            "gcp_subnetwork",
-            "gcp_router",
-            "gcp_route",
-            "gcp_network_endpoint_group",
-            "gcp_instance_group",
+            "gcp_global_network_endpoint_group",
             "gcp_instance",
+            "gcp_instance_group",
+            "gcp_network_endpoint_group",
+            "gcp_route",
+            "gcp_router",
+            "gcp_subnetwork",
+            "gcp_target_vpn_gateway",
+            "gcp_vpn_gateway",
         ],
         "delete": [
-            "gcp_target_vpn_gateway",
-            "gcp_subnetwork",
-            "gcp_router",
-            "gcp_route",
-            "gcp_network_endpoint_group",
-            "gcp_instance_group",
+            "gcp_global_network_endpoint_group",
             "gcp_instance",
+            "gcp_instance_group",
+            "gcp_network_endpoint_group",
+            "gcp_route",
+            "gcp_router",
+            "gcp_subnetwork",
+            "gcp_target_vpn_gateway",
+            "gcp_vpn_gateway",
         ],
     }
     api_identifier: ClassVar[str] = "network"
@@ -347,8 +355,18 @@ class GCPNetwork(GCPResource, BaseNetwork):
 class GCPSubnetwork(GCPResource, BaseSubnet):
     kind: ClassVar[str] = "gcp_subnetwork"
     successor_kinds: ClassVar[Dict[str, List[str]]] = {
-        "default": ["gcp_network_endpoint_group", "gcp_instance_group", "gcp_instance"],
-        "delete": ["gcp_network_endpoint_group", "gcp_instance_group", "gcp_instance"],
+        "default": [
+            "gcp_global_network_endpoint_group",
+            "gcp_network_endpoint_group",
+            "gcp_instance_group",
+            "gcp_instance",
+        ],
+        "delete": [
+            "gcp_global_network_endpoint_group",
+            "gcp_network_endpoint_group",
+            "gcp_instance_group",
+            "gcp_instance",
+        ],
     }
     api_identifier: ClassVar[str] = "subnetwork"
 
@@ -424,6 +442,10 @@ class GCPSnapshot(GCPResource, BaseSnapshot):
 @dataclass(eq=False)
 class GCPSSLCertificate(GCPResource, BaseCertificate):
     kind: ClassVar[str] = "gcp_ssl_certificate"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": [],
+        "delete": ["gcp_instance", "gcp_target_https_proxy", "gcp_target_ssl_proxy"],
+    }
     api_identifier: ClassVar[str] = "sslCertificate"
 
     description: Optional[str] = None
@@ -437,7 +459,7 @@ class GCPSSLCertificate(GCPResource, BaseCertificate):
 class GCPMachineType(GCPResource, BaseInstanceType):
     kind: ClassVar[str] = "gcp_machine_type"
     successor_kinds: ClassVar[Dict[str, List[str]]] = {
-        "default": ["gcp_instance"],
+        "default": ["gcp_instance", "gcp_instance_template"],
         "delete": [],
     }
     api_identifier: ClassVar[str] = "machineType"
@@ -450,6 +472,10 @@ class GCPMachineType(GCPResource, BaseInstanceType):
 @dataclass(eq=False)
 class GCPNetworkEndpointGroup(GCPResource, BaseResource):
     kind: ClassVar[str] = "gcp_network_endpoint_group"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": [],
+        "delete": ["gcp_backend_service"],
+    }
     api_identifier: ClassVar[str] = "networkEndpointGroup"
 
     default_port: int = -1
@@ -469,8 +495,8 @@ class GCPGlobalNetworkEndpointGroup(GCPResource, BaseResource):
 class GCPInstanceGroup(GCPResource, BaseResource):
     kind: ClassVar[str] = "gcp_instance_group"
     successor_kinds: ClassVar[Dict[str, List[str]]] = {
-        "default": ["gcp_instance"],
-        "delete": ["gcp_backend_service"],
+        "default": ["gcp_instance", "gcp_instance_group_manager"],
+        "delete": ["gcp_backend_service", "gcp_instance_group_manager"],
     }
     api_identifier: ClassVar[str] = "instanceGroup"
 
@@ -478,12 +504,23 @@ class GCPInstanceGroup(GCPResource, BaseResource):
 @dataclass(eq=False)
 class GCPInstanceGroupManager(GCPResource, BaseResource):
     kind: ClassVar[str] = "gcp_instance_group_manager"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": [
+            "gcp_health_check",
+            "gcp_http_health_check",
+            "gcp_https_health_check",
+        ],
+    }
     api_identifier: ClassVar[str] = "instanceGroupManager"
 
 
 @dataclass(eq=False)
 class GCPAutoscaler(GCPResource, BaseAutoScalingGroup):
     kind: ClassVar[str] = "gcp_autoscaler"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["gcp_instance_group_manager"],
+        "delete": ["gcp_instance_group_manager"],
+    }
     api_identifier: ClassVar[str] = "autoscaler"
 
 
@@ -492,14 +529,25 @@ class GCPHealthCheck(GCPResource, BaseHealthCheck):
     kind: ClassVar[str] = "gcp_health_check"
     successor_kinds: ClassVar[Dict[str, List[str]]] = {
         "default": [],
-        "delete": ["gcp_target_pool"],
+        "delete": [
+            "gcp_target_pool",
+            "gcp_backend_service",
+            "gcp_instance_group_manager",
+        ],
     }
     api_identifier: ClassVar[str] = "healthCheck"
 
 
 @dataclass(eq=False)
 class GCPHTTPHealthCheck(GCPResource, BaseHealthCheck):
+    """Deprecated by gcp. GCPHealthCheck is the new standard."""
+
     kind: ClassVar[str] = "gcp_http_health_check"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": [],
+        "delete": ["gcp_backend_service", "gcp_instance_group_manager"],
+    }
+
     api_identifier: ClassVar[str] = "httpHealthCheck"
 
     host: str = ""
@@ -510,12 +558,24 @@ class GCPHTTPHealthCheck(GCPResource, BaseHealthCheck):
 @dataclass(eq=False)
 class GCPHTTPSHealthCheck(GCPHTTPHealthCheck):
     kind: ClassVar[str] = "gcp_https_health_check"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": [],
+        "delete": ["gcp_backend_service", "gcp_instance_group_manager"],
+    }
     api_identifier: ClassVar[str] = "httpsHealthCheck"
 
 
 @dataclass(eq=False)
 class GCPUrlMap(GCPResource, BaseResource):
     kind: ClassVar[str] = "gcp_url_map"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["gcp_backend_service"],
+        "delete": [
+            "gcp_target_http_proxy",
+            "gcp_target_https_proxy",
+            "gcp_target_grpc_proxy",
+        ],
+    }
     api_identifier: ClassVar[str] = "urlMap"
 
 
@@ -524,7 +584,7 @@ class GCPTargetPool(GCPResource, BaseResource):
     kind: ClassVar[str] = "gcp_target_pool"
     successor_kinds: ClassVar[Dict[str, List[str]]] = {
         "default": ["gcp_instance", "gcp_http_health_check"],
-        "delete": ["gcp_forwarding_rule"],
+        "delete": ["gcp_forwarding_rule", "gcp_global_forwarding_rule"],
     }
     api_identifier: ClassVar[str] = "targetPool"
 
@@ -535,6 +595,10 @@ class GCPTargetPool(GCPResource, BaseResource):
 @dataclass(eq=False)
 class GCPTargetHttpProxy(GCPResource, BaseResource):
     kind: ClassVar[str] = "gcp_target_http_proxy"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["gcp_url_map"],
+        "delete": ["gcp_forwarding_rule", "gcp_global_forwarding_rule"],
+    }
     api_identifier: ClassVar[str] = "targetHttpProxy"
 
     def __post_init__(self) -> None:
@@ -546,6 +610,10 @@ class GCPTargetHttpProxy(GCPResource, BaseResource):
 @dataclass(eq=False)
 class GCPTargetHttpsProxy(GCPResource, BaseResource):
     kind: ClassVar[str] = "gcp_target_https_proxy"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["gcp_url_map", "gcp_ssl_certificate"],
+        "delete": ["gcp_forwarding_rule", "gcp_global_forwarding_rule"],
+    }
     api_identifier: ClassVar[str] = "targetHttpsProxy"
 
     def __post_init__(self) -> None:
@@ -557,6 +625,10 @@ class GCPTargetHttpsProxy(GCPResource, BaseResource):
 @dataclass(eq=False)
 class GCPTargetSslProxy(GCPResource, BaseResource):
     kind: ClassVar[str] = "gcp_target_ssl_proxy"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["gcp_backend_service", "gcp_ssl_certificate"],
+        "delete": ["gcp_forwarding_rule", "gcp_global_forwarding_rule"],
+    }
     api_identifier: ClassVar[str] = "targetSslProxy"
 
     def __post_init__(self) -> None:
@@ -569,7 +641,7 @@ class GCPTargetTcpProxy(GCPResource, BaseResource):
     kind: ClassVar[str] = "gcp_target_tcp_proxy"
     successor_kinds: ClassVar[Dict[str, List[str]]] = {
         "default": ["gcp_backend_service"],
-        "delete": ["gcp_forwarding_rule"],
+        "delete": ["gcp_forwarding_rule", "gcp_global_forwarding_rule"],
     }
     api_identifier: ClassVar[str] = "targetTcpProxy"
 
@@ -581,6 +653,10 @@ class GCPTargetTcpProxy(GCPResource, BaseResource):
 @dataclass(eq=False)
 class GCPTargetGrpcProxy(GCPResource, BaseResource):
     kind: ClassVar[str] = "gcp_target_grpc_proxy"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["gcp_url_map"],
+        "delete": ["gcp_forwarding_rule", "gcp_global_forwarding_rule"],
+    }
     api_identifier: ClassVar[str] = "targetGrpcProxy"
 
     def __post_init__(self) -> None:
@@ -591,6 +667,9 @@ class GCPTargetGrpcProxy(GCPResource, BaseResource):
 @dataclass(eq=False)
 class GCPTargetInstance(GCPResource, BaseResource):
     kind: ClassVar[str] = "gcp_target_instance"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["gcp_instance"],
+    }
     api_identifier: ClassVar[str] = "targetInstance"
 
 
@@ -604,8 +683,14 @@ class GCPQuota(GCPResource, BaseQuota):
 class GCPBackendService(GCPResource, BaseResource):
     kind: ClassVar[str] = "gcp_backend_service"
     successor_kinds: ClassVar[Dict[str, List[str]]] = {
-        "default": ["gcp_instance_group", "gcp_health_check"],
-        "delete": ["gcp_target_tcp_proxy"],
+        "default": [
+            "gcp_instance_group",
+            "gcp_network_endpoint_group",
+            "gcp_health_check",
+            "gcp_http_health_check",
+            "gcp_https_health_check",
+        ],
+        "delete": ["gcp_target_tcp_proxy", "gcp_target_ssl_proxy"],
     }
 
     api_identifier: ClassVar[str] = "backendService"
@@ -618,6 +703,10 @@ class GCPForwardingRule(GCPResource, BaseLoadBalancer):
         "default": [
             "gcp_target_vpn_gateway",
             "gcp_target_tcp_proxy",
+            "gcp_target_ssl_proxy",
+            "gcp_target_grpc_proxy",
+            "gcp_target_http_proxy",
+            "gcp_target_https_proxy",
             "gcp_target_pool",
         ],
         "delete": [],
@@ -638,6 +727,18 @@ class GCPForwardingRule(GCPResource, BaseLoadBalancer):
 @dataclass(eq=False)
 class GCPGlobalForwardingRule(GCPForwardingRule):
     kind: ClassVar[str] = "gcp_global_forwarding_rule"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": [
+            "gcp_target_vpn_gateway",
+            "gcp_target_tcp_proxy",
+            "gcp_target_ssl_proxy",
+            "gcp_target_grpc_proxy",
+            "gcp_target_http_proxy",
+            "gcp_target_https_proxy",
+            "gcp_target_pool",
+        ],
+        "delete": [],
+    }
     api_identifier: ClassVar[str] = "globalForwardingRule"
 
 

--- a/plugins/gcp/resoto_plugin_gcp/resources.py
+++ b/plugins/gcp/resoto_plugin_gcp/resources.py
@@ -117,6 +117,10 @@ class GCPProject(GCPResource, BaseAccount):
     successor_kinds: ClassVar[Dict[str, List[str]]] = {
         "default": [
             "gcp_target_tcp_proxy",
+            "gcp_target_ssl_proxy",
+            "gcp_target_http_proxy",
+            "gcp_target_https_proxy",
+            "gcp_target_grpc_proxy",
             "gcp_subnetwork",
             "gcp_ssl_certificate",
             "gcp_snapshot",
@@ -141,6 +145,7 @@ class GCPZone(GCPResource, BaseZone):
     kind: ClassVar[str] = "gcp_zone"
     successor_kinds: ClassVar[Dict[str, List[str]]] = {
         "default": [
+            "gcp_autoscaler",
             "gcp_database",
             "gcp_disk",
             "gcp_disk_type",
@@ -163,14 +168,26 @@ class GCPRegion(GCPResource, BaseRegion):
     kind: ClassVar[str] = "gcp_region"
     successor_kinds: ClassVar[Dict[str, List[str]]] = {
         "default": [
+            "gcp_autoscaler",
+            "gcp_backend_service",
             "gcp_database",
+            "gcp_disk",
+            "gcp_disk_type",
             "gcp_forwarding_rule",
             "gcp_gke_cluster",
+            "gcp_health_check",
+            "gcp_instance_group",
+            "gcp_instance_group_manager",
+            "gcp_network_endpoint_group",
             "gcp_quota",
             "gcp_router",
+            "gcp_ssl_certificate",
             "gcp_subnetwork",
+            "gcp_target_http_proxy",
+            "gcp_target_https_proxy",
             "gcp_target_pool",
             "gcp_target_vpn_gateway",
+            "gcp_url_map",
             "gcp_vpn_tunnel",
             "gcp_zone",
         ],
@@ -444,7 +461,7 @@ class GCPSSLCertificate(GCPResource, BaseCertificate):
     kind: ClassVar[str] = "gcp_ssl_certificate"
     successor_kinds: ClassVar[Dict[str, List[str]]] = {
         "default": [],
-        "delete": ["gcp_instance", "gcp_target_https_proxy", "gcp_target_ssl_proxy"],
+        "delete": ["gcp_instance", "gcp_target_https_proxy", "gcp_target_ssl_proxy", "gcp_target_grpc_proxy"],
     }
     api_identifier: ClassVar[str] = "sslCertificate"
 
@@ -560,7 +577,7 @@ class GCPHTTPSHealthCheck(GCPHTTPHealthCheck):
     kind: ClassVar[str] = "gcp_https_health_check"
     successor_kinds: ClassVar[Dict[str, List[str]]] = {
         "default": [],
-        "delete": ["gcp_backend_service", "gcp_instance_group_manager"],
+        "delete": ["gcp_backend_service", "gcp_instance_group_manager", "gcp_target_pool"],
     }
     api_identifier: ClassVar[str] = "httpsHealthCheck"
 
@@ -583,7 +600,7 @@ class GCPUrlMap(GCPResource, BaseResource):
 class GCPTargetPool(GCPResource, BaseResource):
     kind: ClassVar[str] = "gcp_target_pool"
     successor_kinds: ClassVar[Dict[str, List[str]]] = {
-        "default": ["gcp_instance", "gcp_http_health_check"],
+        "default": ["gcp_instance", "gcp_http_health_check", "gcp_https_health_check"],
         "delete": ["gcp_forwarding_rule", "gcp_global_forwarding_rule"],
     }
     api_identifier: ClassVar[str] = "targetPool"
@@ -612,7 +629,7 @@ class GCPTargetHttpsProxy(GCPResource, BaseResource):
     kind: ClassVar[str] = "gcp_target_https_proxy"
     successor_kinds: ClassVar[Dict[str, List[str]]] = {
         "default": ["gcp_url_map", "gcp_ssl_certificate"],
-        "delete": ["gcp_forwarding_rule", "gcp_global_forwarding_rule"],
+        "delete": ["gcp_forwarding_rule", "gcp_global_forwarding_rule", "gcp_backend_service"],
     }
     api_identifier: ClassVar[str] = "targetHttpsProxy"
 
@@ -654,7 +671,7 @@ class GCPTargetTcpProxy(GCPResource, BaseResource):
 class GCPTargetGrpcProxy(GCPResource, BaseResource):
     kind: ClassVar[str] = "gcp_target_grpc_proxy"
     successor_kinds: ClassVar[Dict[str, List[str]]] = {
-        "default": ["gcp_url_map"],
+        "default": ["gcp_url_map", "gcp_ssl_certificate"],
         "delete": ["gcp_forwarding_rule", "gcp_global_forwarding_rule"],
     }
     api_identifier: ClassVar[str] = "targetGrpcProxy"
@@ -688,6 +705,7 @@ class GCPBackendService(GCPResource, BaseResource):
             "gcp_network_endpoint_group",
             "gcp_health_check",
             "gcp_http_health_check",
+            "gcp_https_health_check",
             "gcp_https_health_check",
         ],
         "delete": ["gcp_target_tcp_proxy", "gcp_target_ssl_proxy"],

--- a/plugins/slack/resoto_plugin_slack/resources.py
+++ b/plugins/slack/resoto_plugin_slack/resources.py
@@ -22,6 +22,10 @@ class SlackResource:
 @dataclass(eq=False)
 class SlackTeam(SlackResource, BaseAccount):
     kind: ClassVar[str] = "slack_team"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["slack_region"],
+        "delete": [],
+    }
     domain: str = None
     email_domain: str = None
     icon: str = None
@@ -41,6 +45,10 @@ class SlackTeam(SlackResource, BaseAccount):
 @dataclass(eq=False)
 class SlackRegion(SlackResource, BaseRegion):
     kind = "slack_region"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["slack_usergroup", "slack_user", "slack_conversation"],
+        "delete": [],
+    }
 
 
 @dataclass(eq=False)
@@ -133,6 +141,10 @@ class SlackUser(SlackResource, BaseUser):
 @dataclass(eq=False)
 class SlackUsergroup(SlackResource, BaseGroup):
     kind: ClassVar[str] = "slack_usergroup"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["slack_user"],
+        "delete": [],
+    }
 
     auto_provision: bool = None
     auto_type: Optional[str] = None
@@ -179,6 +191,10 @@ class SlackUsergroup(SlackResource, BaseGroup):
 @dataclass(eq=False)
 class SlackConversation(SlackResource, BaseResource):
     kind: ClassVar[str] = "slack_conversation"
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {
+        "default": ["slack_user"],
+        "delete": [],
+    }
 
     creator: Optional[str] = None
     is_archived: bool = None

--- a/resotocore/resotocore/model/model.py
+++ b/resotocore/resotocore/model/model.py
@@ -252,7 +252,8 @@ class Kind(ABC):
             props = list(map(lambda p: from_js(p, Property), js.get("properties", [])))
             bases: Optional[List[str]] = js.get("bases")
             allow_unknown_props = js.get("allow_unknown_props", False)
-            return ComplexKind(js["fqn"], bases if bases else [], props, allow_unknown_props)
+            successor_kinds = js.get("successor_kinds")
+            return ComplexKind(js["fqn"], bases if bases else [], props, allow_unknown_props, successor_kinds)
         else:
             raise JSONDecodeError("Given type can not be read.", json.dumps(js), 0)
 
@@ -732,11 +733,20 @@ class DictionaryKind(Kind):
 
 
 class ComplexKind(Kind):
-    def __init__(self, fqn: str, bases: List[str], properties: List[Property], allow_unknown_props: bool = False):
+    def __init__(
+        self,
+        fqn: str,
+        bases: List[str],
+        properties: List[Property],
+        allow_unknown_props: bool = False,
+        # EdgeType -> possible list of successor kinds
+        successor_kinds: Optional[Dict[str, List[str]]] = None,
+    ):
         super().__init__(fqn)
         self.bases = bases
         self.properties = properties
         self.allow_unknown_props = allow_unknown_props
+        self.successor_kinds = successor_kinds
         self.__prop_by_name = {prop.name: prop for prop in properties}
         self.__resolved = False
         self.__resolved_kinds: Dict[str, Tuple[Property, Kind]] = {}

--- a/resotocore/resotocore/model/model.py
+++ b/resotocore/resotocore/model/model.py
@@ -746,7 +746,7 @@ class ComplexKind(Kind):
         self.bases = bases
         self.properties = properties
         self.allow_unknown_props = allow_unknown_props
-        self.successor_kinds = successor_kinds
+        self.successor_kinds = successor_kinds or {}
         self.__prop_by_name = {prop.name: prop for prop in properties}
         self.__resolved = False
         self.__resolved_kinds: Dict[str, Tuple[Property, Kind]] = {}
@@ -766,6 +766,12 @@ class ComplexKind(Kind):
 
             # property path -> kind
             self.__property_by_path = ComplexKind.resolve_properties(self)
+
+            # make sure all successor kinds can be resolved
+            for names in self.successor_kinds.values():
+                for name in names or []:
+                    if name not in model:
+                        raise AttributeError(f"{name} is not a known kind")
 
             # resolve the hierarchy
             if not self.is_root():
@@ -787,6 +793,7 @@ class ComplexKind(Kind):
                 and self.properties == other.properties
                 and self.bases == other.bases
                 and self.allow_unknown_props == other.allow_unknown_props
+                and self.successor_kinds == other.successor_kinds
             )
         else:
             return False

--- a/resotocore/resotocore/model/model_handler.py
+++ b/resotocore/resotocore/model/model_handler.py
@@ -128,7 +128,7 @@ class ModelHandlerDB(ModelHandler):
 
         def class_node(cpx: ComplexKind) -> str:
             props = "\n".join([f"**{p.name}**: {p.kind}" for p in cpx.properties]) if with_properties else ""
-            link = " [[#{cpx.fqn}]]" if link_classes else ""
+            link = f" [[#{cpx.fqn}]]" if link_classes else ""
             return f"class {cpx.fqn}{link} {{\n{props}\n}}"
 
         def descendants(cpx: ComplexKind) -> Set[str]:

--- a/resotocore/resotocore/model/model_handler.py
+++ b/resotocore/resotocore/model/model_handler.py
@@ -2,7 +2,7 @@ import logging
 import re
 from abc import ABC, abstractmethod
 from functools import reduce
-from typing import Optional, List, Set
+from typing import Optional, List, Set, Callable
 
 from plantuml import PlantUML
 
@@ -22,18 +22,54 @@ class ModelHandler(ABC):
     @abstractmethod
     async def uml_image(
         self,
-        show_packages: Optional[List[str]] = None,
-        hide_packages: Optional[List[str]] = None,
         output: str = "svg",
         *,
-        with_bases: bool = False,
-        with_descendants: bool = False,
+        show_packages: Optional[List[str]] = None,
+        hide_packages: Optional[List[str]] = None,
+        with_inheritance: bool = True,
+        with_base_classes: bool = False,
+        with_subclasses: bool = False,
+        dependency_edges: Optional[Set[str]] = None,
+        with_predecessors: bool = False,
+        with_successors: bool = False,
     ) -> bytes:
-        pass
+        """
+        Generate a PlantUML image of the model.
+
+        :param output: "svg" or "png"
+        :param show_packages: regexp that matches packages to show
+        :param hide_packages: regexp that matches packages to hide
+        :param with_inheritance: draw inheritance relationship between classes
+        :param with_base_classes: include base classes for all matching classes to show in the diagram
+        :param with_subclasses: include subclasses for all matching classes to show in the diagram
+        :param dependency_edges: draw dependency edges of given edge type between classes
+        :param with_predecessors: include predecessors for all matching classes to show in the diagram
+        :param with_successors: include successors for all matching classes to show in the diagram
+        :return: the generated image
+        """
 
     @abstractmethod
     async def update_model(self, kinds: List[Kind]) -> Model:
         pass
+
+
+PlantUmlAttrs = (
+    "hide empty members\n"
+    "skinparam ArrowColor #ffaf37\n"
+    "skinparam ArrowThickness 2\n"
+    "skinparam BackgroundColor transparent\n"
+    "skinparam ClassAttributeFontColor #d9b8ff\n"
+    "skinparam ClassBackgroundColor #3d176e\n"
+    "skinparam ClassBorderColor #000d19\n"
+    "skinparam ClassFontColor #d9b8ff\n"
+    "skinparam ClassFontName Helvetica\n"
+    "skinparam ClassFontSize 17\n"
+    "skinparam Padding 5\n"
+    "skinparam RoundCorner 5\n"
+    "skinparam Shadowing false\n"
+    "skinparam stereotypeCBackgroundColor #e98df7\n"
+    "skinparam stereotypeIBackgroundColor #e98df7\n"
+)
 
 
 class ModelHandlerDB(ModelHandler):
@@ -53,18 +89,27 @@ class ModelHandlerDB(ModelHandler):
 
     async def uml_image(
         self,
-        show_packages: Optional[List[str]] = None,
-        hide_packages: Optional[List[str]] = None,
         output: str = "svg",
         *,
-        with_bases: bool = False,
-        with_descendants: bool = False,
+        show_packages: Optional[List[str]] = None,
+        hide_packages: Optional[List[str]] = None,
+        with_inheritance: bool = True,
+        with_base_classes: bool = False,
+        with_subclasses: bool = False,
+        dependency_edges: Optional[Set[str]] = None,
+        with_predecessors: bool = False,
+        with_successors: bool = False,
     ) -> bytes:
+        allowed_edge_types: Set[str] = dependency_edges or set()
         assert output in ("svg", "png"), "Only svg and png is supported!"
         model = await self.load_model()
         graph = model.graph()
         show = [re.compile(s) for s in show_packages] if show_packages else None
         hide = [re.compile(s) for s in hide_packages] if hide_packages else None
+
+        def not_hidden(key: str) -> bool:
+            k: Kind = graph.nodes[key]["data"]
+            return not (hide and exist(lambda r: r.fullmatch(k.fqn), hide))
 
         def node_visible(key: str) -> bool:
             k: Kind = graph.nodes[key]["data"]
@@ -79,43 +124,53 @@ class ModelHandlerDB(ModelHandler):
             props = "\n".join([f"**{p.name}**: {p.kind}" for p in cpx.properties])
             return f"class {cpx.fqn} {{\n{props}\n}}"
 
-        def class_inheritance(from_node: str, to_node: str) -> str:
-            return f"{to_node} <|--- {from_node}"
+        def descendants(cpx: ComplexKind) -> Set[str]:
+            return {kind.fqn for kind in model.complex_kinds() if cpx.fqn in kind.kind_hierarchy()}
 
-        def descendants(fqn: str) -> Set[str]:
-            return {kind.fqn for kind in model.complex_kinds() if fqn in kind.kind_hierarchy()}
+        def predecessors(cpx: ComplexKind) -> Set[str]:
+            return {
+                kind.fqn
+                for kind in model.complex_kinds()
+                for et in allowed_edge_types
+                if cpx.fqn in kind.successor_kinds.get(et, [])
+            }
+
+        def successors(cpx: ComplexKind) -> Set[str]:
+            return (
+                {kind for et in allowed_edge_types for kind in cpx.successor_kinds.get(et, [])}
+                if isinstance(cpx, ComplexKind)
+                else set()
+            )
 
         visible_kinds = [node["data"] for nid, node in graph.nodes(data=True) if node_visible(nid)]
         visible = {v.fqn for v in visible_kinds}
-        if with_bases:
-            bases: Set[str] = reduce(lambda res, cpl: res.union(cpl.kind_hierarchy()), visible_kinds, set())
-            visible.update(bases)
-        if with_descendants:
-            desc: Set[str] = reduce(lambda res, cpl: res.union(descendants(cpl.fqn)), visible_kinds, set())
-            visible.update(desc)
 
-        params = (
-            "hide empty members\n"
-            "skinparam ArrowColor #ffaf37\n"
-            "skinparam ArrowThickness 2\n"
-            "skinparam BackgroundColor transparent\n"
-            "skinparam ClassAttributeFontColor #d9b8ff\n"
-            "skinparam ClassBackgroundColor #3d176e\n"
-            "skinparam ClassBorderColor #000d19\n"
-            "skinparam ClassFontColor #d9b8ff\n"
-            "skinparam ClassFontName Helvetica\n"
-            "skinparam ClassFontSize 17\n"
-            "skinparam Padding 5\n"
-            "skinparam RoundCorner 5\n"
-            "skinparam Shadowing false\n"
-            "skinparam stereotypeCBackgroundColor #e98df7\n"
-            "skinparam stereotypeIBackgroundColor #e98df7\n"
-        )
+        def add_visible(fn: Callable[[ComplexKind], Set[str]]) -> None:
+            selected: Set[str] = reduce(lambda res, cpl: res.union(fn(cpl)), visible_kinds, set())
+            visible.update(n for n in selected if not_hidden(n))
+
+        if with_base_classes:
+            add_visible(lambda cpl: cpl.kind_hierarchy())
+        if with_subclasses:
+            add_visible(descendants)
+        if with_predecessors:
+            add_visible(predecessors)
+        if with_successors:
+            add_visible(successors)
 
         nodes = "\n".join([class_node(node["data"]) for nid, node in graph.nodes(data=True) if nid in visible])
-        edges = "\n".join([class_inheritance(fr, to) for fr, to in graph.edges() if fr in visible and to in visible])
+        edges = ""
+        for fr, to, data in graph.edges(data=True):
+            if fr in visible and to in visible:
+                if with_inheritance and data["type"] == "inheritance":
+                    edges += f"{fr} <|--- {to}\n"
+                elif data["type"] == "successor" and data["edge_type"] in allowed_edge_types:
+                    edges += f"{fr} -[#1A83AF]-> {to}\n"
+                else:
+                    print("NOT VISIBLE: ", fr, to, data)
+
         puml = PlantUML(f"{self.plantuml_server}/{output}/")
-        return await run_async(puml.processes, f"@startuml\n{params}\n{nodes}\n{edges}\n@enduml")  # type: ignore
+        return await run_async(puml.processes, f"@startuml\n{PlantUmlAttrs}\n{nodes}\n{edges}\n@enduml")  # type: ignore
 
     async def update_model(self, kinds: List[Kind]) -> Model:
         # load existing model

--- a/resotocore/resotocore/model/model_handler.py
+++ b/resotocore/resotocore/model/model_handler.py
@@ -163,7 +163,7 @@ class ModelHandlerDB(ModelHandler):
         for fr, to, data in graph.edges(data=True):
             if fr in visible and to in visible:
                 if with_inheritance and data["type"] == "inheritance":
-                    edges += f"{fr} <|--- {to}\n"
+                    edges += f"{to} <|--- {fr}\n"
                 elif data["type"] == "successor" and data["edge_type"] in allowed_edge_types:
                     edges += f"{fr} -[#1A83AF]-> {to}\n"
                 else:

--- a/resotocore/resotocore/model/model_handler.py
+++ b/resotocore/resotocore/model/model_handler.py
@@ -32,6 +32,7 @@ class ModelHandler(ABC):
         dependency_edges: Optional[Set[str]] = None,
         with_predecessors: bool = False,
         with_successors: bool = False,
+        with_properties: bool = True,
     ) -> bytes:
         """
         Generate a PlantUML image of the model.
@@ -45,6 +46,7 @@ class ModelHandler(ABC):
         :param dependency_edges: draw dependency edges of given edge type between classes
         :param with_predecessors: include predecessors for all matching classes to show in the diagram
         :param with_successors: include successors for all matching classes to show in the diagram
+        :param with_properties: include properties for all matching classes to show in the diagram
         :return: the generated image
         """
 
@@ -99,6 +101,7 @@ class ModelHandlerDB(ModelHandler):
         dependency_edges: Optional[Set[str]] = None,
         with_predecessors: bool = False,
         with_successors: bool = False,
+        with_properties: bool = True,
     ) -> bytes:
         allowed_edge_types: Set[str] = dependency_edges or set()
         assert output in ("svg", "png"), "Only svg and png is supported!"
@@ -121,7 +124,7 @@ class ModelHandlerDB(ModelHandler):
                 return exist(lambda r: r.fullmatch(k.fqn), show)
 
         def class_node(cpx: ComplexKind) -> str:
-            props = "\n".join([f"**{p.name}**: {p.kind}" for p in cpx.properties])
+            props = "\n".join([f"**{p.name}**: {p.kind}" for p in cpx.properties]) if with_properties else ""
             return f"class {cpx.fqn} {{\n{props}\n}}"
 
         def descendants(cpx: ComplexKind) -> Set[str]:

--- a/resotocore/resotocore/static/api-doc.yaml
+++ b/resotocore/resotocore/static/api-doc.yaml
@@ -148,6 +148,12 @@ paths:
           schema:
             type: boolean
             default: true
+        - name: link_classes
+          description: Add anchor links to classes.
+          in: query
+          schema:
+            type: boolean
+            default: false
       responses:
         "200":
           description: "Returns the model as uml diagram in svg format"

--- a/resotocore/resotocore/static/api-doc.yaml
+++ b/resotocore/resotocore/static/api-doc.yaml
@@ -2385,14 +2385,29 @@ components:
       allOf:
         - $ref: '#/components/schemas/KindBase'
       properties:
-        base:
-          type: string
-          description: "In case of inheritance, this defines the base kind."
+        bases:
+          type: array
+          items:
+            type: string
+          description: "In case of inheritance, this defines the base kinds."
         properties:
           type: array
           description: "Defines all properties of this complex kind"
           items:
             $ref: '#/components/schemas/Property'
+        allow_unknown_props:
+          type: boolean
+          default: False
+          description: "In case properties are accepted, that are not listed in the model"
+        successor_kinds:
+          description: "Dictionary of successor kinds."
+          example: |
+            { "default": ["kind1", "kind2"], "delete": ["kind3"] }
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
     StringDictKind:
       type: object
       description: "A simple dictionary where all keys and values are strings"
@@ -2501,6 +2516,8 @@ components:
           description: Indicates, if the argument expects a value.
         possible_values:
           type: array
+          items:
+            type: string
           description: Possible values for this argument.
         can_occur_multiple_times:
           type: boolean

--- a/resotocore/resotocore/static/api-doc.yaml
+++ b/resotocore/resotocore/static/api-doc.yaml
@@ -142,6 +142,12 @@ paths:
           schema:
             type: boolean
             default: false
+        - name: with_properties
+          description: Show properties of selected entries
+          in: query
+          schema:
+            type: boolean
+            default: true
       responses:
         "200":
           description: "Returns the model as uml diagram in svg format"

--- a/resotocore/resotocore/static/api-doc.yaml
+++ b/resotocore/resotocore/static/api-doc.yaml
@@ -75,6 +75,16 @@ paths:
       tags:
         - model
       parameters:
+        - name: output
+          description: The output format.
+          in: query
+          schema:
+            type: string
+            enum:
+              - svg
+              - png
+            default: svg
+          required: false
         - name: show
           description: comma separated list of resources to show. Entries can be regexps.
           in: query
@@ -93,14 +103,41 @@ paths:
           required: false
           explode: false
           example: aws_ec2_instance,gcp.*
-        - name: with_bases
+        - name: with_inheritance
+          description: Include inheritance relations in the model.
+          in: query
+          schema:
+            type: boolean
+            default: true
+        - name: with_base_classes
           description: Include all base classes of visible entries
           in: query
           schema:
             type: boolean
             default: true
-        - name: with_descendants
+        - name: with_subclasses
           description: Include all descendant classes of visible entries
+          in: query
+          schema:
+            type: boolean
+            default: false
+        - name: dependency
+          description: |
+            comma separated list of dependency relationships.
+          in: query
+          schema:
+            type: string
+          required: false
+          explode: false
+          example: default
+        - name: with_predecessors
+          description: Include all predecessors of selected entries
+          in: query
+          schema:
+            type: boolean
+            default: false
+        - name: with_successors
+          description: Include all successors of selected entries
           in: query
           schema:
             type: boolean

--- a/resotocore/resotocore/web/api.py
+++ b/resotocore/resotocore/web/api.py
@@ -553,6 +553,7 @@ class Api:
         dependency = set(request.query["dependency"].split(",")) if "dependency" in request.query else None
         with_predecessors = request.query.get("with_predecessors", "false") != "false"
         with_successors = request.query.get("with_successors", "false") != "false"
+        with_properties = request.query.get("with_properties", "true") != "false"
         result = await self.model_handler.uml_image(
             output=output,
             show_packages=show,
@@ -563,6 +564,7 @@ class Api:
             dependency_edges=dependency,
             with_predecessors=with_predecessors,
             with_successors=with_successors,
+            with_properties=with_properties,
         )
         response = web.StreamResponse()
         mt = {"svg": "image/svg+xml", "png": "image/png"}

--- a/resotocore/resotocore/web/api.py
+++ b/resotocore/resotocore/web/api.py
@@ -554,6 +554,7 @@ class Api:
         with_predecessors = request.query.get("with_predecessors", "false") != "false"
         with_successors = request.query.get("with_successors", "false") != "false"
         with_properties = request.query.get("with_properties", "true") != "false"
+        link_classes = request.query.get("link_classes", "false") != "false"
         result = await self.model_handler.uml_image(
             output=output,
             show_packages=show,

--- a/resotocore/resotocore/web/api.py
+++ b/resotocore/resotocore/web/api.py
@@ -544,15 +544,29 @@ class Api:
         return web.json_response([wt_to_js(ot) for ot in self.worker_task_queue.outstanding_tasks.values()])
 
     async def model_uml(self, request: Request) -> StreamResponse:
+        output = request.query.get("output", "svg")
         show = request.query["show"].split(",") if "show" in request.query else None
         hide = request.query["hide"].split(",") if "hide" in request.query else None
-        with_bases = request.query.get("with_bases", "true") != "false"
-        with_descendants = request.query.get("with_descendants", "false") != "false"
+        with_inheritance = request.query.get("with_inheritance", "true") != "false"
+        with_base_classes = request.query.get("with_base_classes", "true") != "false"
+        with_subclasses = request.query.get("with_subclasses", "false") != "false"
+        dependency = set(request.query["dependency"].split(",")) if "dependency" in request.query else None
+        with_predecessors = request.query.get("with_predecessors", "false") != "false"
+        with_successors = request.query.get("with_successors", "false") != "false"
         result = await self.model_handler.uml_image(
-            show, hide, with_bases=with_bases, with_descendants=with_descendants
+            output=output,
+            show_packages=show,
+            hide_packages=hide,
+            with_inheritance=with_inheritance,
+            with_base_classes=with_base_classes,
+            with_subclasses=with_subclasses,
+            dependency_edges=dependency,
+            with_predecessors=with_predecessors,
+            with_successors=with_successors,
         )
         response = web.StreamResponse()
-        response.headers["Content-Type"] = "image/svg+xml"
+        mt = {"svg": "image/svg+xml", "png": "image/png"}
+        response.headers["Content-Type"] = mt[output]
         await response.prepare(request)
         await response.write_eof(result)
         return response

--- a/resotocore/resotocore/web/api.py
+++ b/resotocore/resotocore/web/api.py
@@ -566,6 +566,7 @@ class Api:
             with_predecessors=with_predecessors,
             with_successors=with_successors,
             with_properties=with_properties,
+            link_classes=link_classes,
         )
         response = web.StreamResponse()
         mt = {"svg": "image/svg+xml", "png": "image/png"}

--- a/resotocore/tests/resotocore/cli/command_test.py
+++ b/resotocore/tests/resotocore/cli/command_test.py
@@ -528,6 +528,8 @@ async def test_kinds_command(cli: CLI, foo_model: Model) -> None:
             "some_int": "int32",
             "some_string": "string",
         },
+        "predecessors": [],
+        "successors": ["bla"],
     }
     result = await cli.execute_cli_command("kind string", stream.list)
     assert result[0][0] == {"name": "string", "runtime_kind": "string"}

--- a/resotocore/tests/resotocore/db/graphdb_test.py
+++ b/resotocore/tests/resotocore/db/graphdb_test.py
@@ -193,6 +193,7 @@ def foo_kinds() -> List[Kind]:
             Property("ctime", "datetime"),
             Property("age", "trafo.duration_to_datetime", False, SyntheticProperty(["ctime"])),
         ],
+        successor_kinds={EdgeType.default: ["bla"]},
     )
     bla = ComplexKind(
         "bla",
@@ -203,6 +204,7 @@ def foo_kinds() -> List[Kind]:
             Property("f", "int32"),
             Property("g", "int32[]"),
         ],
+        successor_kinds={EdgeType.default: ["bla"]},
     )
     cloud = ComplexKind("cloud", ["foo"], [])
     account = ComplexKind("account", ["foo"], [])

--- a/resotocore/tests/resotocore/model/__init__.py
+++ b/resotocore/tests/resotocore/model/__init__.py
@@ -24,6 +24,7 @@ class ModelHandlerStatic(ModelHandler):
         with_predecessors: bool = False,
         with_successors: bool = False,
         with_properties: bool = True,
+        link_classes: bool = False,
     ) -> bytes:
         raise NotImplemented
 

--- a/resotocore/tests/resotocore/model/__init__.py
+++ b/resotocore/tests/resotocore/model/__init__.py
@@ -23,6 +23,7 @@ class ModelHandlerStatic(ModelHandler):
         dependency_edges: Optional[Set[str]] = None,
         with_predecessors: bool = False,
         with_successors: bool = False,
+        with_properties: bool = True,
     ) -> bytes:
         raise NotImplemented
 

--- a/resotocore/tests/resotocore/model/__init__.py
+++ b/resotocore/tests/resotocore/model/__init__.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import Optional, List, Set
 
 from resotocore.model.model import Model, Kind
 from resotocore.model.model_handler import ModelHandler
@@ -13,12 +13,16 @@ class ModelHandlerStatic(ModelHandler):
 
     async def uml_image(
         self,
-        show_packages: Optional[List[str]] = None,
-        hide_packages: Optional[List[str]] = None,
         output: str = "svg",
         *,
-        with_bases: bool = False,
-        with_descendants: bool = False,
+        show_packages: Optional[List[str]] = None,
+        hide_packages: Optional[List[str]] = None,
+        with_inheritance: bool = True,
+        with_base_classes: bool = False,
+        with_subclasses: bool = False,
+        dependency_edges: Optional[Set[str]] = None,
+        with_predecessors: bool = False,
+        with_successors: bool = False,
     ) -> bytes:
         raise NotImplemented
 

--- a/resotocore/tests/resotocore/model/model_test.py
+++ b/resotocore/tests/resotocore/model/model_test.py
@@ -11,6 +11,7 @@ from networkx import DiGraph
 
 from resotocore.cli.model import CLIContext
 from resotocore.console_renderer import ConsoleRenderer, ConsoleColorSystem
+from resotocore.model.graph_access import EdgeType
 from resotocore.model.model import (
     StringKind,
     Kind,
@@ -49,19 +50,19 @@ def test_json_marshalling() -> None:
     roundtrip(ArrayKind(StringKind("string")), Kind)
     roundtrip(Property("foo", "foo"), Property)
     roundtrip(Property("age", "trafo.duration_to_datetime", False, SyntheticProperty(["ctime"])), Property)
-    roundtrip(
-        ComplexKind(
-            "Test",
-            ["Base"],
-            [
-                Property("array", "string[]"),
-                Property("s", "float"),
-                Property("i", "int32"),
-                Property("other", "SomeComposite"),
-            ],
-        ),
-        Kind,
-    )
+    props = [
+        Property("array", "string[]"),
+        Property("s", "float"),
+        Property("i", "int32"),
+        Property("other", "SomeComposite"),
+    ]
+    successor_kinds = {
+        EdgeType.default: ["Base", "Test"],
+        EdgeType.delete: ["Base"],
+    }
+    roundtrip(ComplexKind("Test", ["Base"], props), Kind)
+    roundtrip(ComplexKind("Test", [], props, True), Kind)
+    roundtrip(ComplexKind("Test", [], props, True, successor_kinds), Kind)
 
 
 def test_string() -> None:

--- a/resotolib/resotolib/baseresources.py
+++ b/resotolib/resotolib/baseresources.py
@@ -71,17 +71,20 @@ class BaseResource(ABC):
     the resource within the Graph. The name is used for display purposes. Tags are
     key/value pairs that get exported in the GRAPHML view.
 
-    There's also two class variables, kind and phantom.
-    kind is a string describing the type of resource, e.g. 'aws_ec2_instance'
-    or 'some_cloud_load_balancer'.
-    phantom is a bool describing whether or not the resource actually exists within
-    the cloud or if it's just a phantom resource like pricing information or usage
-    quota. I.e. some information relevant to the cloud account but not actually existing
-    in the form of a usable resource.
+    There's also class variables, kind, phantom and successor_kinds.
+    `kind` is a string describing the type of resource, e.g. 'aws_ec2_instance'
+       or 'some_cloud_load_balancer'.
+    `phantom` is a bool describing whether the resource actually exists within
+       the cloud or if it's just a phantom resource like pricing information
+       or usage quota. I.e. some information relevant to the cloud account
+       but not actually existing in the form of a usable resource.
+    `successor_kinds` is a list of kinds that can be connected to this resource for
+       the related edge type.
     """
 
     kind: ClassVar[str] = "resource"
     phantom: ClassVar[bool] = False
+    successor_kinds: ClassVar[Dict[str, List[str]]] = {"default": [], "delete": []}
 
     id: str
     tags: Dict[str, Optional[str]] = None

--- a/resotolib/resotolib/core/model_export.py
+++ b/resotolib/resotolib/core/model_export.py
@@ -2,7 +2,7 @@ from dataclasses import is_dataclass, fields, Field
 from datetime import datetime, date, timedelta, timezone
 from functools import lru_cache, reduce
 from pydoc import locate
-from typing import List, MutableSet, Union, Tuple, Dict, Set, Any, TypeVar
+from typing import List, MutableSet, Union, Tuple, Dict, Set, Any, TypeVar, Type
 from resotolib.baseresources import BaseResource
 from resotolib.utils import type_str, str2timedelta, str2timezone
 from typing import get_args, get_origin
@@ -205,10 +205,11 @@ def dataclasses_to_resotocore_model(
                 "bases": base_names,
                 "properties": props,
                 "allow_unknown_props": allow_unknown_props,
+                "successor_kinds": getattr(clazz, "successor_kinds", None),
             }
         )
 
-    def export_enum(clazz: type) -> None:
+    def export_enum(clazz: Type[Enum]) -> None:
         # The name of the enum literal is taken not the value.
         # This matches jsons handling of enumeration marshalling.
         enum_values = [literal.name for literal in clazz]
@@ -220,7 +221,7 @@ def dataclasses_to_resotocore_model(
         if is_dataclass(cls):
             export_data_class(cls)
         elif is_enum(cls):
-            export_enum(cls)
+            export_enum(cls)  # type: ignore
         else:
             raise AttributeError(f"Don't know how to handle: {cls}")
     return model


### PR DESCRIPTION
# Description

The following changes are included in this PR:

- option to define successors for a given kind in the model
- store and retrieve successor information
- allow successors to be defined in dataclass and export it
- define successors for `aws`, `gcp` and `digitalocean`  resources if applicable.
- add `successors` and `predecessors` to the `kind` output
- add dependency edges in the uml generation


# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
