### PR TITLE
[resotocore][feat] format --json prettifies json

### DIFF
--- a/resotocore/resotocore/cli/command.py
+++ b/resotocore/resotocore/cli/command.py
@@ -1937,7 +1937,7 @@ class FormatCommand(CLICommand, OutputTransformer):
 
     formats = {
         "ndjson": respond_ndjson,
-        "json": respond_json,
+        "json": partial(respond_json, indent=2),
         "text": respond_text,
         "yaml": respond_yaml,
         "cytoscape": respond_cytoscape,

--- a/resotocore/resotocore/web/content_renderer.py
+++ b/resotocore/resotocore/web/content_renderer.py
@@ -2,7 +2,7 @@ import json
 import logging
 import re
 from collections import defaultdict
-from typing import AsyncGenerator, List, Dict, AsyncIterator, Tuple, Callable, Optional
+from typing import AsyncGenerator, List, Dict, AsyncIterator, Tuple, Callable, Optional, Any
 
 import yaml
 from aiohttp.web import StreamResponse, Request, Response, json_response
@@ -14,23 +14,17 @@ from resotocore.error import QueryTookToLongError
 from resotocore.model.resolve_in_graph import NodePath
 from resotocore.model.typed_model import to_json
 from resotocore.types import Json, JsonElement
-from resotocore.util import (
-    del_value_in_path,
-    value_in_path,
-    value_in_path_get,
-    count_iterator,
-    identity,
-)
+from resotocore.util import del_value_in_path, value_in_path, value_in_path_get, count_iterator, identity
 
 log = logging.getLogger(__name__)
 
 
-async def respond_json(gen: AsyncIterator[JsonElement]) -> AsyncGenerator[str, None]:
+async def respond_json(gen: AsyncIterator[JsonElement], **json_args: Any) -> AsyncGenerator[str, None]:
     sep = ","
     yield "["
     first = True
     async for item in gen:
-        js = json.dumps(to_json(item))
+        js = json.dumps(to_json(item), **json_args)
         if not first:
             yield sep
         yield js


### PR DESCRIPTION
# Description

JSON format now prettifies the output by indenting the result.

Example:
```bash
> search is(cloud) | tail -1 | format --json
[
{
  "id": "P8N2J8xvGJiuQnRbEI2wtQ",
  "type": "node",
  "revision": "_d3KXGfC--A",
  "metadata": {
    "python_type": "resotolib.baseresources.Cloud",
    "cleaned": false,
    "phantom": false,
    "protected": false,
    "replace": true,
    "descendant_summary": {
      "slack_team": 1,
      "slack_region": 3,
      "slack_user": 4586,
      "slack_usergroup": 81,
      "slack_conversation": 1479
    },
    "descendant_count": 6150
  },
  "reported": {
    "kind": "cloud",
    "id": "slack",
    "tags": {},
    "name": "slack",
    "ctime": "2022-02-24T12:18:49Z",
    "age": "2mo28d"
  }
}
]
```
