### PR TITLE
[resotocore][fix] Allow for empty Discord alert message & move to embed description

### DIFF
--- a/resotocore/resotocore/core_config.py
+++ b/resotocore/resotocore/core_config.py
@@ -181,23 +181,21 @@ def alias_templates() -> List[AliasTemplateConfig]:
     return [
         AliasTemplateConfig(
             "discord",
-            "Send result of a search to discord",
+            "Send the result of a search to Discord",
             # defines the fields to show in the message
             "jq {name:{{key}}, value:{{value}}} | "
             # discord limit: https://discord.com/developers/docs/resources/channel#embed-object-embed-limits
             "chunk 25 | "
             # define the discord webhook json
-            'jq {content: "{{message}}", embeds: [{title: "{{title}}", fields:.}]} | '
+            'jq {embeds: [{title: "{{title}}", description: "{{message}}", fields:.}]} | '
             # call the api
             "http POST {{webhook}}",
             [
-                AliasTemplateParameterConfig("key", "The field of the resource to show as key", ".kind"),
-                AliasTemplateParameterConfig("value", "The field of the resource to show as value", ".name"),
-                AliasTemplateParameterConfig(
-                    "message", "User defined message of the post.", "🔥🔥🔥 Resoto found stuff! 🔥🔥🔥"
-                ),
-                AliasTemplateParameterConfig("title", "The title of the post."),
-                AliasTemplateParameterConfig("webhook", "The complete webhook url.", None),
+                AliasTemplateParameterConfig("key", "Resource field to show as key", ".kind"),
+                AliasTemplateParameterConfig("value", "Resource field to show as value", ".name"),
+                AliasTemplateParameterConfig("message", "Alert message"),
+                AliasTemplateParameterConfig("title", "Alert title"),
+                AliasTemplateParameterConfig("webhook", "Discord Webhook URL"),
             ],
         )
     ]

--- a/resotocore/resotocore/core_config.py
+++ b/resotocore/resotocore/core_config.py
@@ -187,13 +187,14 @@ def alias_templates() -> List[AliasTemplateConfig]:
             # discord limit: https://discord.com/developers/docs/resources/channel#embed-object-embed-limits
             "chunk 25 | "
             # define the discord webhook json
-            'jq {embeds: [{title: "{{title}}", description: "{{message}}", fields:.}]} | '
+            'jq {embeds: [{type: "rich", title: "{{title}}", {{#message}}description: "{{message}}",{{/message}} '
+            'fields:., footer:{text: "Message created by Resoto"}}]} | '
             # call the api
             "http POST {{webhook}}",
             [
                 AliasTemplateParameterConfig("key", "Resource field to show as key", ".kind"),
                 AliasTemplateParameterConfig("value", "Resource field to show as value", ".name"),
-                AliasTemplateParameterConfig("message", "Alert message"),
+                AliasTemplateParameterConfig("message", "Alert message", ""),
                 AliasTemplateParameterConfig("title", "Alert title"),
                 AliasTemplateParameterConfig("webhook", "Discord Webhook URL"),
             ],

--- a/resotocore/tests/resotocore/cli/command_test.py
+++ b/resotocore/tests/resotocore/cli/command_test.py
@@ -844,13 +844,13 @@ async def test_http_command(cli: CLI, echo_http_server: Tuple[int, List[Tuple[Re
 async def test_discord_alias(cli: CLI, echo_http_server: Tuple[int, List[Tuple[Request, Json]]]) -> None:
     port, requests = echo_http_server
     result = await cli.execute_cli_command(
-        f'search is(bla) | discord webhook="http://localhost:{port}/success" title=test', stream.list
+        f'search is(bla) | discord webhook="http://localhost:{port}/success" title=test message="test message"', stream.list
     )
     # 100 times bla, discord allows 25 fields -> 4 requests
     assert result == [["4 requests with status 200 sent."]]
     assert len(requests) == 4
     assert requests[0][1] == {
-        "embeds": [{"title": "test", "fields": [{"name": "bla", "value": "yes or no"} for _ in range(0, 25)]}],
+        "embeds": [{"title": "test", "description": "test message", "fields": [{"name": "bla", "value": "yes or no"} for _ in range(0, 25)]}],
     }
 
 

--- a/resotocore/tests/resotocore/cli/command_test.py
+++ b/resotocore/tests/resotocore/cli/command_test.py
@@ -850,12 +850,15 @@ async def test_discord_alias(cli: CLI, echo_http_server: Tuple[int, List[Tuple[R
     # 100 times bla, discord allows 25 fields -> 4 requests
     assert result == [["4 requests with status 200 sent."]]
     assert len(requests) == 4
+    print(requests[0][1])
     assert requests[0][1] == {
         "embeds": [
             {
+                "type": "rich",
                 "title": "test",
                 "description": "test message",
                 "fields": [{"name": "bla", "value": "yes or no"} for _ in range(0, 25)],
+                "footer": {"text": "Message created by Resoto"},
             }
         ],
     }

--- a/resotocore/tests/resotocore/cli/command_test.py
+++ b/resotocore/tests/resotocore/cli/command_test.py
@@ -850,7 +850,6 @@ async def test_discord_alias(cli: CLI, echo_http_server: Tuple[int, List[Tuple[R
     assert result == [["4 requests with status 200 sent."]]
     assert len(requests) == 4
     assert requests[0][1] == {
-        "content": "🔥🔥🔥 Resoto found stuff! 🔥🔥🔥",
         "embeds": [{"title": "test", "fields": [{"name": "bla", "value": "yes or no"} for _ in range(0, 25)]}],
     }
 

--- a/resotocore/tests/resotocore/cli/command_test.py
+++ b/resotocore/tests/resotocore/cli/command_test.py
@@ -844,13 +844,20 @@ async def test_http_command(cli: CLI, echo_http_server: Tuple[int, List[Tuple[Re
 async def test_discord_alias(cli: CLI, echo_http_server: Tuple[int, List[Tuple[Request, Json]]]) -> None:
     port, requests = echo_http_server
     result = await cli.execute_cli_command(
-        f'search is(bla) | discord webhook="http://localhost:{port}/success" title=test message="test message"', stream.list
+        f'search is(bla) | discord webhook="http://localhost:{port}/success" title=test message="test message"',
+        stream.list,
     )
     # 100 times bla, discord allows 25 fields -> 4 requests
     assert result == [["4 requests with status 200 sent."]]
     assert len(requests) == 4
     assert requests[0][1] == {
-        "embeds": [{"title": "test", "description": "test message", "fields": [{"name": "bla", "value": "yes or no"} for _ in range(0, 25)]}],
+        "embeds": [
+            {
+                "title": "test",
+                "description": "test message",
+                "fields": [{"name": "bla", "value": "yes or no"} for _ in range(0, 25)],
+            }
+        ],
     }
 
 


### PR DESCRIPTION
# Description

As I was editing the Discord how-to guide, I noticed that the current Discord alerts look a little unpolished:
<img width="282" alt="image" src="https://user-images.githubusercontent.com/52870424/177595955-042dcf17-a3e6-4aa9-bbf9-1f5bddce54d5.png">

We should allow for users to omit the alert message entirely if they only want to specify the title. Also, the message text should be contained within the embed object for a cleaner look (and also so that the message doesn't look like a title).

# To-Dos

- [ ] Add test coverage for new or updated functionality
- [ ] Lint and test with `tox`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
