### PR TITLE
[plugins][digitalocean] Use Gb instead of Mb for DO instances

### DIFF
--- a/plugins/digitalocean/resoto_plugin_digitalocean/collector.py
+++ b/plugins/digitalocean/resoto_plugin_digitalocean/collector.py
@@ -505,7 +505,7 @@ class DigitalOceanTeamCollector:
                 "urn": lambda d: droplet_id(d["id"]),
                 "instance_status": "status",
                 "instance_cores": "vcpus",
-                "instance_memory": "memory",
+                "instance_memory": lambda d: d["memory"] / 1024.0,
                 "droplet_backup_ids": lambda d: list(
                     map(str, d.get("backup_ids", []) or [])
                 ),

--- a/plugins/digitalocean/test/test_collector.py
+++ b/plugins/digitalocean/test/test_collector.py
@@ -171,7 +171,7 @@ def test_collect_droplets() -> None:
     droplet = graph.search_first("urn", "do:droplet:289110074")
     assert droplet.urn == "do:droplet:289110074"
     assert droplet.name == "ubuntu-s-1vcpu-1gb-fra1-01"
-    assert droplet.instance_memory == 1024
+    assert droplet.instance_memory == 1
     assert droplet.instance_cores == 1
     assert droplet.instance_status == "running"
     assert droplet.region().urn == "do:region:fra1"


### PR DESCRIPTION
# Description

Changed the DO plugin: droplets use gigabytes instead of megabytes.

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [ ] Add test coverage for new or updated functionality
- [ ] Lint and test with `tox`
- [ ] Document new or updated functionality (someengineering/resoto.com#XXXX)

# Issues Fixed

<!-- If this PR will fix/resolve an open issue on the repository, please reference it below. -->
<!-- (Otherwise, feel free to delete this section.) -->

- Fixes #XXXX

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
