### PR TITLE
[plugins/onprem][chore] Bump paramiko 2.11.0

### DIFF
--- a/plugins/onprem/requirements.txt
+++ b/plugins/onprem/requirements.txt
@@ -1,2 +1,2 @@
 resotolib==2.4.0a0
-paramiko==2.10.4
+paramiko==2.11.0


### PR DESCRIPTION
# Description

Bump paramiko 2.11.0

Fixes
```
python3.10/site-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
  "class": algorithms.Blowfish,
```

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
