### PR TITLE
[resotocore][fix] Ignore PyTz deprecation shim warnings

### DIFF
--- a/resotocore/resotocore/task/scheduler.py
+++ b/resotocore/resotocore/task/scheduler.py
@@ -1,3 +1,4 @@
+import warnings
 from datetime import datetime
 from typing import Callable, Any, List
 
@@ -8,6 +9,12 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 
 from resotolib.utils import get_local_tzinfo
+
+
+warnings.filterwarnings(
+    "ignore",
+    message="The localize method is no longer necessary, as this time zone supports the fold attribute",
+)
 
 
 class Scheduler:


### PR DESCRIPTION
# Description

Ignore
```
/Users/lukas/repo/resoto/venv-pypy/lib/pypy3.9/site-packages/apscheduler/util.py:436: PytzUsageWarning: The localize method is no longer necessary, as this time zone supports the fold attribute (PEP 495). For more details on migrating to a PEP 495-compliant implementation, see https://pytz-deprecation-shim.readthedocs.io/en/latest/migration.html
```

generated by the use of new Python 3.9+ ZoneInfo timezones. The warning is generated in the external APScheduler dependency.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
