### PR TITLE
[resotocore][fix] Make query parser more strict

### DIFF
--- a/resotocore/resotocore/query/query_parser.py
+++ b/resotocore/resotocore/query/query_parser.py
@@ -72,16 +72,18 @@ from resotocore.query.model import (
 
 operation_p = (
     reduce(
-        lambda x, y: x | y, [lexeme(string(a)) for a in ["<=", ">=", ">", "<", "==", "!=", "=~", "!~", "in", "not in"]]
+        lambda x, y: x | y,
+        [lexeme(string(a)) for a in ["<=", ">=", ">", "<", "==", "!=", "=~", "!~"]],
     )
     | lexeme(string("=")).result("==")
     | lexeme(string("~")).result("=~")
+    | (whitespace >> string("in") << space_dp).desc("in")
+    | (whitespace >> string("not in") << space_dp).desc("not in")
 )
 
 array_modifier_p = reduce(lambda x, y: x | y, [lexeme(string(a)) for a in ["all", "any", "none"]])
 
 function_p = reduce(lambda x, y: x | y, [lexeme(string(a)) for a in ["in_subnet", "has_desired_change", "has_key"]])
-
 
 preamble_prop_p = reduce(lambda x, y: x | y, [lexeme(string(a)) for a in ["edge_type"]])
 

--- a/resotocore/tests/resotocore/query/query_parser_test.py
+++ b/resotocore/tests/resotocore/query/query_parser_test.py
@@ -6,6 +6,7 @@ from dataclasses import replace
 from deepdiff import DeepDiff
 from hypothesis import given, settings, HealthCheck
 
+from resotocore import error
 from tests.resotocore.query import query
 from resotocore.query.model import (
     Navigation,
@@ -305,6 +306,12 @@ def test_with_clause() -> None:
 
     assert_round_trip(with_clause_parser, WithClause(clause_filter, nav, term, WithClause(clause_filter, nav)), edge)
     assert_round_trip(with_clause_parser, WithClause(clause_filter, nav), edge)
+
+
+def test_special_cases() -> None:
+    with pytest.raises(error.ParseError):
+        # parser was able to read: is(instance) and sort in "stance_cores"
+        parse_query("is(instance) and sort instance_cores")
 
 
 @given(query)


### PR DESCRIPTION
# Description

A query like `search is(instance) and sort instance_cores` was read into `search is(instance) and sort in "stance_cores"`.
For the `in` and `not in` operators at least one space is now required.

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
