### PR TITLE
[ci][fix] Properly handle commits without associated PRs in release notes generator

### DIFF
--- a/tools/release_notes.py
+++ b/tools/release_notes.py
@@ -89,7 +89,7 @@ def show_log(from_tag: str, to_tag: str):
             print(
                 f"- [`{commit.commit_hash}`](https://github.com/someengineering/resoto/commit/{commit.commit_hash}) "
                 f'<span class="badge badge--secondary">{commit.component}</span> {commit.message}'
-                f"([#{commit.pr}](https://github.com/someengineering/resoto/pull/{commit.pr}))"
+                f"{f' ([#{commit.pr}](https://github.com/someengineering/resoto/pull/{commit.pr}))' if commit.pr else ''}"
             )
 
     print("\n<!--truncate-->")


### PR DESCRIPTION
# Description

Commits without associated PRs have `(#)` added to the generated release notes.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
