### PR TITLE
 [plugins/aws][feat] Add support for Elastic Beanstalk Application Environments and Resources

### DIFF
--- a/plugins/aws/resoto_plugin_aws/resource/elasticbeanstalk.py
+++ b/plugins/aws/resoto_plugin_aws/resource/elasticbeanstalk.py
@@ -265,7 +265,6 @@ class AwsBeanstalkEnvironment(AwsResource):
         builder.dependant_node(
             self,
             reverse=True,
-            # delete_same_as_default=True, ??
             clazz=AwsBeanstalkApplication,
             name=self.application_name,
         )
@@ -278,7 +277,6 @@ class AwsBeanstalkEnvironment(AwsResource):
                     builder.dependant_node(
                         self,
                         reverse=True,
-                        # delete_same_as_default=True, ??
                         clazz=AwsAutoScalingGroup,
                         name=group.auto_scaling_group_name,
                     )
@@ -288,7 +286,6 @@ class AwsBeanstalkEnvironment(AwsResource):
                     builder.dependant_node(
                         self,
                         reverse=True,
-                        # delete_same_as_default=True, ??
                         clazz=AwsEc2Instance,
                         id=instance.instance_id,
                     )
@@ -298,7 +295,6 @@ class AwsBeanstalkEnvironment(AwsResource):
                     builder.dependant_node(
                         self,
                         reverse=True,
-                        # delete_same_as_default=True, ??
                         clazz=AwsAlb,
                         name=lb.load_balancer_name,
                     )

--- a/plugins/aws/resoto_plugin_aws/resource/elasticbeanstalk.py
+++ b/plugins/aws/resoto_plugin_aws/resource/elasticbeanstalk.py
@@ -1,8 +1,10 @@
 from typing import ClassVar, Dict, List, Optional, Type
 from attrs import define, field
 from resoto_plugin_aws.aws_client import AwsClient
-from resoto_plugin_aws.resource.base import AwsApiSpec, AwsResource
-from resotolib.json_bender import Bender, S, Bend
+from resoto_plugin_aws.resource.base import AwsApiSpec, AwsResource, GraphBuilder
+from resoto_plugin_aws.utils import ToDict
+from resotolib.json_bender import Bender, S, Bend, bend
+from resotolib.types import Json
 
 
 @define(eq=False, slots=False)
@@ -70,11 +72,22 @@ class AwsBeanstalkApplication(AwsResource):
         "resource_lifecycle_config": S("ResourceLifecycleConfig")
         >> Bend(AwsBeanstalkApplicationResourceLifecycleConfig.mapping),
     }
-    arn: Optional[str] = field(default=None)
     description: Optional[str] = field(default=None)
     versions: List[str] = field(factory=list)
     configuration_templates: List[str] = field(factory=list)
     resource_lifecycle_config: Optional[AwsBeanstalkApplicationResourceLifecycleConfig] = field(default=None)
+
+    @classmethod
+    def collect(cls: Type[AwsResource], json: List[Json], builder: GraphBuilder) -> None:
+        def add_tags(app: AwsBeanstalkApplication) -> None:
+            tags = builder.client.list("elasticbeanstalk", "list-tags-for-resource", "ResourceTags", ResourceArn=app.arn)
+            if tags:
+                app.tags = bend(ToDict(), tags)
+
+        for js in json:
+            instance = cls.from_api(js)
+            builder.add_node(instance, js)
+            builder.submit_work(add_tags, instance)
 
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
         client.call(
@@ -101,6 +114,117 @@ class AwsBeanstalkApplication(AwsResource):
             service=self.api_spec.service, action="delete-application", result_name=None, ApplicationName=self.name
         )
         return True
+
+
+# @define(eq=False, slots=False)
+# class AwsBeanstalkListener:
+#     kind: ClassVar[str] = "aws_beanstalk_listener"
+#     mapping: ClassVar[Dict[str, Bender]] = {
+#         "protocol": S("Protocol"),
+#         "port": S("Port")
+#     }
+#     protocol: Optional[str] = field(default=None)
+#     port: Optional[int] = field(default=None)
+
+# @define(eq=False, slots=False)
+# class AwsBeanstalkLoadBalancerDescription:
+#     kind: ClassVar[str] = "aws_beanstalk_load_balancer_description"
+#     mapping: ClassVar[Dict[str, Bender]] = {
+#         "load_balancer_name": S("LoadBalancerName"),
+#         "domain": S("Domain"),
+#         "listeners": S("Listeners", default=[]) >> ForallBend(AwsBeanstalkListener.mapping)
+#     }
+#     load_balancer_name: Optional[str] = field(default=None)
+#     domain: Optional[str] = field(default=None)
+#     listeners: List[AwsBeanstalkListener] = field(factory=list)
+
+# @define(eq=False, slots=False)
+# class AwsBeanstalkEnvironmentResourcesDescription:
+#     kind: ClassVar[str] = "aws_beanstalk_environment_resources_description"
+#     mapping: ClassVar[Dict[str, Bender]] = {
+#         "load_balancer": S("LoadBalancer") >> Bend(AwsBeanstalkLoadBalancerDescription.mapping)
+#     }
+#     load_balancer: Optional[AwsBeanstalkLoadBalancerDescription] = field(default=None)
+
+# @define(eq=False, slots=False)
+# class AwsBeanstalkEnvironmentTier:
+#     kind: ClassVar[str] = "aws_beanstalk_environment_tier"
+#     mapping: ClassVar[Dict[str, Bender]] = {
+#         "name": S("Name"),
+#         "type": S("Type"),
+#         "version": S("Version")
+#     }
+#     name: Optional[str] = field(default=None)
+#     type: Optional[str] = field(default=None)
+#     version: Optional[str] = field(default=None)
+
+# @define(eq=False, slots=False)
+# class AwsBeanstalkEnvironmentLink:
+#     kind: ClassVar[str] = "aws_beanstalk_environment_link"
+#     mapping: ClassVar[Dict[str, Bender]] = {
+#         "link_name": S("LinkName"),
+#         "environment_name": S("EnvironmentName")
+#     }
+#     link_name: Optional[str] = field(default=None)
+#     environment_name: Optional[str] = field(default=None)
+
+
+# @define(eq=False, slots=False)
+# class AwsBeanstalkEnvironment(AwsResource):
+#     kind: ClassVar[str] = "aws_beanstalk_environment"
+#     api_spec: ClassVar[AwsApiSpec] = AwsApiSpec("elasticbeanstalk", "describe-environments", "Environments")
+#     mapping: ClassVar[Dict[str, Bender]] = {
+#         "id": S("id"),
+#         # "tags": S("Tags", default=[]) >> ToDict(),
+#         "name": S("Tags", default=[]) >> TagsValue("Name"),
+#         "ctime": K(None),
+#         "mtime": K(None),
+#         "atime": K(None),
+#         "environment_next_token": S("NextToken"),
+#         "environment_name": S("EnvironmentName"),
+#         "environment_id": S("EnvironmentId"),
+#         "application_name": S("ApplicationName"),
+#         "version_label": S("VersionLabel"),
+#         "solution_stack_name": S("SolutionStackName"),
+#         "platform_arn": S("PlatformArn"),
+#         "template_name": S("TemplateName"),
+#         "description": S("Description"),
+#         "endpoint_url": S("EndpointURL"),
+#         "cname": S("CNAME"),
+#         "date_created": S("DateCreated"),
+#         "date_updated": S("DateUpdated"),
+#         "status": S("Status"),
+#         "abortable_operation_in_progress": S("AbortableOperationInProgress"),
+#         "health": S("Health"),
+#         "health_status": S("HealthStatus"),
+#         "resources": S("Resources") >> Bend(AwsBeanstalkEnvironmentResourcesDescription.mapping),
+#         "tier": S("Tier") >> Bend(AwsBeanstalkEnvironmentTier.mapping),
+#         "environment_links": S("EnvironmentLinks", default=[]) >> ForallBend(AwsBeanstalkEnvironmentLink.mapping),
+#         "environment_arn": S("EnvironmentArn"),
+#         "operations_role": S("OperationsRole")
+#     }
+#     environment_next_token: Optional[str] = field(default=None)
+#     environment_name: Optional[str] = field(default=None)
+#     environment_id: Optional[str] = field(default=None)
+#     application_name: Optional[str] = field(default=None)
+#     version_label: Optional[str] = field(default=None)
+#     solution_stack_name: Optional[str] = field(default=None)
+#     platform_arn: Optional[str] = field(default=None)
+#     template_name: Optional[str] = field(default=None)
+#     description: Optional[str] = field(default=None)
+#     endpoint_url: Optional[str] = field(default=None)
+#     cname: Optional[str] = field(default=None)
+#     date_created: Optional[datetime] = field(default=None)
+#     date_updated: Optional[datetime] = field(default=None)
+#     status: Optional[str] = field(default=None)
+#     abortable_operation_in_progress: Optional[bool] = field(default=None)
+#     health: Optional[str] = field(default=None)
+#     health_status: Optional[str] = field(default=None)
+#     resources: Optional[AwsBeanstalkEnvironmentResourcesDescription] = field(default=None)
+#     tier: Optional[AwsBeanstalkEnvironmentTier] = field(default=None)
+#     environment_links: List[AwsBeanstalkEnvironmentLink] = field(factory=list)
+#     environment_arn: Optional[str] = field(default=None)
+#     operations_role: Optional[str] = field(default=None)
 
 
 resources: List[Type[AwsResource]] = [AwsBeanstalkApplication]

--- a/plugins/aws/resoto_plugin_aws/resource/elasticbeanstalk.py
+++ b/plugins/aws/resoto_plugin_aws/resource/elasticbeanstalk.py
@@ -195,6 +195,16 @@ class AwsBeanstalkEnvironment(AwsResource):
             builder.add_node(instance, js)
             builder.submit_work(add_tags, instance)
 
+    def connect_in_graph(self, builder: GraphBuilder, source: Json) -> None:
+        super().connect_in_graph(builder, source)
+        builder.dependant_node(
+            self,
+            reverse=True,
+            delete_same_as_default=True,
+            clazz=AwsBeanstalkApplication,
+            name=self.application_name
+         )
+
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
         client.call(
             service=self.api_spec.service,

--- a/plugins/aws/resoto_plugin_aws/resource/elasticbeanstalk.py
+++ b/plugins/aws/resoto_plugin_aws/resource/elasticbeanstalk.py
@@ -3,7 +3,7 @@ from attrs import define, field
 from resoto_plugin_aws.aws_client import AwsClient
 from resoto_plugin_aws.resource.base import AwsApiSpec, AwsResource, GraphBuilder
 from resoto_plugin_aws.utils import ToDict
-from resotolib.json_bender import Bender, S, Bend, bend
+from resotolib.json_bender import Bender, S, Bend, ForallBend, bend
 from resotolib.types import Json
 
 
@@ -116,115 +116,72 @@ class AwsBeanstalkApplication(AwsResource):
         return True
 
 
-# @define(eq=False, slots=False)
-# class AwsBeanstalkListener:
-#     kind: ClassVar[str] = "aws_beanstalk_listener"
-#     mapping: ClassVar[Dict[str, Bender]] = {
-#         "protocol": S("Protocol"),
-#         "port": S("Port")
-#     }
-#     protocol: Optional[str] = field(default=None)
-#     port: Optional[int] = field(default=None)
+@define(eq=False, slots=False)
+class AwsBeanstalkEnvironmentTier:
+    kind: ClassVar[str] = "aws_beanstalk_environment_tier"
+    mapping: ClassVar[Dict[str, Bender]] = {
+        "name": S("Name"),
+        "type": S("Type"),
+        "version": S("Version")
+    }
+    name: Optional[str] = field(default=None)
+    type: Optional[str] = field(default=None)
+    version: Optional[str] = field(default=None)
 
-# @define(eq=False, slots=False)
-# class AwsBeanstalkLoadBalancerDescription:
-#     kind: ClassVar[str] = "aws_beanstalk_load_balancer_description"
-#     mapping: ClassVar[Dict[str, Bender]] = {
-#         "load_balancer_name": S("LoadBalancerName"),
-#         "domain": S("Domain"),
-#         "listeners": S("Listeners", default=[]) >> ForallBend(AwsBeanstalkListener.mapping)
-#     }
-#     load_balancer_name: Optional[str] = field(default=None)
-#     domain: Optional[str] = field(default=None)
-#     listeners: List[AwsBeanstalkListener] = field(factory=list)
-
-# @define(eq=False, slots=False)
-# class AwsBeanstalkEnvironmentResourcesDescription:
-#     kind: ClassVar[str] = "aws_beanstalk_environment_resources_description"
-#     mapping: ClassVar[Dict[str, Bender]] = {
-#         "load_balancer": S("LoadBalancer") >> Bend(AwsBeanstalkLoadBalancerDescription.mapping)
-#     }
-#     load_balancer: Optional[AwsBeanstalkLoadBalancerDescription] = field(default=None)
-
-# @define(eq=False, slots=False)
-# class AwsBeanstalkEnvironmentTier:
-#     kind: ClassVar[str] = "aws_beanstalk_environment_tier"
-#     mapping: ClassVar[Dict[str, Bender]] = {
-#         "name": S("Name"),
-#         "type": S("Type"),
-#         "version": S("Version")
-#     }
-#     name: Optional[str] = field(default=None)
-#     type: Optional[str] = field(default=None)
-#     version: Optional[str] = field(default=None)
-
-# @define(eq=False, slots=False)
-# class AwsBeanstalkEnvironmentLink:
-#     kind: ClassVar[str] = "aws_beanstalk_environment_link"
-#     mapping: ClassVar[Dict[str, Bender]] = {
-#         "link_name": S("LinkName"),
-#         "environment_name": S("EnvironmentName")
-#     }
-#     link_name: Optional[str] = field(default=None)
-#     environment_name: Optional[str] = field(default=None)
+@define(eq=False, slots=False)
+class AwsBeanstalkEnvironmentLink:
+    kind: ClassVar[str] = "aws_beanstalk_environment_link"
+    mapping: ClassVar[Dict[str, Bender]] = {
+        "link_name": S("LinkName"),
+        "environment_name": S("EnvironmentName")
+    }
+    link_name: Optional[str] = field(default=None)
+    environment_name: Optional[str] = field(default=None)
 
 
-# @define(eq=False, slots=False)
-# class AwsBeanstalkEnvironment(AwsResource):
-#     kind: ClassVar[str] = "aws_beanstalk_environment"
-#     api_spec: ClassVar[AwsApiSpec] = AwsApiSpec("elasticbeanstalk", "describe-environments", "Environments")
-#     mapping: ClassVar[Dict[str, Bender]] = {
-#         "id": S("id"),
-#         # "tags": S("Tags", default=[]) >> ToDict(),
-#         "name": S("Tags", default=[]) >> TagsValue("Name"),
-#         "ctime": K(None),
-#         "mtime": K(None),
-#         "atime": K(None),
-#         "environment_next_token": S("NextToken"),
-#         "environment_name": S("EnvironmentName"),
-#         "environment_id": S("EnvironmentId"),
-#         "application_name": S("ApplicationName"),
-#         "version_label": S("VersionLabel"),
-#         "solution_stack_name": S("SolutionStackName"),
-#         "platform_arn": S("PlatformArn"),
-#         "template_name": S("TemplateName"),
-#         "description": S("Description"),
-#         "endpoint_url": S("EndpointURL"),
-#         "cname": S("CNAME"),
-#         "date_created": S("DateCreated"),
-#         "date_updated": S("DateUpdated"),
-#         "status": S("Status"),
-#         "abortable_operation_in_progress": S("AbortableOperationInProgress"),
-#         "health": S("Health"),
-#         "health_status": S("HealthStatus"),
-#         "resources": S("Resources") >> Bend(AwsBeanstalkEnvironmentResourcesDescription.mapping),
-#         "tier": S("Tier") >> Bend(AwsBeanstalkEnvironmentTier.mapping),
-#         "environment_links": S("EnvironmentLinks", default=[]) >> ForallBend(AwsBeanstalkEnvironmentLink.mapping),
-#         "environment_arn": S("EnvironmentArn"),
-#         "operations_role": S("OperationsRole")
-#     }
-#     environment_next_token: Optional[str] = field(default=None)
-#     environment_name: Optional[str] = field(default=None)
-#     environment_id: Optional[str] = field(default=None)
-#     application_name: Optional[str] = field(default=None)
-#     version_label: Optional[str] = field(default=None)
-#     solution_stack_name: Optional[str] = field(default=None)
-#     platform_arn: Optional[str] = field(default=None)
-#     template_name: Optional[str] = field(default=None)
-#     description: Optional[str] = field(default=None)
-#     endpoint_url: Optional[str] = field(default=None)
-#     cname: Optional[str] = field(default=None)
-#     date_created: Optional[datetime] = field(default=None)
-#     date_updated: Optional[datetime] = field(default=None)
-#     status: Optional[str] = field(default=None)
-#     abortable_operation_in_progress: Optional[bool] = field(default=None)
-#     health: Optional[str] = field(default=None)
-#     health_status: Optional[str] = field(default=None)
-#     resources: Optional[AwsBeanstalkEnvironmentResourcesDescription] = field(default=None)
-#     tier: Optional[AwsBeanstalkEnvironmentTier] = field(default=None)
-#     environment_links: List[AwsBeanstalkEnvironmentLink] = field(factory=list)
-#     environment_arn: Optional[str] = field(default=None)
-#     operations_role: Optional[str] = field(default=None)
+@define(eq=False, slots=False)
+class AwsBeanstalkEnvironment(AwsResource):
+    kind: ClassVar[str] = "aws_beanstalk_environment"
+    api_spec: ClassVar[AwsApiSpec] = AwsApiSpec("elasticbeanstalk", "describe-environments", "Environments")
+    mapping: ClassVar[Dict[str, Bender]] = {
+        "id": S("EnvironmentId"),
+        "name": S("EnvironmentName"),
+        "ctime": S("DateCreated"),
+        "mtime": S("DateUpdated"),
+        "arn": S("EnvironmentArn"),
+        "application_name": S("ApplicationName"),
+        "version_label": S("VersionLabel"),
+        "solution_stack_name": S("SolutionStackName"),
+        "platform_arn": S("PlatformArn"),
+        "template_name": S("TemplateName"),
+        "description": S("Description"),
+        "endpoint_url": S("EndpointURL"),
+        "cname": S("CNAME"),
+        "status": S("Status"),
+        "abortable_operation_in_progress": S("AbortableOperationInProgress"),
+        "health": S("Health"),
+        "health_status": S("HealthStatus"),
+        "resources": [],
+        "tier": S("Tier") >> Bend(AwsBeanstalkEnvironmentTier.mapping),
+        "environment_links": S("EnvironmentLinks", default=[]) >> ForallBend(AwsBeanstalkEnvironmentLink.mapping),
+        "operations_role": S("OperationsRole")
+    }
+    application_name: Optional[str] = field(default=None)
+    version_label: Optional[str] = field(default=None)
+    solution_stack_name: Optional[str] = field(default=None)
+    platform_arn: Optional[str] = field(default=None)
+    template_name: Optional[str] = field(default=None)
+    description: Optional[str] = field(default=None)
+    endpoint_url: Optional[str] = field(default=None)
+    cname: Optional[str] = field(default=None)
+    status: Optional[str] = field(default=None)
+    abortable_operation_in_progress: Optional[bool] = field(default=None)
+    health: Optional[str] = field(default=None)
+    health_status: Optional[str] = field(default=None)
+    resources: Optional[list] = field(default=None)  # List[Type[AwsResource]]?
+    tier: Optional[AwsBeanstalkEnvironmentTier] = field(default=None)
+    environment_links: List[AwsBeanstalkEnvironmentLink] = field(factory=list)
+    operations_role: Optional[str] = field(default=None)
 
 
-resources: List[Type[AwsResource]] = [AwsBeanstalkApplication]
+resources: List[Type[AwsResource]] = [AwsBeanstalkApplication, AwsBeanstalkEnvironment]

--- a/plugins/aws/test/collector_test.py
+++ b/plugins/aws/test/collector_test.py
@@ -25,8 +25,8 @@ def test_collect() -> None:
                 count += 1
         return count
 
-    assert len(ac.graph.edges) == 292
-    assert count_kind(AwsResource) == 114
+    assert len(ac.graph.edges) == 293
+    assert count_kind(AwsResource) == 115
     for resource in all_resources:
         assert count_kind(resource) > 0, "No instances of {} found".format(resource.__name__)
 

--- a/plugins/aws/test/collector_test.py
+++ b/plugins/aws/test/collector_test.py
@@ -25,7 +25,7 @@ def test_collect() -> None:
                 count += 1
         return count
 
-    assert len(ac.graph.edges) == 284
+    assert len(ac.graph.edges) == 286
     assert count_kind(AwsResource) == 114
     for resource in all_resources:
         assert count_kind(resource) > 0, "No instances of {} found".format(resource.__name__)

--- a/plugins/aws/test/collector_test.py
+++ b/plugins/aws/test/collector_test.py
@@ -25,7 +25,7 @@ def test_collect() -> None:
                 count += 1
         return count
 
-    assert len(ac.graph.edges) == 286
+    assert len(ac.graph.edges) == 292
     assert count_kind(AwsResource) == 114
     for resource in all_resources:
         assert count_kind(resource) > 0, "No instances of {} found".format(resource.__name__)

--- a/plugins/aws/test/resources/elasticbeanstalk_test.py
+++ b/plugins/aws/test/resources/elasticbeanstalk_test.py
@@ -1,6 +1,6 @@
 from typing import Any, cast
 from types import SimpleNamespace
-from resoto_plugin_aws.resource.elasticbeanstalk import AwsBeanstalkApplication
+from resoto_plugin_aws.resource.elasticbeanstalk import AwsBeanstalkApplication, AwsBeanstalkEnvironment
 from resoto_plugin_aws.aws_client import AwsClient
 from test.resources import round_trip_for
 
@@ -9,7 +9,6 @@ def test_applications() -> None:
     first, builder = round_trip_for(AwsBeanstalkApplication)
     assert len(builder.resources_of(AwsBeanstalkApplication)) == 3
     assert len(first.tags) == 2
-
 
 
 def test_tagging() -> None:
@@ -41,3 +40,8 @@ def test_delete_application() -> None:
 
     client = cast(AwsClient, SimpleNamespace(call=validate_delete_args))
     app.delete_resource(client)
+
+def test_environments() -> None:
+    first, builder = round_trip_for(AwsBeanstalkEnvironment)
+    assert len(builder.resources_of(AwsBeanstalkEnvironment)) == 1
+    # assert len(first.tags) == 2

--- a/plugins/aws/test/resources/elasticbeanstalk_test.py
+++ b/plugins/aws/test/resources/elasticbeanstalk_test.py
@@ -11,7 +11,7 @@ def test_applications() -> None:
     assert len(first.tags) == 2
 
 
-def test_tagging() -> None:
+def test_tagging_apps() -> None:
     app, _ = round_trip_for(AwsBeanstalkApplication)
 
     def validate_update_args(**kwargs: Any) -> Any:
@@ -44,4 +44,33 @@ def test_delete_application() -> None:
 def test_environments() -> None:
     first, builder = round_trip_for(AwsBeanstalkEnvironment)
     assert len(builder.resources_of(AwsBeanstalkEnvironment)) == 1
-    # assert len(first.tags) == 2
+    assert len(first.tags) == 2
+
+def test_tagging_envs() -> None:
+    env, _ = round_trip_for(AwsBeanstalkEnvironment)
+
+    def validate_update_args(**kwargs: Any) -> Any:
+        if kwargs["action"] == "update-tags-for-resource":
+            assert kwargs["ResourceArn"] == env.arn
+            assert kwargs["TagsToAdd"] == [{"Key": "foo", "Value": "bar"}]
+
+    def validate_delete_args(**kwargs: Any) -> Any:
+        if kwargs["action"] == "update-tags-for-resource":
+            assert kwargs["ResourceArn"] == env.arn
+            assert kwargs["TagsToRemove"] == ["foo"]
+
+    client = cast(AwsClient, SimpleNamespace(call=validate_update_args))
+    env.update_resource_tag(client, "foo", "bar")
+
+    client = cast(AwsClient, SimpleNamespace(call=validate_delete_args))
+    env.delete_resource_tag(client, "foo")
+
+def test_delete_environment() -> None:
+    env, _ = round_trip_for(AwsBeanstalkEnvironment)
+
+    def validate_delete_args(**kwargs: Any) -> None:
+        assert kwargs["action"] == "terminate-environment"
+        assert kwargs["EnvironmentName"] == env.name
+
+    client = cast(AwsClient, SimpleNamespace(call=validate_delete_args))
+    env.delete_resource(client)

--- a/plugins/aws/test/resources/elasticbeanstalk_test.py
+++ b/plugins/aws/test/resources/elasticbeanstalk_test.py
@@ -8,6 +8,8 @@ from test.resources import round_trip_for
 def test_applications() -> None:
     first, builder = round_trip_for(AwsBeanstalkApplication)
     assert len(builder.resources_of(AwsBeanstalkApplication)) == 3
+    assert len(first.tags) == 2
+
 
 
 def test_tagging() -> None:

--- a/plugins/aws/test/resources/elasticbeanstalk_test.py
+++ b/plugins/aws/test/resources/elasticbeanstalk_test.py
@@ -45,6 +45,7 @@ def test_environments() -> None:
     first, builder = round_trip_for(AwsBeanstalkEnvironment)
     assert len(builder.resources_of(AwsBeanstalkEnvironment)) == 1
     assert len(first.tags) == 2
+    assert first.resources.auto_scaling_groups[0].auto_scaling_group_name == "SomeGroup"
 
 def test_tagging_envs() -> None:
     env, _ = round_trip_for(AwsBeanstalkEnvironment)

--- a/plugins/aws/test/resources/elasticbeanstalk_test.py
+++ b/plugins/aws/test/resources/elasticbeanstalk_test.py
@@ -41,11 +41,12 @@ def test_delete_application() -> None:
     client = cast(AwsClient, SimpleNamespace(call=validate_delete_args))
     app.delete_resource(client)
 
+
 def test_environments() -> None:
     first, builder = round_trip_for(AwsBeanstalkEnvironment)
     assert len(builder.resources_of(AwsBeanstalkEnvironment)) == 1
     assert len(first.tags) == 2
-    assert first.resources.auto_scaling_groups[0].auto_scaling_group_name == "SomeGroup"
+
 
 def test_tagging_envs() -> None:
     env, _ = round_trip_for(AwsBeanstalkEnvironment)
@@ -65,6 +66,7 @@ def test_tagging_envs() -> None:
 
     client = cast(AwsClient, SimpleNamespace(call=validate_delete_args))
     env.delete_resource_tag(client, "foo")
+
 
 def test_delete_environment() -> None:
     env, _ = round_trip_for(AwsBeanstalkEnvironment)

--- a/plugins/aws/test/resources/files/elasticbeanstalk/describe-applications.json
+++ b/plugins/aws/test/resources/files/elasticbeanstalk/describe-applications.json
@@ -4,6 +4,7 @@
             "ApplicationName": "ruby",
             "ConfigurationTemplates": [],
             "DateUpdated": "2015-08-13T21:05:44.376Z",
+            "ApplicationArn": "SomeAppArn",
             "Description": "Some Description",
             "Versions": [
                 "Sample Application"

--- a/plugins/aws/test/resources/files/elasticbeanstalk/describe-environment-resources__SomeId.json
+++ b/plugins/aws/test/resources/files/elasticbeanstalk/describe-environment-resources__SomeId.json
@@ -3,27 +3,27 @@
         "EnvironmentName": "TestEnv",
         "AutoScalingGroups": [
             {
-                "Name": "SomeGroup"
+                "Name": "asg-123"
             }
         ],
         "Instances": [
             {
-                "Id": "SomeInstanceId"
+                "Id": "i-1"
             }
         ],
         "LaunchConfigurations": [
             {
-                "Name": "string"
+                "Name": "SomeConfig"
             }
         ],
         "LaunchTemplates": [
             {
-                "Id": "string"
+                "Id": "SomeTemplate"
             }
         ],
         "LoadBalancers": [
             {
-                "Name": "SomeLoadBalancer"
+                "Name": "lb1"
             }
         ],
         "Triggers": [

--- a/plugins/aws/test/resources/files/elasticbeanstalk/describe-environment-resources__SomeId.json
+++ b/plugins/aws/test/resources/files/elasticbeanstalk/describe-environment-resources__SomeId.json
@@ -1,0 +1,41 @@
+{
+    "EnvironmentResources": {
+        "EnvironmentName": "TestEnv",
+        "AutoScalingGroups": [
+            {
+                "Name": "SomeGroup"
+            }
+        ],
+        "Instances": [
+            {
+                "Id": "SomeInstanceId"
+            }
+        ],
+        "LaunchConfigurations": [
+            {
+                "Name": "string"
+            }
+        ],
+        "LaunchTemplates": [
+            {
+                "Id": "string"
+            }
+        ],
+        "LoadBalancers": [
+            {
+                "Name": "SomeLoadBalancer"
+            }
+        ],
+        "Triggers": [
+            {
+                "Name": "SomeTrigger"
+            }
+        ],
+        "Queues": [
+            {
+                "Name": "SomeQueue",
+                "URL": "SomeUrl"
+            }
+        ]
+    }
+}

--- a/plugins/aws/test/resources/files/elasticbeanstalk/describe-environments.json
+++ b/plugins/aws/test/resources/files/elasticbeanstalk/describe-environments.json
@@ -1,0 +1,48 @@
+{
+    "Environments": [
+        {
+            "EnvironmentName": "TestEnv",
+            "EnvironmentId": "SomeId",
+            "ApplicationName": "ruby",
+            "VersionLabel": "SomeLabel",
+            "SolutionStackName": "SomeName",
+            "PlatformArn": "SomeArn",
+            "TemplateName": "SomeName",
+            "Description": "SomeDescription",
+            "EndpointURL": "SomeURL",
+            "CNAME": "SomeName",
+            "DateCreated": "2015-08-13T21:05:44.376Z",
+            "DateUpdated": "2015-09-13T21:05:44.376Z",
+            "Status": "Ready",
+            "AbortableOperationInProgress": false,
+            "Health": "Green",
+            "HealthStatus": "Ok",
+            "Resources": {
+                "LoadBalancer": {
+                    "LoadBalancerName": "SomeName",
+                    "Domain": "SomeDomain",
+                    "Listeners": [
+                        {
+                            "Protocol": "SomeProtocol",
+                            "Port": 123
+                        }
+                    ]
+                }
+            },
+            "Tier": {
+                "Name": "SomeName",
+                "Type": "SomeType",
+                "Version": "SomeVersion"
+            },
+            "EnvironmentLinks": [
+                {
+                    "LinkName": "SomeName",
+                    "EnvironmentName": "SomeName"
+                }
+            ],
+            "EnvironmentArn": "SomeEnvArn",
+            "OperationsRole": "SomeRole"
+        }
+    ],
+    "NextToken": "SomeToken"
+}

--- a/plugins/aws/test/resources/files/elasticbeanstalk/list-tags-for-resource__SomeAppArn.json
+++ b/plugins/aws/test/resources/files/elasticbeanstalk/list-tags-for-resource__SomeAppArn.json
@@ -1,0 +1,13 @@
+{
+    "ResourceArn": "SomeAppArn",
+    "ResourceTags": [
+        {
+            "Key": "owner",
+            "Value": "sre"
+        },
+        {
+            "Key": "expiration",
+            "Value": "never"
+        }
+    ]
+}

--- a/plugins/aws/test/resources/files/elasticbeanstalk/list-tags-for-resource__SomeEnvArn.json
+++ b/plugins/aws/test/resources/files/elasticbeanstalk/list-tags-for-resource__SomeEnvArn.json
@@ -1,0 +1,13 @@
+{
+    "ResourceArn": "SomeEnvArn",
+    "ResourceTags": [
+        {
+            "Key": "SomeKey",
+            "Value": "SomeValue"
+        },
+        {
+            "Key": "SomeOtherKey",
+            "Value": "SomeOtherValue"
+        }
+    ]
+}

--- a/plugins/aws/tools/model_gen.py
+++ b/plugins/aws/tools/model_gen.py
@@ -460,6 +460,13 @@ models: Dict[str, List[AwsResotoModel]] = {
         #     prefix="Beanstalk",
         #     prop_prefix="beanstalk_",
         # ),
+        AwsResotoModel(
+            "describe-environments",
+            "Environments",
+            "EnvironmentDescriptionsMessage",
+            prefix="Beanstalk",
+            prop_prefix="environment_"
+        )
     ],
     "elb": [
         # AwsResotoModel(

--- a/plugins/aws/tools/model_gen.py
+++ b/plugins/aws/tools/model_gen.py
@@ -460,13 +460,13 @@ models: Dict[str, List[AwsResotoModel]] = {
         #     prefix="Beanstalk",
         #     prop_prefix="beanstalk_",
         # ),
-        AwsResotoModel(
-            "describe-environments",
-            "Environments",
-            "EnvironmentDescriptionsMessage",
-            prefix="Beanstalk",
-            prop_prefix="environment_"
-        )
+        # AwsResotoModel(
+        #     "describe-environments",
+        #     "Environments",
+        #     "EnvironmentDescriptionsMessage",
+        #     prefix="Beanstalk",
+        #     prop_prefix="environment_"
+        # )
     ],
     "elb": [
         # AwsResotoModel(


### PR DESCRIPTION
# Description

- collect existing tags on Elasticbeanstalk Applications
- collect Environments of Applications (incl. existing tags)
- add edges from Environments to Applications
- collect Resources in Environments
- add edges from Resources to Environments
- tagging and deletion methods for Environments

# To-Dos

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`
- [ ] Document new or updated functionality (someengineering/resoto.com#XXXX)


# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
