### PR TITLE
[plugins/aws][fix] Remove access_key_status and redundant base resource

### DIFF
--- a/plugins/aws/resoto_plugin_aws/resources.py
+++ b/plugins/aws/resoto_plugin_aws/resources.py
@@ -210,17 +210,17 @@ class AWSLambdaFunction(AWSResource, BaseServerlessFunction):
 
     def delete(self, graph: Graph) -> bool:
         client = aws_client(self, "lambda", graph)
-        client.delete_function(self.name)
+        client.delete_function(FunctionName=self.id)
         return True
 
     def update_tag(self, key, value) -> bool:
         client = aws_client(self, "lambda")
-        client.tag_resource(Resources=[self.id], Tags=[{"Key": key, "Value": value}])
+        client.tag_resource(Resource=self.id, Tags={key: value})
         return True
 
     def delete_tag(self, key) -> bool:
         client = aws_client(self, "lambda")
-        client.delete_tags(Resources=[self.id], Tags=[{"Key": key}])
+        client.untag_resource(Resource=self.id, TagKeys=[key])
         return True
 
 

--- a/resotolib/resotolib/baseresources.py
+++ b/resotolib/resotolib/baseresources.py
@@ -862,12 +862,6 @@ class BaseGatewayQuota(BaseQuota):
 
 
 @define(eq=False, slots=False)
-class BaseServerlessFunction(BaseResource):
-    kind: ClassVar[str] = "serverless_function"
-    access_key_status: str = ""
-
-
-@define(eq=False, slots=False)
 class BaseSecurityGroup(BaseResource):
     kind: ClassVar[str] = "security_group"
 


### PR DESCRIPTION
# Description

Remove access_key_status and redundant base resource.
Fixes tagging and cleanup for lambdas.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
