### PR TITLE
[resotocore][fix] Do not normalize configuration values

### DIFF
--- a/resotocore/resotocore/config/config_handler_service.py
+++ b/resotocore/resotocore/config/config_handler_service.py
@@ -39,7 +39,7 @@ class ConfigHandlerService(ConfigHandler):
                 if key in model:
                     try:
                         value_kind = model[key]
-                        coerced = value_kind.check_valid(value)
+                        coerced = value_kind.check_valid(value, normalize=False)
                         final_config[key] = value_kind.sort_json(coerced or value)
                     except Exception as ex:
                         raise AttributeError(f"Error validating section {key}: {ex}") from ex

--- a/resotocore/tests/resotocore/model/model_test.py
+++ b/resotocore/tests/resotocore/model/model_test.py
@@ -131,7 +131,8 @@ def test_duration() -> None:
     assert (
         expect_error(a, "23df") == "Wrong format for duration: 23df. Examples: 1yr, 3mo, 3d4h3min1s, 3days and 2hours"
     )
-    assert a.coerce_if_required("12d") == "1036800s"
+    assert a.coerce("12d") == "1036800s"
+    assert a.coerce("12d", normalize=False) == "12d"
     with pytest.raises(AttributeError) as no_date:
         a.check_valid("simply no duration")
     assert (


### PR DESCRIPTION
# Description

Duration values get normalized by default to SI base unit, which is seconds.
This PR adapts this behaviour and will not normalize configuration values.

<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
