### PR TITLE
[resotocore][feat] Send event when usage metrics are turned off

### DIFF
--- a/resotocore/resotocore/__main__.py
+++ b/resotocore/resotocore/__main__.py
@@ -31,14 +31,7 @@ from resotocore.config.core_config_handler import CoreConfigHandler
 from resotocore.core_config import config_from_db, CoreConfig, RunConfig
 from resotocore.db import SystemData
 from resotocore.db.db_access import DbAccess
-from resotocore.dependencies import (
-    db_access,
-    setup_process,
-    parse_args,
-    system_info,
-    reconfigure_logging,
-    event_stream,
-)
+from resotocore.dependencies import db_access, setup_process, parse_args, system_info, reconfigure_logging, event_stream
 from resotocore.error import RestartService
 from resotocore.message_bus import MessageBus
 from resotocore.model.model_handler import ModelHandlerDB
@@ -151,7 +144,7 @@ def with_config(
     task_handler = TaskHandlerService(
         db.running_task_db, db.job_db, message_bus, event_sender, subscriptions, scheduler, cli, config
     )
-    core_config_handler = CoreConfigHandler(config, message_bus, worker_task_queue, config_handler)
+    core_config_handler = CoreConfigHandler(config, message_bus, worker_task_queue, config_handler, event_sender)
     merge_outer_edges_handler = MergeOuterEdgesHandler(message_bus, subscriptions, task_handler, db, model)
     cli_deps.extend(task_handler=task_handler)
     api = Api(

--- a/resotocore/resotocore/analytics/__init__.py
+++ b/resotocore/resotocore/analytics/__init__.py
@@ -36,6 +36,7 @@ class CoreEvent:
     TaskCompleted = "task-handler.task-completed"
     ClientError = "error.client"
     ServerError = "error.server"
+    UsageMetricsTurnedOff = "usage-metrics.turned-off"
 
 
 @dataclass(frozen=True)

--- a/resotocore/resotocore/config/config_handler_service.py
+++ b/resotocore/resotocore/config/config_handler_service.py
@@ -10,7 +10,7 @@ from resotocore.db.modeldb import ModelDb
 from resotocore.message_bus import MessageBus, CoreMessage
 from resotocore.model.model import Model, Kind, ComplexKind
 from resotocore.types import Json
-from resotocore.util import uuid_str
+from resotocore.util import uuid_str, deep_merge
 from resotocore.worker_task_queue import WorkerTaskQueue, WorkerTask, WorkerTaskName
 from resotocore.ids import TaskId, ConfigId
 
@@ -76,7 +76,7 @@ class ConfigHandlerService(ConfigHandler):
     async def patch_config(self, cfg: ConfigEntity) -> ConfigEntity:
         current = await self.cfg_db.get(cfg.id)
         current_config = current.config if current else {}
-        coerced = await self.coerce_and_check_model(cfg.id, {**current_config, **cfg.config})
+        coerced = await self.coerce_and_check_model(cfg.id, deep_merge(current_config, cfg.config))
         result = await self.cfg_db.update(ConfigEntity(cfg.id, coerced, current.revision if current else None))
         await self.message_bus.emit_event(CoreMessage.ConfigUpdated, dict(id=result.id, revision=result.revision))
         return result

--- a/resotocore/resotocore/util.py
+++ b/resotocore/resotocore/util.py
@@ -176,7 +176,7 @@ def if_set(x: Optional[AnyT], func: Callable[[AnyT], Any], if_not: Any = None) -
 
 def value_in_path_get(element: JsonElement, path_or_name: Union[List[str], str], if_none: AnyT) -> AnyT:
     result = value_in_path(element, path_or_name)
-    return result if result and isinstance(result, type(if_none)) else if_none
+    return result if result is not None and isinstance(result, type(if_none)) else if_none
 
 
 def value_in_path(element: JsonElement, path_or_name: Union[List[str], str]) -> Optional[Any]:
@@ -209,7 +209,7 @@ def deep_merge(left: Json, right: Json) -> Json:
             left_value = left_value if isinstance(left_value, dict) else {}
             # noinspection PyTypeChecker
             return deep_merge(left_value, right_value)
-        elif right_value:
+        elif right_value is not None:
             return right_value
         else:
             return left_value

--- a/resotocore/tests/resotocore/config/core_config_handler_test.py
+++ b/resotocore/tests/resotocore/config/core_config_handler_test.py
@@ -3,15 +3,12 @@ import asyncio
 import pytest
 from jsons import DeserializationError
 from pytest import fixture
+from typing_extensions import AsyncIterator
 
-from resotocore.config import ConfigHandler
+from resotocore.analytics import InMemoryEventSender, AnalyticsEvent, CoreEvent
+from resotocore.config import ConfigHandler, ConfigEntity
 from resotocore.config.core_config_handler import CoreConfigHandler
-from resotocore.core_config import (
-    ResotoCoreConfigId,
-    ResotoCoreRoot,
-    ResotoCoreCommandsRoot,
-    CustomCommandsConfig,
-)
+from resotocore.core_config import ResotoCoreConfigId, ResotoCoreRoot, ResotoCoreCommandsRoot, CustomCommandsConfig
 from resotocore.dependencies import empty_config
 from resotocore.message_bus import MessageBus, CoreMessage
 from resotocore.worker_task_queue import WorkerTaskQueue
@@ -29,14 +26,22 @@ config_handler_exits = []
 
 
 @fixture
-def core_config_handler(
+async def core_config_handler(
     message_bus: MessageBus, task_queue: WorkerTaskQueue, config_handler: ConfigHandler
 ) -> CoreConfigHandler:
     def on_exit() -> None:
         config_handler_exits.append(True)
 
     config = empty_config()
-    return CoreConfigHandler(config, message_bus, task_queue, config_handler, on_exit)
+    sender = InMemoryEventSender()
+    return CoreConfigHandler(config, message_bus, task_queue, config_handler, sender, on_exit)
+
+
+@fixture
+async def core_config_handler_started(core_config_handler: CoreConfigHandler) -> AsyncIterator[CoreConfigHandler]:
+    await core_config_handler.start()
+    yield core_config_handler
+    await core_config_handler.stop()
 
 
 @pytest.mark.asyncio
@@ -90,3 +95,19 @@ async def test_validation() -> None:
     pytest.raises(DeserializationError, validate, {"config": {ResotoCoreCommandsRoot: {"commands": 23}}})
     # valid entry can be read
     assert validate({"config": {ResotoCoreCommandsRoot: CustomCommandsConfig().json()}}) is None
+
+
+@pytest.mark.asyncio
+async def test_detect_usage_metrics_turned_off(
+    config_handler: ConfigHandler, core_config_handler_started: CoreConfigHandler
+) -> None:
+    # make sure usage metrics are enabled
+    core_config_handler_started.config.runtime.usage_metrics = True
+    # disable usage metrics
+    await config_handler.patch_config(
+        ConfigEntity(ResotoCoreConfigId, {ResotoCoreRoot: {"runtime": {"usage_metrics": False}}})
+    )
+    await asyncio.sleep(0)
+    events: List[AnalyticsEvent] = core_config_handler_started.event_sender.events  # type: ignore # in-memory sender
+    assert len(events) == 1
+    assert events[0].kind == CoreEvent.UsageMetricsTurnedOff


### PR DESCRIPTION
# Description

When the core config is updated, usage metrics are enabled and are now configured off, send this as last event and restart.

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`
- [x] Document new or updated functionality (someengineering/resoto.com#XXXX)


# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
