### PR TITLE
[resotocore][fix] search navigation after tail

### DIFF
--- a/resotocore/resotocore/query/query_parser.py
+++ b/resotocore/resotocore/query/query_parser.py
@@ -323,9 +323,9 @@ def part_parser() -> Parser:
     tag = yield tag_parser
     sort = yield sort_parser.optional()
     limit = yield limit_parser.optional()
+    reverse = yield reversed_p
     nav = yield navigation_parser.optional() if term or sort or limit else navigation_parser
     term = term if term else AllTerm()
-    reverse = yield reversed_p
     return Part(term, tag, with_clause, sort if sort else [], limit, nav, reverse)
 
 

--- a/resotocore/tests/resotocore/query/query_parser_test.py
+++ b/resotocore/tests/resotocore/query/query_parser_test.py
@@ -313,6 +313,10 @@ def test_special_cases() -> None:
         # parser was able to read: is(instance) and sort in "stance_cores"
         parse_query("is(instance) and sort instance_cores")
 
+    # parser read the reversed option as separate part, so following query became 3 parts
+    q = parse_query("all sort kind desc limit 1 reversed -default-> all sort kind asc")
+    assert len(q.parts) == 2
+
 
 @given(query)
 @settings(max_examples=50, suppress_health_check=HealthCheck.all())


### PR DESCRIPTION
# Description

```bash
search all | tail -1 | successors
```

Did not execute and threw an errror. Now this search is possible.

