### PR TITLE
Incompatible attribute type

### DIFF
--- a/plugins/aws/resoto_plugin_aws/resources.py
+++ b/plugins/aws/resoto_plugin_aws/resources.py
@@ -203,9 +203,9 @@ class AWSLambdaFunction(AWSResource, BaseServerlessFunction):
     }
 
     role: Optional[str] = None
-    runtime: str = None
-    code_size: int = None
-    memory_size: int = None
+    runtime: Optional[str] = None
+    code_size: Optional[int] = None
+    memory_size: Optional[int] = None
     kms_key_arn: Optional[str] = None
 
     def delete(self, graph: Graph) -> bool:


### PR DESCRIPTION
# Description

**"filename"**: "plugins/aws/resoto_plugin_aws/resources.py"
**"warning_type"**: "Incompatible attribute type [8]",
**"warning_message"**: " Attribute `runtime` declared in class `AWSLambdaFunction` has type `str` but is used as type `None`.",
**"warning_line"**: 206
**"fix"**: add Optional types

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [ ] Add test coverage for new or updated functionality
- [ ] Lint and test with `tox`
- [ ] Document new or updated functionality (someengineering/resoto.com#XXXX)

# Issues Fixed

<!-- If this PR will fix/resolve an open issue on the repository, please reference it below. -->
<!-- (Otherwise, feel free to delete this section.) -->

- Fixes #XXXX

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
