### PR TITLE
feat(helm): Adds a serviceMonitor and its service to scrape resoto metrics

### DIFF
--- a/kubernetes/chart/Chart.yaml
+++ b/kubernetes/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/kubernetes/chart/templates/resotormetrics/deployment.yaml
+++ b/kubernetes/chart/templates/resotormetrics/deployment.yaml
@@ -5,10 +5,12 @@ metadata:
   labels:
     resoto: metrics
     {{- include "resoto.labels" . | nindent 4 }}
+  {{- if not .Values.resotometrics.serviceMonitor.enabled }}
   annotations:
     prometheus.io/scrape: 'true'
     prometheus.io/path: '/metrics'
     prometheus.io/port: '9955'
+  {{- end }}
 spec:
   replicas: 1
   selector:

--- a/kubernetes/chart/templates/resotormetrics/serviceMonitor.yaml
+++ b/kubernetes/chart/templates/resotormetrics/serviceMonitor.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.resotometrics.serviceMonitor.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "resoto.fullname" . }}-resotometrics
+  labels:
+    resoto: metrics
+    {{- include "resoto.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9955
+      protocol: TCP
+      name: metrics
+  selector:
+    resoto: metrics
+    {{- include "resoto.selectorLabels" . | nindent 4 }}
+---
+apiVersion: "monitoring.coreos.com/v1"
+kind: ServiceMonitor
+metadata:
+  labels:
+    resoto: metrics
+    {{- include "resoto.labels" . | nindent 4 }}
+  name: {{ include "resoto.fullname" . }}-resotometrics
+spec:
+  selector:
+    matchLabels:
+      resoto: metrics
+      {{- include "resoto.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace | quote }}
+  endpoints:
+  - port: metrics
+    interval: {{ .Values.resotometrics.serviceMonitor.interval }}
+    scrapeTimeout: {{ .Values.resotometrics.serviceMonitor.scrapeTimeout }}
+{{- end }}

--- a/kubernetes/chart/values.yaml
+++ b/kubernetes/chart/values.yaml
@@ -56,6 +56,14 @@ resotometrics:
   extraArgs: [ ]
   # Use this section to pass extra environment variables
   extraEnv: [ ]
+  # Prometheus serviceMonitor configuration
+  serviceMonitor:
+    # Whether a Prometheus serviceMonitor should be created
+    enabled: false
+    # Metrics scrape interval
+    interval: 30s
+    # Metrics scrape timeout
+    scrapeTimeout: 25s
 
 resotocore:
   service:


### PR DESCRIPTION
Signed-off-by: cebidhem <cebidhem@pm.me>

# Description

ServiceMonitors are the way to scrape metrics for users deploying Prometheus through the Operator (kube-prometheus-stack). 
If explicitly enabled by the user, this aims to create a service and a servicemonitor to scrape resoto metrics.

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Document new or updated functionality (someengineering/resoto.com#XXXX)

Comments have been added within the values.yaml file. If you feel this should be added somewhere else, please let me know.

# Issues Fixed

<!-- If this PR will fix/resolve an open issue on the repository, please reference it below. -->
<!-- (Otherwise, feel free to delete this section.) -->

- Fixes #1057

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
