### PR TITLE
[resotocore][fix] Use unicode characters for text result

### DIFF
--- a/resotocore/resotocore/web/content_renderer.py
+++ b/resotocore/resotocore/web/content_renderer.py
@@ -106,7 +106,7 @@ async def respond_text(gen: AsyncIterator[JsonElement]) -> AsyncGenerator[str, N
             if isinstance(js, (dict, list)):
                 if flag:
                     yield sep
-                yml = yaml.dump(to_result(js), default_flow_style=False, sort_keys=False)
+                yml = yaml.dump(to_result(js), allow_unicode=True, default_flow_style=False, sort_keys=False)
                 yield yml
             else:
                 yield str(js)


### PR DESCRIPTION
# Description

Text representation using `dump` should display unicode characters as is and note escape them.