### PR TITLE
[plugins/aws][fix] Fix edge count with unique keys

### DIFF
--- a/plugins/aws/test/collector_test.py
+++ b/plugins/aws/test/collector_test.py
@@ -24,7 +24,7 @@ def test_collect() -> None:
                 count += 1
         return count
 
-    assert len(ac.graph.edges) == 315
+    assert len(ac.graph.edges) == 317
     assert count_kind(AwsResource) == 125
     for resource in all_resources:
         assert count_kind(resource) > 0, "No instances of {} found".format(resource.__name__)

--- a/plugins/aws/test/resources/files/dynamodb/describe-table__test1.json
+++ b/plugins/aws/test/resources/files/dynamodb/describe-table__test1.json
@@ -120,7 +120,7 @@
         "SSEDescription": {
             "Status": "ENABLING",
             "SSEType": "KMS",
-            "KMSMasterKeyArn": "arn:aws:kms:eu-central-1:882347060974:key/32b03fb9",
+            "KMSMasterKeyArn": "arn:aws:kms:eu-central-1:882347060974:key/bdc0c890",
             "InaccessibleEncryptionDateTime": "2022-08-08T09:36:55Z"
         },
         "ArchivalSummary": {

--- a/plugins/aws/test/resources/files/kms/describe-key__bdc0c890.json
+++ b/plugins/aws/test/resources/files/kms/describe-key__bdc0c890.json
@@ -2,7 +2,7 @@
     "KeyMetadata": {
         "AWSAccountId": "882347060974",
         "KeyId": "bdc0c890",
-        "Arn": "arn:aws:kms:eu-central-1:882347060974:key/32b03fb9",
+        "Arn": "arn:aws:kms:eu-central-1:882347060974:key/bdc0c890",
         "CreationDate": "2022-05-06T08:43:41Z",
         "Enabled": true,
         "Description": "Just some Key",


### PR DESCRIPTION
# Description

KMS Keys collected in the test run had a mixup regarding id/arn. This led to volatile behaviour in counting edges to those keys. The two test keys had different ids but same arn.

# To-Dos

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`
- [ ] Document new or updated functionality (someengineering/resoto.com#XXXX)


# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
