### PR TITLE
[plugins/aws][feat] Normalise KMS Key IDs and add edges

### DIFF
--- a/plugins/aws/resoto_plugin_aws/resource/athena.py
+++ b/plugins/aws/resoto_plugin_aws/resource/athena.py
@@ -129,10 +129,7 @@ class AwsAthenaWorkGroup(AwsResource):
             and (ec := rc.encryption_configuration)
         ):
             if ec.kms_key:
-                if ec.kms_key.startswith("arn:"):
-                    builder.dependant_node(from_node=self, clazz=AwsKmsKey, arn=ec.kms_key)
-                else:
-                    builder.dependant_node(from_node=self, clazz=AwsKmsKey, id=ec.kms_key)
+                builder.dependant_node(from_node=self, clazz=AwsKmsKey, id=AwsKmsKey.normalise_id(ec.kms_key))
 
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
         client.call(

--- a/plugins/aws/resoto_plugin_aws/resource/ec2.py
+++ b/plugins/aws/resoto_plugin_aws/resource/ec2.py
@@ -476,7 +476,7 @@ class AwsEc2Volume(EC2Taggable, AwsResource, BaseVolume):
             builder.dependant_node(
                 self,
                 clazz=AwsKmsKey,
-                id=self.volume_kms_key_id,
+                id=AwsKmsKey.normalise_id(self.volume_kms_key_id),
             )
 
     def delete_resource(self, client: AwsClient) -> bool:
@@ -538,7 +538,7 @@ class AwsEc2Snapshot(EC2Taggable, AwsResource, BaseSnapshot):
             builder.dependant_node(
                 self,
                 clazz=AwsKmsKey,
-                id=self.snapshot_kms_key_id,
+                id=AwsKmsKey.normalise_id(self.snapshot_kms_key_id),
             )
 
     def delete_resource(self, client: AwsClient) -> bool:

--- a/plugins/aws/resoto_plugin_aws/resource/kms.py
+++ b/plugins/aws/resoto_plugin_aws/resource/kms.py
@@ -130,5 +130,13 @@ class AwsKmsKey(AwsResource, BaseAccessKey):
         client.call(service="kms", action="disable-key", result_name=None, KeyId=self.id)
         return True
 
+    @staticmethod
+    def normalise_id(identifier: str) -> str:
+        if identifier.startswith("arn:"):
+            # format: "arn:aws:kms:region:account-id:key/id"
+            return identifier.rsplit("/", 1)[-1]
+        else:
+            return identifier
+
 
 resources: List[Type[AwsResource]] = [AwsKmsKey]

--- a/plugins/aws/resoto_plugin_aws/resource/rds.py
+++ b/plugins/aws/resoto_plugin_aws/resource/rds.py
@@ -477,10 +477,7 @@ class AwsRdsInstance(RdsTaggable, AwsResource, BaseDatabase):
         ]
         keys = [key for key in potential_keys if key]
         for key_reference in keys:
-            if key_reference.startswith("arn:"):
-                builder.dependant_node(from_node=self, clazz=AwsKmsKey, arn=key_reference)
-            else:
-                builder.dependant_node(from_node=self, clazz=AwsKmsKey, id=key_reference)
+            builder.dependant_node(from_node=self, clazz=AwsKmsKey, id=AwsKmsKey.normalise_id(key_reference))
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(

--- a/plugins/aws/resoto_plugin_aws/resource/rds.py
+++ b/plugins/aws/resoto_plugin_aws/resource/rds.py
@@ -464,21 +464,17 @@ class AwsRdsInstance(RdsTaggable, AwsResource, BaseDatabase):
                 builder.dependant_node(
                     self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet_id
                 )
-        if self.rds_kms_key_id:
-            if self.rds_kms_key_id.startswith("arn:"):
-                builder.dependant_node(from_node=self, clazz=AwsKmsKey, arn=self.rds_kms_key_id)
+        potential_keys = [
+            self.rds_kms_key_id,
+            self.rds_performance_insights_kms_key_id,
+            self.rds_activity_stream_kms_key_id,
+        ]
+        keys = [key for key in potential_keys if key]
+        for key_reference in keys:
+            if key_reference.startswith("arn:"):
+                builder.dependant_node(from_node=self, clazz=AwsKmsKey, arn=key_reference)
             else:
-                builder.dependant_node(from_node=self, clazz=AwsKmsKey, id=self.rds_kms_key_id)
-        if self.rds_performance_insights_kms_key_id:
-            if self.rds_performance_insights_kms_key_id.startswith("arn:"):
-                builder.dependant_node(from_node=self, clazz=AwsKmsKey, arn=self.rds_performance_insights_kms_key_id)
-            else:
-                builder.dependant_node(from_node=self, clazz=AwsKmsKey, id=self.rds_performance_insights_kms_key_id)
-        if self.rds_activity_stream_kms_key_id:
-            if self.rds_activity_stream_kms_key_id.startswith("arn:"):
-                builder.dependant_node(from_node=self, clazz=AwsKmsKey, arn=self.rds_activity_stream_kms_key_id)
-            else:
-                builder.dependant_node(from_node=self, clazz=AwsKmsKey, id=self.rds_activity_stream_kms_key_id)
+                builder.dependant_node(from_node=self, clazz=AwsKmsKey, id=key_reference)
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(

--- a/plugins/aws/resoto_plugin_aws/resource/rds.py
+++ b/plugins/aws/resoto_plugin_aws/resource/rds.py
@@ -4,6 +4,7 @@ from attr import define, field
 from resoto_plugin_aws.resource.base import AwsApiSpec, AwsResource, GraphBuilder
 from resoto_plugin_aws.resource.cloudwatch import AwsCloudwatchQuery, AwsCloudwatchMetricData
 from resoto_plugin_aws.resource.ec2 import AwsEc2SecurityGroup, AwsEc2Subnet, AwsEc2Vpc
+from resoto_plugin_aws.resource.kms import AwsKmsKey
 from resoto_plugin_aws.utils import ToDict
 from resotolib.baseresources import BaseAccount, BaseDatabase, ModelReference  # noqa: F401
 from resotolib.json_bender import F, K, S, Bend, Bender, ForallBend
@@ -248,8 +249,9 @@ class AwsRdsInstance(RdsTaggable, AwsResource, BaseDatabase):
     reference_kinds: ClassVar[ModelReference] = {
         "predecessors": {
             "default": ["aws_vpc", "aws_ec2_security_group", "aws_ec2_subnet"],
-            "delete": ["aws_vpc", "aws_ec2_security_group", "aws_ec2_subnet"],
+            "delete": ["aws_vpc", "aws_ec2_security_group", "aws_ec2_subnet", "aws_kms_key"],
         },
+        "successors": {"default": ["aws_kms_key"]},
     }
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("DBInstanceIdentifier"),
@@ -444,7 +446,6 @@ class AwsRdsInstance(RdsTaggable, AwsResource, BaseDatabase):
         update_atime_mtime()
 
     def connect_in_graph(self, builder: GraphBuilder, source: Json) -> None:
-        super().connect_in_graph(builder, source)
         for group in self.rds_vpc_security_groups:
             builder.dependant_node(
                 self,
@@ -463,6 +464,21 @@ class AwsRdsInstance(RdsTaggable, AwsResource, BaseDatabase):
                 builder.dependant_node(
                     self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet_id
                 )
+        if self.rds_kms_key_id:
+            if self.rds_kms_key_id.startswith("arn:"):
+                builder.dependant_node(from_node=self, clazz=AwsKmsKey, arn=self.rds_kms_key_id)
+            else:
+                builder.dependant_node(from_node=self, clazz=AwsKmsKey, id=self.rds_kms_key_id)
+        if self.rds_performance_insights_kms_key_id:
+            if self.rds_performance_insights_kms_key_id.startswith("arn:"):
+                builder.dependant_node(from_node=self, clazz=AwsKmsKey, arn=self.rds_performance_insights_kms_key_id)
+            else:
+                builder.dependant_node(from_node=self, clazz=AwsKmsKey, id=self.rds_performance_insights_kms_key_id)
+        if self.rds_activity_stream_kms_key_id:
+            if self.rds_activity_stream_kms_key_id.startswith("arn:"):
+                builder.dependant_node(from_node=self, clazz=AwsKmsKey, arn=self.rds_activity_stream_kms_key_id)
+            else:
+                builder.dependant_node(from_node=self, clazz=AwsKmsKey, id=self.rds_activity_stream_kms_key_id)
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(

--- a/plugins/aws/test/resources/kms_test.py
+++ b/plugins/aws/test/resources/kms_test.py
@@ -43,7 +43,7 @@ def test_disable_keys() -> None:
     key.delete_resource(client)
 
 
-def test_delete_queues() -> None:
+def test_delete_keys() -> None:
     key, _ = round_trip_for(AwsKmsKey)
 
     def validate_delete_args(**kwargs: Any) -> None:
@@ -52,3 +52,8 @@ def test_delete_queues() -> None:
 
     client = cast(AwsClient, SimpleNamespace(call=validate_delete_args))
     key.delete_resource(client)
+
+
+def test_normalise_keys() -> None:
+    assert AwsKmsKey.normalise_id("arn:aws:kms:us-west-2:test:key/kms-1") == "kms-1"
+    assert AwsKmsKey.normalise_id("kms-1") == "kms-1"


### PR DESCRIPTION
# Description

- Add edge between RDS Instances and KMS Keys
- Kms Keys can be identified by a variety of references (Id, Arn, ...). This introduces a normalisation method that leads back to the actual key id, making it simpler to add edges to Keys

# To-Dos

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
