### PR TITLE
[resotocore][fix] Do not run jupyterlite build when in pypy

### DIFF
--- a/resotocore/setup.py
+++ b/resotocore/setup.py
@@ -28,10 +28,15 @@ class PostDevelopCommand(develop):
 
     def run(self):
         develop.run(self)
-        import pip
 
-        pip.main(["install", "-r", "requirements-jupyterlite.txt"])
-        check_call(["jupyter", "lite", "build"])
+        import sys
+
+        is_pypy = "__pypy__" in sys.builtin_module_names
+        if not is_pypy:
+            import pip
+
+            pip.main(["install", "-r", "requirements-jupyterlite.txt"])
+            check_call(["jupyter", "lite", "build"])
 
 
 setup(


### PR DESCRIPTION
# Description

If pypy is detected, jupyterlite won't generate assets instead of failing with a cloudpickle error. cloudpickle does not support pypy runtime.

# To-Dos

- [ ] Add test coverage for new or updated functionality
- [ ] Lint and test with `tox`
- [ ] Document new or updated functionality (someengineering/resoto.com#XXXX)


# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
