### PR TITLE
[aws][feat] Return all API's that get called during collect

### DIFF
--- a/plugins/aws/resoto_plugin_aws/collector.py
+++ b/plugins/aws/resoto_plugin_aws/collector.py
@@ -29,7 +29,7 @@ from resoto_plugin_aws.resource import (
     sqs,
     redshift,
 )
-from resoto_plugin_aws.resource.base import AwsRegion, AwsAccount, AwsResource, GraphBuilder, ExecutorQueue
+from resoto_plugin_aws.resource.base import AwsRegion, AwsAccount, AwsResource, GraphBuilder, ExecutorQueue, AwsApiSpec
 from resotolib.baseresources import Cloud, EdgeType
 from resotolib.graph import Graph
 from resotolib.proc import set_thread_name
@@ -61,6 +61,17 @@ regional_resources: List[Type[AwsResource]] = (
     + redshift.resources
 )
 all_resources: List[Type[AwsResource]] = global_resources + regional_resources
+
+
+def called_collect_apis() -> List[AwsApiSpec]:
+    """
+    Return a list of all the APIs that are called by the collector during the collect cycle.
+    """
+    # list all calls here, that are not defined in any resource.
+    additional_calls = [AwsApiSpec("pricing", "get-products")]
+    specs = [spec for r in all_resources for spec in r.called_apis()] + additional_calls
+    unique_specs = {f"{spec.service}::{spec.api_action}": spec for spec in specs}
+    return sorted(unique_specs.values(), key=lambda s: s.service + "::" + s.api_action)
 
 
 class AwsAccountCollector:

--- a/plugins/aws/resoto_plugin_aws/resource/athena.py
+++ b/plugins/aws/resoto_plugin_aws/resource/athena.py
@@ -87,6 +87,10 @@ class AwsAthenaWorkGroup(AwsResource):
     }
 
     @classmethod
+    def called_apis(cls) -> List[AwsApiSpec]:
+        return [cls.api_spec, AwsApiSpec("athena", "get-work-group"), AwsApiSpec("athena", "list-tags-for-resource")]
+
+    @classmethod
     def collect(cls: Type[AwsResource], json: List[Json], builder: GraphBuilder) -> None:
         def fetch_workgroup(name: str) -> Optional[AwsAthenaWorkGroup]:
             result = builder.client.get(
@@ -122,6 +126,7 @@ class AwsAthenaWorkGroup(AwsResource):
                 builder.add_node(wg)
                 builder.submit_work(add_tags, wg)
 
+    # noinspection PyUnboundLocalVariable
     def connect_in_graph(self, builder: GraphBuilder, source: Json) -> None:
         if (
             (wc := self.workgroup_configuration)
@@ -176,6 +181,10 @@ class AwsAthenaDataCatalog(AwsResource):
     description: Optional[str] = None
     datacatalog_type: Optional[str] = None
     datacatalog_parameters: Optional[Dict[str, str]] = None
+
+    @classmethod
+    def called_apis(cls) -> List[AwsApiSpec]:
+        return [cls.api_spec, AwsApiSpec("athena", "get-data-catalog"), AwsApiSpec("athena", "list-tags-for-resource")]
 
     @classmethod
     def collect(cls: Type[AwsResource], json: List[Json], builder: GraphBuilder) -> None:

--- a/plugins/aws/resoto_plugin_aws/resource/base.py
+++ b/plugins/aws/resoto_plugin_aws/resource/base.py
@@ -44,6 +44,10 @@ class AwsApiSpec:
     result_property: Optional[str] = None
     parameter: Optional[Dict[str, Any]] = None
 
+    def action_string(self) -> str:
+        action = "".join(word.title() for word in self.api_action.split("-"))
+        return f"{self.service}:{action}"
+
 
 @define(eq=False, slots=False)
 class AwsResource(BaseResource, ABC):
@@ -147,6 +151,15 @@ class AwsResource(BaseResource, ABC):
         for js in json:
             instance = cls.from_api(js)
             builder.add_node(instance, js)
+
+    @classmethod
+    def called_apis(cls) -> List[AwsApiSpec]:
+        # The default implementation will return the defined api_spec if defined, otherwise an empty list.
+        # In case your resource needs more than this api call, please override this method and return the proper list.
+        if spec := cls.api_spec:
+            return [spec]
+        else:
+            return []
 
     def connect_in_graph(self, builder: GraphBuilder, source: Json) -> None:
         # Default behavior: add resource to the namespace

--- a/plugins/aws/resoto_plugin_aws/resource/cloudwatch.py
+++ b/plugins/aws/resoto_plugin_aws/resource/cloudwatch.py
@@ -14,7 +14,7 @@ from resotolib.types import Json
 from resotolib.utils import chunks
 
 
-# todo: annotate with no serialization annotation
+# noinspection PyUnresolvedReferences
 class CloudwatchTaggable:
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
         if isinstance(self, AwsResource):
@@ -264,6 +264,10 @@ class AwsCloudwatchMetricData:
             if value != 0:
                 return timestamp, value
         return None
+
+    @classmethod
+    def called_apis(cls) -> List[AwsApiSpec]:
+        return [AwsApiSpec("cloudwatch", "get_metric_data")]
 
     @staticmethod
     def query_for(

--- a/plugins/aws/resoto_plugin_aws/resource/dynamodb.py
+++ b/plugins/aws/resoto_plugin_aws/resource/dynamodb.py
@@ -304,7 +304,7 @@ class AwsDynamoDbTable(DynamoDbTaggable, AwsResource):
     def collect(cls: Type[AwsResource], json: List[Json], builder: GraphBuilder) -> None:
         def add_instance(table: str) -> None:
             table_description = builder.client.get("dynamodb", "describe-table", "Table", TableName=table)
-            if table_description:
+            if table_description is not None:
                 instance = cls.from_api(table_description)
                 builder.add_node(instance, table_description)
                 builder.submit_work(add_tags, instance)

--- a/plugins/aws/resoto_plugin_aws/resource/ec2.py
+++ b/plugins/aws/resoto_plugin_aws/resource/ec2.py
@@ -37,11 +37,10 @@ from resotolib.types import Json
 from resotolib.utils import utc
 
 
-# todo: annotate with no serialization annotation
+# noinspection PyUnresolvedReferences
 class EC2Taggable:
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
         if isinstance(self, AwsResource):
-            # noinspection PyUnresolvedReferences
             if spec := self.api_spec:
                 client.call(
                     service=spec.service,

--- a/plugins/aws/resoto_plugin_aws/resource/eks.py
+++ b/plugins/aws/resoto_plugin_aws/resource/eks.py
@@ -12,7 +12,7 @@ from resotolib.types import Json
 from resoto_plugin_aws.aws_client import AwsClient
 
 
-# todo: annotate with no serialization annotation
+# noinspection PyUnresolvedReferences
 class EKSTaggable:
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
         if isinstance(self, AwsResource):
@@ -332,6 +332,15 @@ class AwsEksCluster(EKSTaggable, AwsResource):
     cluster_platform_version: Optional[str] = field(default=None)
     cluster_encryption_config: List[AwsEksEncryptionConfig] = field(factory=list)
     cluster_connector_config: Optional[AwsEksConnectorConfig] = field(default=None)
+
+    @classmethod
+    def called_apis(cls) -> List[AwsApiSpec]:
+        return [
+            cls.api_spec,
+            AwsApiSpec("eks", "describe-cluster"),
+            AwsApiSpec("eks", "list-nodegroups"),
+            AwsApiSpec("eks", "describe-nodegroup"),
+        ]
 
     @classmethod
     def collect(cls: Type[AwsResource], json: List[Json], builder: GraphBuilder) -> None:

--- a/plugins/aws/resoto_plugin_aws/resource/elasticache.py
+++ b/plugins/aws/resoto_plugin_aws/resource/elasticache.py
@@ -14,6 +14,7 @@ from resotolib.types import Json
 from resoto_plugin_aws.resource.ec2 import AwsEc2SecurityGroup
 
 
+# noinspection PyUnresolvedReferences
 class ElastiCacheTaggable:
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
         if isinstance(self, AwsResource):
@@ -258,6 +259,10 @@ class AwsElastiCacheCacheCluster(ElastiCacheTaggable, AwsResource):
         return True
 
     @classmethod
+    def called_apis(cls) -> List[AwsApiSpec]:
+        return [cls.api_spec, AwsApiSpec(cls.api_spec.service, "list-tags-for-resource")]
+
+    @classmethod
     def collect(cls: Type[AwsResource], json: List[Json], builder: GraphBuilder) -> None:
         def add_tags(resource: AwsElastiCacheCacheCluster) -> None:
             tags = builder.client.list(
@@ -439,13 +444,14 @@ class AwsElastiCacheReplicationGroup(ElastiCacheTaggable, AwsResource):
     replication_group_data_tiering: Optional[str] = field(default=None)
 
     @classmethod
+    def called_apis(cls) -> List[AwsApiSpec]:
+        return [cls.api_spec, AwsApiSpec(cls.api_spec.service, "list-tags-for-resource")]
+
+    @classmethod
     def collect(cls: Type[AwsResource], json: List[Json], builder: GraphBuilder) -> None:
         def add_tags(resource: AwsElastiCacheReplicationGroup) -> None:
             tags = builder.client.list(
-                resource.api_spec.service,
-                "list-tags-for-resource",
-                None,
-                ResourceName=resource.arn,
+                resource.api_spec.service, "list-tags-for-resource", None, ResourceName=resource.arn
             )
             if tags:
                 resource.tags = bend(S("TagList", default=[]) >> ToDict(), tags[0])

--- a/plugins/aws/resoto_plugin_aws/resource/elasticbeanstalk.py
+++ b/plugins/aws/resoto_plugin_aws/resource/elasticbeanstalk.py
@@ -84,6 +84,10 @@ class AwsBeanstalkApplication(AwsResource):
     beanstalk_resource_lifecycle_config: Optional[AwsBeanstalkApplicationResourceLifecycleConfig] = field(default=None)
 
     @classmethod
+    def called_apis(cls) -> List[AwsApiSpec]:
+        return [cls.api_spec, AwsApiSpec(cls.api_spec.service, "list-tags-for-resource")]
+
+    @classmethod
     def collect(cls: Type[AwsResource], json: List[Json], builder: GraphBuilder) -> None:
         def add_tags(app: AwsBeanstalkApplication) -> None:
             tags = builder.client.list(
@@ -247,6 +251,14 @@ class AwsBeanstalkEnvironment(AwsResource):
     beanstalk_tier: Optional[AwsBeanstalkEnvironmentTier] = field(default=None)
     beanstalk_environment_links: List[AwsBeanstalkEnvironmentLink] = field(factory=list)
     beanstalk_operations_role: Optional[str] = field(default=None)
+
+    @classmethod
+    def called_apis(cls) -> List[AwsApiSpec]:
+        return [
+            cls.api_spec,
+            AwsApiSpec(cls.api_spec.service, "describe-environment-resources"),
+            AwsApiSpec(cls.api_spec.service, "list-tags-for-resource"),
+        ]
 
     @classmethod
     def collect(cls: Type[AwsResource], json: List[Json], builder: GraphBuilder) -> None:

--- a/plugins/aws/resoto_plugin_aws/resource/elb.py
+++ b/plugins/aws/resoto_plugin_aws/resource/elb.py
@@ -11,7 +11,7 @@ from resotolib.types import Json
 from resoto_plugin_aws.aws_client import AwsClient
 
 
-# todo: annotate with no serialization annotation
+# noinspection PyUnresolvedReferences
 class ElbTaggable:
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
         if isinstance(self, AwsResource):
@@ -180,6 +180,10 @@ class AwsElb(ElbTaggable, AwsResource, BaseLoadBalancer):
     elb_availability_zones: List[str] = field(factory=list)
     elb_health_check: Optional[AwsElbHealthCheck] = field(default=None)
     elb_source_security_group: Optional[AwsElbSourceSecurityGroup] = field(default=None)
+
+    @classmethod
+    def called_apis(cls) -> List[AwsApiSpec]:
+        return [cls.api_spec, AwsApiSpec(cls.api_spec.service, "describe-tags")]
 
     @classmethod
     def collect(cls: Type[AwsResource], json: List[Json], builder: GraphBuilder) -> None:

--- a/plugins/aws/resoto_plugin_aws/resource/elbv2.py
+++ b/plugins/aws/resoto_plugin_aws/resource/elbv2.py
@@ -12,7 +12,7 @@ from resotolib.types import Json
 from resoto_plugin_aws.aws_client import AwsClient
 
 
-# todo: annotate with no serialization annotation
+# noinspection PyUnresolvedReferences
 class ElbV2Taggable:
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
         if isinstance(self, AwsResource):
@@ -290,6 +290,10 @@ class AwsAlb(ElbV2Taggable, AwsResource, BaseLoadBalancer):
     alb_listener: List[AwsAlbListener] = field(factory=list)
 
     @classmethod
+    def called_apis(cls) -> List[AwsApiSpec]:
+        return [cls.api_spec, AwsApiSpec("elbv2", "describe-listeners"), AwsApiSpec("elbv2", "describe-tags")]
+
+    @classmethod
     def collect(cls: Type[AwsResource], json: List[Json], builder: GraphBuilder) -> None:
         for js in json:
             lb = AwsAlb.from_api(js)
@@ -403,6 +407,10 @@ class AwsAlbTargetGroup(ElbV2Taggable, AwsResource):
     alb_protocol_version: Optional[str] = field(default=None)
     alb_ip_address_type: Optional[str] = field(default=None)
     alb_target_health: List[AwsAlbTargetHealthDescription] = field(factory=list)
+
+    @classmethod
+    def called_apis(cls) -> List[AwsApiSpec]:
+        return [cls.api_spec, AwsApiSpec("elbv2", "describe-target-health"), AwsApiSpec("elbv2", "describe-tags")]
 
     @classmethod
     def collect(cls: Type[AwsResource], json: List[Json], builder: GraphBuilder) -> None:

--- a/plugins/aws/resoto_plugin_aws/resource/iam.py
+++ b/plugins/aws/resoto_plugin_aws/resource/iam.py
@@ -386,6 +386,10 @@ class AwsIamUser(AwsResource, BaseUser):
     user_permissions_boundary: Optional[AwsIamAttachedPermissionsBoundary] = field(default=None)
 
     @classmethod
+    def called_apis(cls) -> List[AwsApiSpec]:
+        return [cls.api_spec, AwsApiSpec("iam", "list-access-keys"), AwsApiSpec("iam", "get-access-key-last-used")]
+
+    @classmethod
     def collect(cls: Type[AwsResource], json_list: List[Json], builder: GraphBuilder) -> None:
         for json in json_list:
             for js in json.get("GroupDetailList", []):

--- a/plugins/aws/resoto_plugin_aws/resource/kinesis.py
+++ b/plugins/aws/resoto_plugin_aws/resource/kinesis.py
@@ -89,6 +89,10 @@ class AwsKinesisStream(AwsResource):
     kinesis_key_id: Optional[str] = field(default=None)
 
     @classmethod
+    def called_apis(cls) -> List[AwsApiSpec]:
+        return [cls.api_spec, AwsApiSpec("kinesis", "describe-stream"), AwsApiSpec("kinesis", "list_tags_for_stream")]
+
+    @classmethod
     def collect(cls: Type[AwsResource], json: List[Json], builder: GraphBuilder) -> None:
         def add_tags(stream: AwsKinesisStream) -> None:
             tags = builder.client.list(stream.api_spec.service, "list_tags_for_stream", None, StreamName=stream.name)

--- a/plugins/aws/resoto_plugin_aws/resource/kms.py
+++ b/plugins/aws/resoto_plugin_aws/resource/kms.py
@@ -96,9 +96,10 @@ class AwsKmsKey(AwsResource, BaseAccessKey):
     def collect(cls: Type[AwsResource], json: List[Json], builder: GraphBuilder) -> None:
         def add_instance(key: Dict[str, str]) -> None:
             key_metadata = builder.client.get("kms", "describe-key", result_name="KeyMetadata", KeyId=key["KeyId"])
-            instance = cls.from_api(key_metadata)
-            builder.add_node(instance)
-            builder.submit_work_shared_pool(add_tags, instance)
+            if key_metadata is not None:
+                instance = cls.from_api(key_metadata)
+                builder.add_node(instance)
+                builder.submit_work_shared_pool(add_tags, instance)
 
         def add_tags(key: AwsKmsKey) -> None:
             tags = builder.client.list("kms", "list-resource-tags", result_name=None, KeyId=key.id)

--- a/plugins/aws/resoto_plugin_aws/resource/kms.py
+++ b/plugins/aws/resoto_plugin_aws/resource/kms.py
@@ -89,9 +89,13 @@ class AwsKmsKey(AwsResource, BaseAccessKey):
     kms_mac_algorithms: List[str] = field(factory=list)
 
     @classmethod
+    def called_apis(cls) -> List[AwsApiSpec]:
+        return [cls.api_spec, AwsApiSpec("kms", "describe-key"), AwsApiSpec("kms", "list-resource-tags")]
+
+    @classmethod
     def collect(cls: Type[AwsResource], json: List[Json], builder: GraphBuilder) -> None:
         def add_instance(key: Dict[str, str]) -> None:
-            key_metadata = builder.client.call("kms", "describe-key", result_name="KeyMetadata", KeyId=key["KeyId"])
+            key_metadata = builder.client.get("kms", "describe-key", result_name="KeyMetadata", KeyId=key["KeyId"])
             instance = cls.from_api(key_metadata)
             builder.add_node(instance)
             builder.submit_work_shared_pool(add_tags, instance)

--- a/plugins/aws/resoto_plugin_aws/resource/lambda_.py
+++ b/plugins/aws/resoto_plugin_aws/resource/lambda_.py
@@ -173,6 +173,10 @@ class AwsLambdaFunction(AwsResource, BaseServerlessFunction):
     function_ephemeral_storage: Optional[int] = field(default=None)
 
     @classmethod
+    def called_apis(cls) -> List[AwsApiSpec]:
+        return [cls.api_spec, AwsApiSpec("lambda", "list-tags")]
+
+    @classmethod
     def collect(cls: Type[AwsResource], json: List[Json], builder: GraphBuilder) -> None:
         def add_tags(function: AwsLambdaFunction) -> None:
             tags = builder.client.list("lambda", "list-tags", "Tags", Resource=function.arn)

--- a/plugins/aws/resoto_plugin_aws/resource/pricing.py
+++ b/plugins/aws/resoto_plugin_aws/resource/pricing.py
@@ -138,3 +138,6 @@ class AwsPricingPrice:
             {"Type": "TERM_MATCH", "Field": "location", "Value": pricing_region(region)},
         ]
         return cls.single_price_for(client, "AmazonEC2", search_filter)
+
+
+resources = [AwsPricingPrice]

--- a/plugins/aws/resoto_plugin_aws/resource/rds.py
+++ b/plugins/aws/resoto_plugin_aws/resource/rds.py
@@ -13,7 +13,7 @@ from resotolib.utils import utc
 from resoto_plugin_aws.aws_client import AwsClient
 
 
-# todo: annotate with no serialization annotation
+# noinspection PyUnresolvedReferences
 class RdsTaggable:
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
         if isinstance(self, AwsResource):
@@ -406,6 +406,10 @@ class AwsRdsInstance(RdsTaggable, AwsResource, BaseDatabase):
     rds_custom_iam_instance_profile: Optional[str] = field(default=None)
     rds_backup_target: Optional[str] = field(default=None)
     rds_network_type: Optional[str] = field(default=None)
+
+    @classmethod
+    def called_apis(cls) -> List[AwsApiSpec]:
+        return [cls.api_spec, AwsApiSpec(cls.api_spec.service, "list-tags-for-resource")]
 
     @classmethod
     def collect(cls: Type[AwsResource], json: List[Json], builder: GraphBuilder) -> None:

--- a/plugins/aws/resoto_plugin_aws/resource/route53.py
+++ b/plugins/aws/resoto_plugin_aws/resource/route53.py
@@ -64,6 +64,14 @@ class AwsRoute53Zone(AwsResource, BaseDNSZone):
     zone_linked_service: Optional[AwsRoute53LinkedService] = field(default=None)
 
     @classmethod
+    def called_apis(cls) -> List[AwsApiSpec]:
+        return [
+            cls.api_spec,
+            AwsApiSpec("route53", "list-resource-record-sets"),
+            AwsApiSpec("route53", "list-tags-for-resource"),
+        ]
+
+    @classmethod
     def collect(cls: Type[AwsResource], json: List[Json], builder: GraphBuilder) -> None:
         def add_tags(zone: AwsRoute53Zone) -> None:
             tags = builder.client.list(

--- a/plugins/aws/resoto_plugin_aws/resource/s3.py
+++ b/plugins/aws/resoto_plugin_aws/resource/s3.py
@@ -19,6 +19,10 @@ class AwsS3Bucket(AwsResource, BaseBucket):
     mapping: ClassVar[Dict[str, Bender]] = {"id": S("Name"), "name": S("Name"), "ctime": S("CreationDate")}
 
     @classmethod
+    def called_apis(cls) -> List[AwsApiSpec]:
+        return [cls.api_spec, AwsApiSpec("s3", "get-bucket-tagging")]
+
+    @classmethod
     def collect(cls: Type[AwsResource], json: List[Json], builder: GraphBuilder) -> None:
         def add_tags(bucket: AwsS3Bucket, client: AwsClient) -> None:
             tags = bucket._get_tags(client)
@@ -42,7 +46,7 @@ class AwsS3Bucket(AwsResource, BaseBucket):
         """Fetch the S3 buckets tags from the AWS API."""
         tags: Dict[str, str] = {}
         try:
-            response = client.call(service="s3", action="get_bucket_tagging", result_name="TagSet", Bucket=self.name)
+            response = client.call(service="s3", action="get-bucket-tagging", result_name="TagSet", Bucket=self.name)
             tags = tags_as_dict(response)  # type: ignore
         except botocore.exceptions.ClientError as e:
             if e.response["Error"]["Code"] != "NoSuchTagSet":

--- a/plugins/aws/resoto_plugin_aws/resource/service_quotas.py
+++ b/plugins/aws/resoto_plugin_aws/resource/service_quotas.py
@@ -5,7 +5,7 @@ from typing import ClassVar, Dict, Optional, Type, Any, List, Pattern, Union
 from attr import field
 from attrs import define
 
-from resoto_plugin_aws.resource.base import AwsResource, GraphBuilder
+from resoto_plugin_aws.resource.base import AwsResource, GraphBuilder, AwsApiSpec
 from resotolib.baseresources import BaseAccount, BaseQuota, EdgeType, ModelReference  # noqa: F401
 from resotolib.json_bender import Bender, S, Bend
 from resotolib.types import Json
@@ -80,6 +80,10 @@ class AwsServiceQuota(AwsResource, BaseQuota):
     quota_usage_metric: Optional[AwsQuotaMetricInfo] = field(default=None)
     quota_period: Optional[AwsQuotaPeriod] = field(default=None)
     quota_error_reason: Optional[AwsQuotaErrorReason] = field(default=None)
+
+    @classmethod
+    def called_apis(cls) -> List[AwsApiSpec]:
+        return [AwsApiSpec("service-quotas", "list_service_quotas")]
 
     @classmethod
     def collect_resources(cls: Type[AwsResource], builder: GraphBuilder) -> None:

--- a/plugins/aws/resoto_plugin_aws/resource/sqs.py
+++ b/plugins/aws/resoto_plugin_aws/resource/sqs.py
@@ -62,9 +62,13 @@ class AwsSqsQueue(AwsResource):
     sqs_managed_sse_enabled: Optional[bool] = field(default=None)
 
     @classmethod
+    def called_apis(cls) -> List[AwsApiSpec]:
+        return [cls.api_spec, AwsApiSpec("sqs", "get-queue-attributes"), AwsApiSpec("sqs", "list-queue-tags")]
+
+    @classmethod
     def collect(cls: Type[AwsResource], json: List[Json], builder: GraphBuilder) -> None:
         def add_instance(queue_url: str) -> None:
-            queue_attributes = builder.client.call(
+            queue_attributes = builder.client.get(
                 "sqs", "get-queue-attributes", "Attributes", QueueUrl=queue_url, AttributeNames=["All"]
             )
             queue_attributes["QueueUrl"] = queue_url

--- a/plugins/aws/resoto_plugin_aws/resource/sqs.py
+++ b/plugins/aws/resoto_plugin_aws/resource/sqs.py
@@ -71,17 +71,18 @@ class AwsSqsQueue(AwsResource):
             queue_attributes = builder.client.get(
                 "sqs", "get-queue-attributes", "Attributes", QueueUrl=queue_url, AttributeNames=["All"]
             )
-            queue_attributes["QueueUrl"] = queue_url
-            queue_attributes["QueueName"] = queue_url.rsplit("/", 1)[-1]
-            queue_attributes["CreatedTimestamp"] = datetime.fromtimestamp(
-                queue_attributes["CreatedTimestamp"]
-            ).isoformat()
-            queue_attributes["LastModifiedTimestamp"] = datetime.fromtimestamp(
-                queue_attributes["LastModifiedTimestamp"]
-            ).isoformat()
-            instance = cls.from_api(queue_attributes)
-            builder.add_node(instance)
-            builder.submit_work_shared_pool(add_tags, instance)
+            if queue_attributes is not None:
+                queue_attributes["QueueUrl"] = queue_url
+                queue_attributes["QueueName"] = queue_url.rsplit("/", 1)[-1]
+                queue_attributes["CreatedTimestamp"] = datetime.fromtimestamp(
+                    queue_attributes["CreatedTimestamp"]
+                ).isoformat()
+                queue_attributes["LastModifiedTimestamp"] = datetime.fromtimestamp(
+                    queue_attributes["LastModifiedTimestamp"]
+                ).isoformat()
+                instance = cls.from_api(queue_attributes)
+                builder.add_node(instance)
+                builder.submit_work_shared_pool(add_tags, instance)
 
         def add_tags(queue: AwsSqsQueue) -> None:
             tags = builder.client.list("sqs", "list-queue-tags", result_name="Tags", QueueUrl=[queue.sqs_queue_url])

--- a/plugins/aws/test/resources/__init__.py
+++ b/plugins/aws/test/resources/__init__.py
@@ -106,7 +106,7 @@ class BotoErrorSession(Session):  # type: ignore
 
 
 def all_props_set(obj: AwsResourceType, ignore_props: Set[str]) -> None:
-    for field in fields(type(obj)):  # type: ignore
+    for field in fields(type(obj)):
         prop = field.name
         if (
             not prop.startswith("_")

--- a/plugins/aws/test/resources/__init__.py
+++ b/plugins/aws/test/resources/__init__.py
@@ -106,7 +106,7 @@ class BotoErrorSession(Session):  # type: ignore
 
 
 def all_props_set(obj: AwsResourceType, ignore_props: Set[str]) -> None:
-    for field in fields(type(obj)):
+    for field in fields(type(obj)):  # type: ignore
         prop = field.name
         if (
             not prop.startswith("_")

--- a/plugins/aws/test/resources/s3_test.py
+++ b/plugins/aws/test/resources/s3_test.py
@@ -16,7 +16,7 @@ def test_tagging() -> None:
     bucket, _ = round_trip_for(AwsS3Bucket)
 
     def validate_update_args(**kwargs: Any) -> Any:
-        if kwargs["action"] == "get_bucket_tagging":
+        if kwargs["action"] == "get-bucket-tagging":
             assert kwargs["Bucket"] == bucket.name
             return [{"Key": "foo", "Value": "bar"}]
 
@@ -25,7 +25,7 @@ def test_tagging() -> None:
             assert kwargs["Tagging"] == {"TagSet": [{"Key": "foo", "Value": "bar"}]}
 
     def validate_delete_args(**kwargs: Any) -> Any:
-        if kwargs["action"] == "get_bucket_tagging":
+        if kwargs["action"] == "get-bucket-tagging":
             assert kwargs["Bucket"] == bucket.name
             return [{"Key": "foo", "Value": "bar"}]
 


### PR DESCRIPTION
# Description

This creates a list of all API calls that are made. This way it should be possible to create an IAM policy document.

Example:
```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "AllowResotoAccess",
      "Effect": "Allow",
      "Action": [
        "athena:GetDataCatalog",
        "athena:GetWorkGroup",
        "athena:ListDataCatalogs",
        "athena:ListTagsForResource",
        "athena:ListWorkGroups",
        "autoscaling:DescribeAutoScalingGroups",
        "cloudformation:DescribeStacks",
        "cloudformation:ListStackSets",
        "cloudwatch:DescribeAlarms",
        "dynamodb:DescribeGlobalTable",
        "dynamodb:DescribeTable",
        "dynamodb:ListGlobalTables",
        "dynamodb:ListTables",
        "dynamodb:ListTagsOfResource",
        "ec2:DescribeAddresses",
        "ec2:DescribeInstanceTypes",
        "ec2:DescribeInstances",
        "ec2:DescribeInternetGateways",
        "ec2:DescribeKeyPairs",
        "ec2:DescribeNatGateways",
        "ec2:DescribeNetworkAcls",
        "ec2:DescribeNetworkInterfaces",
        "ec2:DescribeReservedInstances",
        "ec2:DescribeRouteTables",
        "ec2:DescribeSecurityGroups",
        "ec2:DescribeSnapshots",
        "ec2:DescribeSubnets",
        "ec2:DescribeVolumes",
        "ec2:DescribeVpcEndpoints",
        "ec2:DescribeVpcPeeringConnections",
        "ec2:DescribeVpcs",
        "eks:DescribeCluster",
        "eks:DescribeNodegroup",
        "eks:ListClusters",
        "eks:ListNodegroups",
        "elasticache:DescribeCacheClusters",
        "elasticache:DescribeReplicationGroups",
        "elasticache:ListTagsForResource",
        "elasticbeanstalk:DescribeApplications",
        "elasticbeanstalk:DescribeEnvironmentResources",
        "elasticbeanstalk:DescribeEnvironments",
        "elasticbeanstalk:ListTagsForResource",
        "elb:DescribeLoadBalancers",
        "elb:DescribeTags",
        "elbv2:DescribeListeners",
        "elbv2:DescribeLoadBalancers",
        "elbv2:DescribeTags",
        "elbv2:DescribeTargetGroups",
        "elbv2:DescribeTargetHealth",
        "iam:GetAccessKeyLastUsed",
        "iam:GetAccountAuthorizationDetails",
        "iam:ListAccessKeys",
        "iam:ListInstanceProfiles",
        "iam:ListServerCertificates",
        "kinesis:DescribeStream",
        "kinesis:ListStreams",
        "kinesis:List_Tags_For_Stream",
        "kms:DescribeKey",
        "kms:ListKeys",
        "kms:ListResourceTags",
        "lambda:ListFunctions",
        "lambda:ListTags",
        "pricing:GetProducts",
        "rds:DescribeDbInstances",
        "rds:ListTagsForResource",
        "redshift:DescribeClusters",
        "route53:ListHostedZones",
        "route53:ListResourceRecordSets",
        "route53:ListTagsForResource",
        "s3:GetBucketTagging",
        "s3:ListBuckets",
        "service-quotas:List_Service_Quotas",
        "sqs:GetQueueAttributes",
        "sqs:ListQueueTags",
        "sqs:ListQueues"
      ],
      "Resource": "*"
    }
  ]
}
```


# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
