### PR TITLE
[resotocore][fix] Migrate to zoneinfo

### DIFF
--- a/resotocore/requirements.txt
+++ b/resotocore/requirements.txt
@@ -22,3 +22,4 @@ aiofiles==0.8.0
 cryptography==37.0.2
 rich~=12.4.4
 Cerberus~=1.3.4
+tzdata==2022.1

--- a/resotocore/requirements.txt
+++ b/resotocore/requirements.txt
@@ -22,4 +22,3 @@ aiofiles==0.8.0
 cryptography==37.0.2
 rich~=12.4.4
 Cerberus~=1.3.4
-tzdata==2022.1

--- a/resotocore/resotocore/cli/cli.py
+++ b/resotocore/resotocore/cli/cli.py
@@ -17,9 +17,9 @@ from aiostream import stream
 from aiostream.core import Stream
 from parsy import Parser
 from rich.padding import Padding
-from tzlocal import get_localzone
 
 from resotolib.parse_util import make_parser, pipe_p, semicolon_p
+from resotolib.utils import get_local_tzinfo
 from resotocore import version
 from resotocore.analytics import CoreEvent
 from resotocore.cli import cmd_with_args_parser, key_values_parser, T, Sink
@@ -515,7 +515,7 @@ class CLI:
         ut = from_utc(now_string) if now_string else utc()
         t = ut.date()
         try:
-            n = ut.astimezone(get_localzone())
+            n = ut.astimezone(get_local_tzinfo())
         except Exception:
             n = ut
         return CIKeyDict(

--- a/resotocore/resotocore/cli/command.py
+++ b/resotocore/resotocore/cli/command.py
@@ -32,7 +32,7 @@ from aiostream.aiter_utils import is_async_iterable
 from aiostream.core import Stream
 from parsy import Parser, string
 from resotolib.x509 import write_cert_to_file, write_key_to_file
-from resotolib.utils import safe_members_in_tarfile
+from resotolib.utils import safe_members_in_tarfile, get_local_tzinfo
 from resotolib.parse_util import (
     double_quoted_or_simple_string_dp,
     space_dp,
@@ -2528,6 +2528,10 @@ class JobsCommand(CLICommand, PreserveOutputFormat):
 
     def info(self) -> str:
         return "Manage all jobs."
+
+    def help(self) -> str:
+        extra_info = f"## Time Zone\nThe default time zone for new jobs is {get_local_tzinfo().key}."
+        return super().help() + "\n" + extra_info
 
     def args_info(self) -> ArgsInfo:
         return {

--- a/resotocore/resotocore/dependencies.py
+++ b/resotocore/resotocore/dependencies.py
@@ -21,7 +21,7 @@ from resotolib.log.logstream import (
     NoEventStreamAsync,
 )
 from resotolib.logger import setup_logger
-from resotolib.utils import iec_size_format
+from resotolib.utils import iec_size_format, get_local_tzinfo
 from resotolib.parse_util import make_parser, variable_p, equals_p, comma_p, json_value_dp
 
 from resotocore import async_extensions, version
@@ -35,7 +35,8 @@ from resotocore.util import utc
 log = logging.getLogger(__name__)
 
 SystemInfo = namedtuple(
-    "SystemInfo", ["version", "git_hash", "cpus", "mem_available", "mem_total", "inside_docker", "started_at"]
+    "SystemInfo",
+    ["version", "git_hash", "cpus", "mem_available", "mem_total", "inside_docker", "time_zone", "started_at"],
 )
 started_at = utc()
 
@@ -57,6 +58,7 @@ def system_info() -> SystemInfo:
         mem_available=iec_size_format(mem.available),
         mem_total=iec_size_format(mem.total),
         inside_docker=inside_docker(),
+        time_zone=get_local_tzinfo().key,
         started_at=started_at,
     )
 

--- a/resotocore/resotocore/task/scheduler.py
+++ b/resotocore/resotocore/task/scheduler.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from zoneinfo import ZoneInfo
 from typing import Callable, Any, List
 
 from apscheduler.executors.asyncio import AsyncIOExecutor
@@ -7,6 +6,8 @@ from apscheduler.job import Job
 from apscheduler.jobstores.memory import MemoryJobStore
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
+
+from resotolib.utils import get_local_tzinfo
 
 
 class Scheduler:
@@ -18,7 +19,7 @@ class Scheduler:
             # max_instances: allowed parallel instances for one job
             # misfire_grace_time: seconds after the designated runtime that the job is still allowed to be run
             job_defaults={"coalesce": True, "max_instances": 32, "misfire_grace_time": 3600},
-            timezone=ZoneInfo("Etc/UTC"),
+            timezone=get_local_tzinfo(),
         )
 
     async def start(self) -> None:

--- a/resotocore/resotocore/task/scheduler.py
+++ b/resotocore/resotocore/task/scheduler.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from zoneinfo import ZoneInfo
 from typing import Callable, Any, List
 
 from apscheduler.executors.asyncio import AsyncIOExecutor
@@ -6,7 +7,6 @@ from apscheduler.job import Job
 from apscheduler.jobstores.memory import MemoryJobStore
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
-from pytz import utc
 
 
 class Scheduler:
@@ -18,7 +18,7 @@ class Scheduler:
             # max_instances: allowed parallel instances for one job
             # misfire_grace_time: seconds after the designated runtime that the job is still allowed to be run
             job_defaults={"coalesce": True, "max_instances": 32, "misfire_grace_time": 3600},
-            timezone=utc,
+            timezone=ZoneInfo("Etc/UTC"),
         )
 
     async def start(self) -> None:

--- a/resotolib/requirements.txt
+++ b/resotolib/requirements.txt
@@ -12,3 +12,5 @@ aiohttp[speedups]==3.8.1
 Pint==0.19.2
 parsy==1.4.0
 cattrs==22.1.0
+tzlocal==4.2
+tzdata==2022.1

--- a/resotolib/resotolib/utils.py
+++ b/resotolib/resotolib/utils.py
@@ -6,6 +6,12 @@ import socket
 import string
 import time
 from datetime import date, datetime, timezone, timedelta
+
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo
+from tzlocal import get_localzone_name
 from functools import wraps
 from pprint import pformat
 from tarfile import TarFile, TarInfo
@@ -65,6 +71,13 @@ def str2timezone(tz: str) -> timezone:
     hours = int(tz[4:6]) * mult
     minutes = int(tz[7:9])
     return timezone(offset=timedelta(hours=hours, minutes=minutes))
+
+
+def get_local_tzinfo() -> ZoneInfo:
+    zone_name = get_localzone_name()
+    if zone_name is None:
+        zone_name = "Etc/UTC"
+    return ZoneInfo(zone_name)
 
 
 def chunks(items: List, n: int) -> List:

--- a/resotolib/test/test_utils.py
+++ b/resotolib/test/test_utils.py
@@ -2,9 +2,13 @@ import unittest
 import threading
 import time
 import copy
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo
 from tempfile import TemporaryDirectory
 from resotolib.lock import RWLock
-from resotolib.utils import ordinal, sha256sum, rrdata_as_dict
+from resotolib.utils import ordinal, sha256sum, rrdata_as_dict, get_local_tzinfo
 from resotolib.baseresources import BaseResource
 from attrs import define
 from typing import ClassVar
@@ -299,3 +303,8 @@ def test_rrdata_as_dict():
     assert res_soa2["record_retry"] == 900
     assert res_soa2["record_expire"] == 1209600
     assert res_soa2["record_minimum"] == 86400
+
+
+def test_get_local_tzinfo():
+    tz = get_local_tzinfo()
+    assert isinstance(tz, ZoneInfo)

--- a/resotolib/test/test_utils.py
+++ b/resotolib/test/test_utils.py
@@ -2,6 +2,7 @@ import unittest
 import threading
 import time
 import copy
+
 try:
     from zoneinfo import ZoneInfo
 except ImportError:


### PR DESCRIPTION
# Description

Migrate to zoneinfo

Fixes
```
/Users/lukas/repo/resoto/venv-pypy/lib/pypy3.9/site-packages/apscheduler/util.py:436: PytzUsageWarning: The localize method is no longer necessary, as this time zone supports the fold attribute (PEP 495). For more details on migrating to a PEP 495-compliant implementation, see https://pytz-deprecation-shim.readthedocs.io/en/latest/migration.html
  return tzinfo.localize(dt)
```

Also adds a dependency to tzdata because of https://docs.python.org/3/library/zoneinfo.html#data-sources
Normal Linux distributions should come with a timezone db, but this prepares it to work on systems that don't come with one, and more importantly also makes it work in minimal container environments that don't come with a system timezone db.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
