### PR TITLE
[docker][chore] Use `nano` as default editor in Docker 🤷

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -158,6 +158,7 @@ FROM phusion/baseimage:focal-1.0.0
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG="en_US.UTF-8"
 ENV TERM="xterm-256color"
+ENV EDITOR="nano"
 COPY --from=build-env /usr/local /usr/local
 ENV PATH=/usr/local/python/bin:/usr/local/pypy/bin:/usr/local/db/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 WORKDIR /

--- a/Dockerfile.resotobase
+++ b/Dockerfile.resotobase
@@ -179,6 +179,7 @@ FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG="en_US.UTF-8"
 ENV TERM="xterm-256color"
+ENV EDITOR="nano"
 COPY --from=build-env /usr/local /usr/local
 ENV PATH=/usr/local/python/bin:/usr/local/pypy/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 WORKDIR /


### PR DESCRIPTION
# Description

Use `nano` instead of `vi` as default config editor in Docker image. 🥹🙂

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
