### PR TITLE
[resotolib][fix] Handle failure to save config after load gracefully

### DIFF
--- a/resotolib/resotolib/config.py
+++ b/resotolib/resotolib/config.py
@@ -144,7 +144,11 @@ class Config(metaclass=MetaConfig):
                 Config.running_config.revision = new_config_revision
             self.init_default_config()
             if self._initial_load:
-                self.save_config()
+                # Try to store the generated config. Handle failure gracefully.
+                try:
+                    self.save_config()
+                except RuntimeError as e:
+                    log.error(f"Failed to save config: {e}")
             self.override_config(Config.running_config)
             self._initial_load = False
             if not self._ce.is_alive():


### PR DESCRIPTION
# Description

Handle failure to save config after load gracefully. This could have multiple harmless causes like the user downgrading resoto. Instead of aborting just log an error so the user can manually fix the config.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
