### PR TITLE
[aws][chore] Rename service parameter for client calls

### DIFF
--- a/plugins/aws/resoto_plugin_aws/resource/apigateway.py
+++ b/plugins/aws/resoto_plugin_aws/resource/apigateway.py
@@ -21,7 +21,7 @@ class ApiGatewayTaggable:
         if isinstance(self, AwsResource):
             if spec := self.api_spec:
                 client.call(
-                    service=spec.service,
+                    aws_service=spec.service,
                     action="tag-resource",
                     result_name=None,
                     resourceArn=self.arn,
@@ -35,7 +35,7 @@ class ApiGatewayTaggable:
         if isinstance(self, AwsResource):
             if spec := self.api_spec:
                 client.call(
-                    service=spec.service,
+                    aws_service=spec.service,
                     action="untag-resource",
                     result_name=None,
                     resourceArn=self.arn,
@@ -172,7 +172,7 @@ class AwsApiGatewayResource(AwsResource):
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
-            service="apigateway",
+            aws_service="apigateway",
             action="delete-resource",
             result_name=None,
             restApiId=self.api_link,
@@ -226,7 +226,7 @@ class AwsApiGatewayAuthorizer(AwsResource):
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
-            service="apigateway",
+            aws_service="apigateway",
             action="delete-authorizer",
             result_name=None,
             restApiId=self.api_link,
@@ -291,7 +291,7 @@ class AwsApiGatewayStage(ApiGatewayTaggable, AwsResource):
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
-            service="apigateway",
+            aws_service="apigateway",
             action="delete-stage",
             result_name=None,
             restApiId=self.api_link,
@@ -319,7 +319,7 @@ class AwsApiGatewayDeployment(AwsResource):
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
-            service="apigateway",
+            aws_service="apigateway",
             action="delete-deployment",
             result_name=None,
             restApiId=self.api_link,
@@ -437,7 +437,7 @@ class AwsApiGatewayRestApi(ApiGatewayTaggable, AwsResource):
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
-            service=self.api_spec.service,
+            aws_service=self.api_spec.service,
             action="delete-rest-api",
             result_name=None,
             restApiId=self.id,

--- a/plugins/aws/resoto_plugin_aws/resource/athena.py
+++ b/plugins/aws/resoto_plugin_aws/resource/athena.py
@@ -93,7 +93,7 @@ class AwsAthenaWorkGroup(AwsResource):
     def collect(cls: Type[AwsResource], json: List[Json], builder: GraphBuilder) -> None:
         def fetch_workgroup(name: str) -> Optional[AwsAthenaWorkGroup]:
             result = builder.client.get(
-                service="athena", action="get-work-group", result_name="WorkGroup", WorkGroup=name
+                aws_service="athena", action="get-work-group", result_name="WorkGroup", WorkGroup=name
             )
             if result is None:
                 return None
@@ -134,7 +134,7 @@ class AwsAthenaWorkGroup(AwsResource):
 
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
         client.call(
-            service=self.api_spec.service,
+            aws_service=self.api_spec.service,
             action="tag_resource",
             result_name=None,
             ResourceARN=self.arn,
@@ -144,7 +144,7 @@ class AwsAthenaWorkGroup(AwsResource):
 
     def delete_resource_tag(self, client: AwsClient, key: str) -> bool:
         client.call(
-            service=self.api_spec.service,
+            aws_service=self.api_spec.service,
             action="untag_resource",
             result_name=None,
             ResourceARN=self.arn,
@@ -154,7 +154,7 @@ class AwsAthenaWorkGroup(AwsResource):
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
-            service=self.api_spec.service,
+            aws_service=self.api_spec.service,
             action="delete-work-group",
             result_name=None,
             WorkGroup=self.name,
@@ -186,7 +186,7 @@ class AwsAthenaDataCatalog(AwsResource):
     def collect(cls: Type[AwsResource], json: List[Json], builder: GraphBuilder) -> None:
         def fetch_data_catalog(data_catalog_name: str) -> Optional[AwsAthenaDataCatalog]:
             result = builder.client.get(
-                service="athena",
+                aws_service="athena",
                 action="get-data-catalog",
                 result_name="DataCatalog",
                 Name=data_catalog_name,
@@ -218,7 +218,7 @@ class AwsAthenaDataCatalog(AwsResource):
 
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
         client.call(
-            service=self.api_spec.service,
+            aws_service=self.api_spec.service,
             action="tag_resource",
             result_name=None,
             ResourceARN=self.arn,
@@ -228,7 +228,7 @@ class AwsAthenaDataCatalog(AwsResource):
 
     def delete_resource_tag(self, client: AwsClient, key: str) -> bool:
         client.call(
-            service=self.api_spec.service,
+            aws_service=self.api_spec.service,
             action="untag_resource",
             result_name=None,
             ResourceARN=self.arn,
@@ -237,7 +237,7 @@ class AwsAthenaDataCatalog(AwsResource):
         return True
 
     def delete_resource(self, client: AwsClient) -> bool:
-        client.call(service="athena", action="delete-data-catalog", result_name=None, Name=self.name)
+        client.call(aws_service="athena", action="delete-data-catalog", result_name=None, Name=self.name)
         return True
 
 

--- a/plugins/aws/resoto_plugin_aws/resource/autoscaling.py
+++ b/plugins/aws/resoto_plugin_aws/resource/autoscaling.py
@@ -281,7 +281,7 @@ class AwsAutoScalingGroup(AwsResource, BaseAutoScalingGroup):
 
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
         client.call(
-            service="autoscaling",
+            aws_service="autoscaling",
             action="create_or_update_tags",
             result_name=None,
             Tags=[
@@ -298,7 +298,7 @@ class AwsAutoScalingGroup(AwsResource, BaseAutoScalingGroup):
 
     def delete_resource_tag(self, client: AwsClient, key: str) -> bool:
         client.call(
-            service="autoscaling",
+            aws_service="autoscaling",
             action="delete_tags",
             result_name=None,
             Tags=[
@@ -313,7 +313,7 @@ class AwsAutoScalingGroup(AwsResource, BaseAutoScalingGroup):
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
-            service=self.api_spec.service,
+            aws_service=self.api_spec.service,
             action="delete_auto_scaling_group",
             result_name=None,
             AutoScalingGroupName=self.name,

--- a/plugins/aws/resoto_plugin_aws/resource/cloudformation.py
+++ b/plugins/aws/resoto_plugin_aws/resource/cloudformation.py
@@ -115,13 +115,14 @@ class AwsCloudFormationStack(AwsResource, BaseStack):
             return False
         service = self.api_spec.service
         stack = cast(
-            Json, client.call(service=service, action="describe_stacks", result_name="Stacks", StackName=self.name)[0]
+            Json,
+            client.call(aws_service=service, action="describe_stacks", result_name="Stacks", StackName=self.name)[0],
         )
         stack = self._wait_for_completion(client, stack, service)
 
         try:
             client.call(
-                service="cloudformation",
+                aws_service="cloudformation",
                 action="update_stack",
                 result_name=None,
                 StackName=self.name,
@@ -148,7 +149,8 @@ class AwsCloudFormationStack(AwsResource, BaseStack):
                 )
             time.sleep(5)
             stack = cast(
-                Json, client.call(service=service, action="describe_stacks", result_name="Stacks", StackName=self.name)
+                Json,
+                client.call(aws_service=service, action="describe_stacks", result_name="Stacks", StackName=self.name),
             )
         return stack
 
@@ -159,7 +161,7 @@ class AwsCloudFormationStack(AwsResource, BaseStack):
         return self._modify_tag(client, key, None, "delete")
 
     def delete_resource(self, client: AwsClient) -> bool:
-        client.call(service=self.api_spec.service, action="delete_stack", result_name=None, StackName=self.name)
+        client.call(aws_service=self.api_spec.service, action="delete_stack", result_name=None, StackName=self.name)
         return True
 
 
@@ -215,7 +217,7 @@ class AwsCloudFormationStackSet(AwsResource):
 
         try:
             client.call(
-                service="cloudformation",
+                aws_service="cloudformation",
                 action="update_stack_set",
                 result_name=None,
                 StackSetName=self.name,
@@ -242,7 +244,7 @@ class AwsCloudFormationStackSet(AwsResource):
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
-            service=self.api_spec.service,
+            aws_service=self.api_spec.service,
             action="delete_stack_set",
             result_name=None,
             StackSetName=self.name,

--- a/plugins/aws/resoto_plugin_aws/resource/cloudwatch.py
+++ b/plugins/aws/resoto_plugin_aws/resource/cloudwatch.py
@@ -20,7 +20,7 @@ class CloudwatchTaggable:
         if isinstance(self, AwsResource):
             if spec := self.api_spec:
                 client.call(
-                    service=spec.service,
+                    aws_service=spec.service,
                     action="tag_resource",
                     result_name=None,
                     ResourceARN=self.arn,
@@ -34,7 +34,7 @@ class CloudwatchTaggable:
         if isinstance(self, AwsResource):
             if spec := self.api_spec:
                 client.call(
-                    service=spec.service,
+                    aws_service=spec.service,
                     action="untag_resource",
                     result_name=None,
                     ResourceARN=self.arn,
@@ -185,7 +185,7 @@ class AwsCloudwatchAlarm(CloudwatchTaggable, AwsResource):
             )
 
     def delete_resource(self, client: AwsClient) -> bool:
-        client.call(service=self.api_spec.service, action="delete_alarms", result_name=None, AlarmNames=[self.name])
+        client.call(aws_service=self.api_spec.service, action="delete_alarms", result_name=None, AlarmNames=[self.name])
         return True
 
 

--- a/plugins/aws/resoto_plugin_aws/resource/dynamodb.py
+++ b/plugins/aws/resoto_plugin_aws/resource/dynamodb.py
@@ -16,7 +16,7 @@ class DynamoDbTaggable:
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
         if isinstance(self, AwsResource):
             client.call(
-                service="dynamodb",
+                aws_service="dynamodb",
                 action="tag-resource",
                 result_name=None,
                 ResourceArn=self.arn,
@@ -28,7 +28,7 @@ class DynamoDbTaggable:
     def delete_resource_tag(self, client: AwsClient, key: str) -> bool:
         if isinstance(self, AwsResource):
             client.call(
-                service="dynamodb",
+                aws_service="dynamodb",
                 action="untag-resource",
                 result_name=None,
                 ResourceArn=self.arn,
@@ -340,7 +340,7 @@ class AwsDynamoDbTable(DynamoDbTaggable, AwsResource):
             )
 
     def delete_resource(self, client: AwsClient) -> bool:
-        client.call(service=self.api_spec.service, action="delete-table", result_name=None, TableName=self.name)
+        client.call(aws_service=self.api_spec.service, action="delete-table", result_name=None, TableName=self.name)
         return True
 
 
@@ -403,7 +403,7 @@ class AwsDynamoDbGlobalTable(DynamoDbTaggable, AwsResource):
                     )
 
     def delete_resource(self, client: AwsClient) -> bool:
-        client.call(service=self.api_spec.service, action="delete-table", result_name=None, TableName=self.name)
+        client.call(aws_service=self.api_spec.service, action="delete-table", result_name=None, TableName=self.name)
         return True
 
 

--- a/plugins/aws/resoto_plugin_aws/resource/ec2.py
+++ b/plugins/aws/resoto_plugin_aws/resource/ec2.py
@@ -43,7 +43,7 @@ class EC2Taggable:
         if isinstance(self, AwsResource):
             if spec := self.api_spec:
                 client.call(
-                    service=spec.service,
+                    aws_service=spec.service,
                     action="create_tags",
                     result_name=None,
                     Resources=[self.id],
@@ -57,7 +57,7 @@ class EC2Taggable:
         if isinstance(self, AwsResource):
             if spec := self.api_spec:
                 client.call(
-                    service=spec.service,
+                    aws_service=spec.service,
                     action="delete_tags",
                     result_name=None,
                     Resources=[self.id],
@@ -480,7 +480,7 @@ class AwsEc2Volume(EC2Taggable, AwsResource, BaseVolume):
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
-            service=self.api_spec.service,
+            aws_service=self.api_spec.service,
             action="delete_volume",
             result_name=None,
             VolumeId=self.id,
@@ -541,7 +541,7 @@ class AwsEc2Snapshot(EC2Taggable, AwsResource, BaseSnapshot):
             )
 
     def delete_resource(self, client: AwsClient) -> bool:
-        client.call(service=self.api_spec.service, action="delete_snapshot", result_name=None, SnapshotId=self.id)
+        client.call(aws_service=self.api_spec.service, action="delete_snapshot", result_name=None, SnapshotId=self.id)
 
         return True
 
@@ -576,7 +576,7 @@ class AwsEc2KeyPair(EC2Taggable, AwsResource):
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
-            service=self.api_spec.service,
+            aws_service=self.api_spec.service,
             action="delete_key_pair",
             result_name=None,
             KeyPairId=self.id,
@@ -1035,7 +1035,7 @@ class AwsEc2Instance(EC2Taggable, AwsResource, BaseInstance):
             self.log("Instance is already terminated")
             return True
         client.call(
-            service=self.api_spec.service,
+            aws_service=self.api_spec.service,
             action="terminate_instances",
             result_name=None,
             InstanceIds=[self.id],
@@ -1196,7 +1196,9 @@ class AwsEc2NetworkAcl(EC2Taggable, AwsResource):
             builder.dependant_node(self, reverse=True, clazz=AwsEc2Subnet, name=association.subnet_id)
 
     def delete_resource(self, client: AwsClient) -> bool:
-        client.call(service=self.api_spec.service, action="delete_network_acl", result_name=None, NetworkAclId=self.id)
+        client.call(
+            aws_service=self.api_spec.service, action="delete_network_acl", result_name=None, NetworkAclId=self.id
+        )
         return True
 
 
@@ -1254,7 +1256,7 @@ class AwsEc2ElasticIp(EC2Taggable, AwsResource, BaseIPAddress):
     def pre_delete_resource(self, client: AwsClient, graph: Graph) -> bool:
         if self.ip_association_id:
             client.call(
-                service=self.api_spec.service,
+                aws_service=self.api_spec.service,
                 action="disassociate_address",
                 result_name=None,
                 AssociationId=self.ip_association_id,
@@ -1264,7 +1266,7 @@ class AwsEc2ElasticIp(EC2Taggable, AwsResource, BaseIPAddress):
     def delete_resource(self, client: AwsClient) -> bool:
 
         client.call(
-            service=self.api_spec.service,
+            aws_service=self.api_spec.service,
             action="release_address",
             result_name=None,
             AllocationId=self.ip_allocation_id,
@@ -1418,7 +1420,7 @@ class AwsEc2NetworkInterface(EC2Taggable, AwsResource, BaseNetworkInterface):
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
-            service=self.api_spec.service,
+            aws_service=self.api_spec.service,
             action="delete_network_interface",
             result_name=None,
             NetworkInterfaceId=self.id,
@@ -1501,7 +1503,7 @@ class AwsEc2Vpc(EC2Taggable, AwsResource, BaseNetwork):
             log_msg = f"Not removing the default VPC {self.id} - aborting delete request"
             self.log(log_msg)
             return False
-        client.call(service=self.api_spec.service, action="delete_vpc", result_name=None, VpcId=self.id)
+        client.call(aws_service=self.api_spec.service, action="delete_vpc", result_name=None, VpcId=self.id)
         return True
 
 
@@ -1579,7 +1581,7 @@ class AwsEc2VpcPeeringConnection(EC2Taggable, AwsResource, BasePeeringConnection
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
-            service=self.api_spec.service,
+            aws_service=self.api_spec.service,
             action="delete_vpc_peering_connection",
             result_name=None,
             VpcPeeringConnectionId=self.id,
@@ -1681,7 +1683,7 @@ class AwsEc2VpcEndpoint(EC2Taggable, AwsResource, BaseEndpoint):
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
-            service=self.api_spec.service, action="delete_vpc_endpoints", result_name=None, VpcEndpointIds=[self.id]
+            aws_service=self.api_spec.service, action="delete_vpc_endpoints", result_name=None, VpcEndpointIds=[self.id]
         )
         return True
 
@@ -1782,7 +1784,7 @@ class AwsEc2Subnet(EC2Taggable, AwsResource, BaseSubnet):
             builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Vpc, id=vpc_id)
 
     def delete_resource(self, client: AwsClient) -> bool:
-        client.call(service=self.api_spec.service, action="delete_subnet", result_name=None, SubnetId=self.id)
+        client.call(aws_service=self.api_spec.service, action="delete_subnet", result_name=None, SubnetId=self.id)
         return True
 
 
@@ -1885,7 +1887,7 @@ class AwsEc2SecurityGroup(EC2Taggable, AwsResource, BaseSecurityGroup):
         remove_egress = []
 
         security_groups = client.call(
-            service=self.api_spec.service,
+            aws_service=self.api_spec.service,
             action="describe_security_groups",
             result_name="SecurityGroups",
             GroupIds=[self.id],
@@ -1905,7 +1907,7 @@ class AwsEc2SecurityGroup(EC2Taggable, AwsResource, BaseSecurityGroup):
 
         if len(remove_ingress) > 0:
             client.call(
-                service=self.api_spec.service,
+                aws_service=self.api_spec.service,
                 action="revoke_security_group_ingress",
                 result_name=None,
                 IpPermissions=remove_ingress,
@@ -1913,7 +1915,7 @@ class AwsEc2SecurityGroup(EC2Taggable, AwsResource, BaseSecurityGroup):
 
         if len(remove_egress) > 0:
             client.call(
-                service=self.api_spec.service,
+                aws_service=self.api_spec.service,
                 action="revoke_security_group_egress",
                 result_name=None,
                 IpPermissions=remove_egress,
@@ -1922,7 +1924,7 @@ class AwsEc2SecurityGroup(EC2Taggable, AwsResource, BaseSecurityGroup):
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
-            service=self.api_spec.service,
+            aws_service=self.api_spec.service,
             action="delete_security_group",
             result_name=None,
             GroupId=self.id,
@@ -2006,7 +2008,9 @@ class AwsEc2NatGateway(EC2Taggable, AwsResource, BaseGateway):
                 builder.dependant_node(self, clazz=AwsEc2NetworkInterface, id=network_interface_id)
 
     def delete_resource(self, client: AwsClient) -> bool:
-        client.call(service=self.api_spec.service, action="delete_nat_gateway", result_name=None, NatGatewayId=self.id)
+        client.call(
+            aws_service=self.api_spec.service, action="delete_nat_gateway", result_name=None, NatGatewayId=self.id
+        )
         return True
 
 
@@ -2049,7 +2053,7 @@ class AwsEc2InternetGateway(EC2Taggable, AwsResource, BaseGateway):
                 log_msg = f"Detaching {predecessor.kind} {predecessor.dname}"
                 self.log(log_msg)
                 client.call(
-                    service=self.api_spec.service,
+                    aws_service=self.api_spec.service,
                     action="detach_internet_gateway",
                     result_name=None,
                     InternetGatewayId=self.id,
@@ -2059,7 +2063,7 @@ class AwsEc2InternetGateway(EC2Taggable, AwsResource, BaseGateway):
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
-            service=self.api_spec.service,
+            aws_service=self.api_spec.service,
             action="delete_internet_gateway",
             result_name=None,
             InternetGatewayId=self.id,
@@ -2169,7 +2173,7 @@ class AwsEc2RouteTable(EC2Taggable, AwsResource, BaseRoutingTable):
                 log_msg = f"Deleting route table association {rta.route_table_association_id}"
                 self.log(log_msg)
                 client.call(
-                    service=self.api_spec.service,
+                    aws_service=self.api_spec.service,
                     action="disassociate_route_table",
                     result_name=None,
                     AssociationId=rta.route_table_association_id,
@@ -2177,7 +2181,9 @@ class AwsEc2RouteTable(EC2Taggable, AwsResource, BaseRoutingTable):
         return True
 
     def delete_resource(self, client: AwsClient) -> bool:
-        client.call(service=self.api_spec.service, action="delete_route_table", result_name=None, RouteTableId=self.id)
+        client.call(
+            aws_service=self.api_spec.service, action="delete_route_table", result_name=None, RouteTableId=self.id
+        )
         return True
 
 
@@ -2292,7 +2298,7 @@ class AwsEc2Host(EC2Taggable, AwsResource):
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
-            service=self.api_spec.service,
+            aws_service=self.api_spec.service,
             action="release-hosts",
             result_name=None,
             HostIds=[self.id],

--- a/plugins/aws/resoto_plugin_aws/resource/eks.py
+++ b/plugins/aws/resoto_plugin_aws/resource/eks.py
@@ -18,7 +18,7 @@ class EKSTaggable:
         if isinstance(self, AwsResource):
             if spec := self.api_spec:
                 client.call(
-                    service=spec.service,
+                    aws_service=spec.service,
                     action="tag_resource",
                     result_name=None,
                     resourceArn=self.arn,
@@ -32,7 +32,7 @@ class EKSTaggable:
         if isinstance(self, AwsResource):
             if spec := self.api_spec:
                 client.call(
-                    service=spec.service,
+                    aws_service=spec.service,
                     action="untag_resource",
                     result_name=None,
                     resourceArn=self.arn,
@@ -193,7 +193,7 @@ class AwsEksNodegroup(EKSTaggable, AwsResource):
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
-            service="eks",
+            aws_service="eks",
             action="delete_nodegroup",
             result_name=None,
             clusterName=self.cluster_name,
@@ -361,7 +361,7 @@ class AwsEksCluster(EKSTaggable, AwsResource):
         builder.add_edge(self, EdgeType.default, clazz=AwsIamRole, arn=self.cluster_role_arn)
 
     def delete_resource(self, client: AwsClient) -> bool:
-        client.call(service=self.api_spec.service, action="delete_cluster", result_name=None, name=self.name)
+        client.call(aws_service=self.api_spec.service, action="delete_cluster", result_name=None, name=self.name)
         return True
 
 

--- a/plugins/aws/resoto_plugin_aws/resource/elasticache.py
+++ b/plugins/aws/resoto_plugin_aws/resource/elasticache.py
@@ -19,7 +19,7 @@ class ElastiCacheTaggable:
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
         if isinstance(self, AwsResource):
             client.call(
-                service="elasticache",
+                aws_service="elasticache",
                 action="add_tags_to_resource",
                 result_name=None,
                 ResourceName=self.arn,
@@ -31,7 +31,7 @@ class ElastiCacheTaggable:
     def delete_resource_tag(self, client: AwsClient, key: str) -> bool:
         if isinstance(self, AwsResource):
             client.call(
-                service="elasticache",
+                aws_service="elasticache",
                 action="remove_tags_from_resource",
                 result_name=None,
                 ResourceName=self.arn,
@@ -254,7 +254,7 @@ class AwsElastiCacheCacheCluster(ElastiCacheTaggable, AwsResource):
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
-            service=self.api_spec.service, action="delete_cache_cluster", result_name=None, CacheClusterId=self.id
+            aws_service=self.api_spec.service, action="delete_cache_cluster", result_name=None, CacheClusterId=self.id
         )
         return True
 
@@ -473,7 +473,7 @@ class AwsElastiCacheReplicationGroup(ElastiCacheTaggable, AwsResource):
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
-            service=self.api_spec.service,
+            aws_service=self.api_spec.service,
             action="delete_replication_group",
             result_name=None,
             ReplicationGroupId=self.id,

--- a/plugins/aws/resoto_plugin_aws/resource/elasticbeanstalk.py
+++ b/plugins/aws/resoto_plugin_aws/resource/elasticbeanstalk.py
@@ -103,7 +103,7 @@ class AwsBeanstalkApplication(AwsResource):
 
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
         client.call(
-            service=self.api_spec.service,
+            aws_service=self.api_spec.service,
             action="update-tags-for-resource",
             result_name=None,
             ResourceArn=self.arn,
@@ -113,7 +113,7 @@ class AwsBeanstalkApplication(AwsResource):
 
     def delete_resource_tag(self, client: AwsClient, key: str) -> bool:
         client.call(
-            service=self.api_spec.service,
+            aws_service=self.api_spec.service,
             action="update-tags-for-resource",
             result_name=None,
             ResourceArn=self.arn,
@@ -123,7 +123,7 @@ class AwsBeanstalkApplication(AwsResource):
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
-            service=self.api_spec.service, action="delete-application", result_name=None, ApplicationName=self.name
+            aws_service=self.api_spec.service, action="delete-application", result_name=None, ApplicationName=self.name
         )
         return True
 
@@ -330,7 +330,7 @@ class AwsBeanstalkEnvironment(AwsResource):
 
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
         client.call(
-            service=self.api_spec.service,
+            aws_service=self.api_spec.service,
             action="update-tags-for-resource",
             result_name=None,
             ResourceArn=self.arn,
@@ -340,7 +340,7 @@ class AwsBeanstalkEnvironment(AwsResource):
 
     def delete_resource_tag(self, client: AwsClient, key: str) -> bool:
         client.call(
-            service=self.api_spec.service,
+            aws_service=self.api_spec.service,
             action="update-tags-for-resource",
             result_name=None,
             ResourceArn=self.arn,
@@ -350,7 +350,10 @@ class AwsBeanstalkEnvironment(AwsResource):
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
-            service=self.api_spec.service, action="terminate-environment", result_name=None, EnvironmentName=self.name
+            aws_service=self.api_spec.service,
+            action="terminate-environment",
+            result_name=None,
+            EnvironmentName=self.name,
         )
         return True
 

--- a/plugins/aws/resoto_plugin_aws/resource/elb.py
+++ b/plugins/aws/resoto_plugin_aws/resource/elb.py
@@ -17,7 +17,7 @@ class ElbTaggable:
         if isinstance(self, AwsResource):
             if spec := self.api_spec:
                 client.call(
-                    service=spec.service,
+                    aws_service=spec.service,
                     action="add_tags",
                     result_name=None,
                     LoadBalancerNames=[self.name],
@@ -31,7 +31,7 @@ class ElbTaggable:
         if isinstance(self, AwsResource):
             if spec := self.api_spec:
                 client.call(
-                    service=spec.service,
+                    aws_service=spec.service,
                     action="remove_tags",
                     result_name=None,
                     LoadBalancerNames=[self.name],
@@ -210,7 +210,10 @@ class AwsElb(ElbTaggable, AwsResource, BaseLoadBalancer):
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
-            service=self.api_spec.service, action="delete_load_balancer", result_name=None, LoadBalancerName=self.name
+            aws_service=self.api_spec.service,
+            action="delete_load_balancer",
+            result_name=None,
+            LoadBalancerName=self.name,
         )
         return True
 

--- a/plugins/aws/resoto_plugin_aws/resource/elbv2.py
+++ b/plugins/aws/resoto_plugin_aws/resource/elbv2.py
@@ -18,7 +18,7 @@ class ElbV2Taggable:
         if isinstance(self, AwsResource):
             if spec := self.api_spec:
                 client.call(
-                    service=spec.service,
+                    aws_service=spec.service,
                     action="add_tags",
                     result_name=None,
                     ResourceArns=[self.arn],
@@ -32,7 +32,7 @@ class ElbV2Taggable:
         if isinstance(self, AwsResource):
             if spec := self.api_spec:
                 client.call(
-                    service=spec.service,
+                    aws_service=spec.service,
                     action="remove_tags",
                     result_name=None,
                     ResourceArns=[self.arn],
@@ -315,7 +315,7 @@ class AwsAlb(ElbV2Taggable, AwsResource, BaseLoadBalancer):
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
-            service=self.api_spec.service, action="delete_load_balancer", result_name=None, LoadBalancerArn=self.arn
+            aws_service=self.api_spec.service, action="delete_load_balancer", result_name=None, LoadBalancerArn=self.arn
         )
         return True
 
@@ -439,7 +439,7 @@ class AwsAlbTargetGroup(ElbV2Taggable, AwsResource):
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
-            service=self.api_spec.service, action="delete_target_group", result_name=None, TargetGroupArn=self.arn
+            aws_service=self.api_spec.service, action="delete_target_group", result_name=None, TargetGroupArn=self.arn
         )
         return True
 

--- a/plugins/aws/resoto_plugin_aws/resource/glacier.py
+++ b/plugins/aws/resoto_plugin_aws/resource/glacier.py
@@ -206,18 +206,18 @@ class AwsGlacierVault(AwsResource):
 
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
         client.call(
-            service="glacier", action="add-tags-to-vault", result_name=None, vaultName=self.name, Tags={key: value}
+            aws_service="glacier", action="add-tags-to-vault", result_name=None, vaultName=self.name, Tags={key: value}
         )
         return True
 
     def delete_resource_tag(self, client: AwsClient, key: str) -> bool:
         client.call(
-            service="glacier", action="remove-tags-from-vault", result_name=None, vaultName=self.name, TagKeys=[key]
+            aws_service="glacier", action="remove-tags-from-vault", result_name=None, vaultName=self.name, TagKeys=[key]
         )
         return True
 
     def delete_resource(self, client: AwsClient) -> bool:
-        client.call(service="glacier", action="delete-vault", result_name=None, vaultName=self.name)
+        client.call(aws_service="glacier", action="delete-vault", result_name=None, vaultName=self.name)
         return True
 
 

--- a/plugins/aws/resoto_plugin_aws/resource/iam.py
+++ b/plugins/aws/resoto_plugin_aws/resource/iam.py
@@ -28,7 +28,7 @@ from resoto_plugin_aws.aws_client import AwsClient
 def iam_update_tag(resource: AwsResource, client: AwsClient, action: str, key: str, value: str, **kwargs: Any) -> bool:
     if spec := resource.api_spec:
         client.call(
-            service=spec.service,
+            aws_service=spec.service,
             action=action,
             result_name=None,
             Tags=[{"Key": key, "Value": value}],
@@ -41,7 +41,7 @@ def iam_update_tag(resource: AwsResource, client: AwsClient, action: str, key: s
 def iam_delete_tag(resource: AwsResource, client: AwsClient, action: str, key: str, **kwargs: Any) -> bool:
     if spec := resource.api_spec:
         client.call(
-            service=spec.service,
+            aws_service=spec.service,
             action=action,
             result_name=None,
             TagKeys=[key],
@@ -147,7 +147,7 @@ class AwsIamRole(AwsResource):
                 log_msg = f"Detaching {successor.rtdname}"
                 self.log(log_msg)
                 client.call(
-                    service="iam",
+                    aws_service="iam",
                     action="detach_role_policy",
                     result_name=None,
                     PolicyArn=successor.arn,
@@ -158,7 +158,7 @@ class AwsIamRole(AwsResource):
             log_msg = f"Deleting inline policy {role_policy}"
             self.log(log_msg)
             client.call(
-                service="iam",
+                aws_service="iam",
                 action="delete_role_policy",
                 result_name=None,
                 PolicyName=role_policy.policy_name,
@@ -168,7 +168,7 @@ class AwsIamRole(AwsResource):
         return True
 
     def delete_resource(self, client: AwsClient) -> bool:
-        client.call(service="iam", action="delete_role", result_name=None, RoleName=self.name)
+        client.call(aws_service="iam", action="delete_role", result_name=None, RoleName=self.name)
         return True
 
 
@@ -208,7 +208,7 @@ class AwsIamServerCertificate(AwsResource, BaseCertificate):
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
-            service=self.api_spec.service,
+            aws_service=self.api_spec.service,
             action="delete_server_certificate",
             result_name=None,
             ServerCertificateName=self.name,
@@ -262,7 +262,7 @@ class AwsIamPolicy(AwsResource, BasePolicy):
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
-            service="iam",
+            aws_service="iam",
             action="delete_policy",
             result_name=None,
             PolicyArn=self.arn,
@@ -300,7 +300,7 @@ class AwsIamGroup(AwsResource, BaseGroup):
                 log_msg = f"Detaching {successor.rtdname}"
                 self.log(log_msg)
                 client.call(
-                    service="iam",
+                    aws_service="iam",
                     action="detach_group_policy",
                     result_name=None,
                     GroupName=self.name,
@@ -311,7 +311,7 @@ class AwsIamGroup(AwsResource, BaseGroup):
             log_msg = f"Deleting inline policy {group_policy}"
             self.log(log_msg)
             client.call(
-                service="iam",
+                aws_service="iam",
                 action="delete_group_policy",
                 result_name=None,
                 GroupName=self.name,
@@ -322,7 +322,7 @@ class AwsIamGroup(AwsResource, BaseGroup):
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
-            service="iam",
+            aws_service="iam",
             action="delete_group",
             result_name=None,
             GroupName=self.name,
@@ -435,7 +435,7 @@ class AwsIamUser(AwsResource, BaseUser):
                 log_msg = f"Detaching {successor.rtdname}"
                 self.log(log_msg)
                 client.call(
-                    service="iam",
+                    aws_service="iam",
                     action="detach_user_policy",
                     result_name=None,
                     UserName=self.name,
@@ -446,7 +446,7 @@ class AwsIamUser(AwsResource, BaseUser):
             log_msg = f"Deleting inline policy {user_policy}"
             self.log(log_msg)
             client.call(
-                service="iam",
+                aws_service="iam",
                 action="delete_user_policy",
                 result_name=None,
                 UserName=self.name,
@@ -456,7 +456,7 @@ class AwsIamUser(AwsResource, BaseUser):
         return True
 
     def delete_resource(self, client: AwsClient) -> bool:
-        client.call(service="iam", action="delete_user", result_name=None, UserName=self.name)
+        client.call(aws_service="iam", action="delete_user", result_name=None, UserName=self.name)
         return True
 
 
@@ -494,7 +494,7 @@ class AwsIamInstanceProfile(AwsResource, BaseInstanceProfile):
                 log_msg = f"Detaching {predecessor.rtdname}"
                 self.log(log_msg)
                 client.call(
-                    service="iam",
+                    aws_service="iam",
                     action="remove_role_from_instance_profile",
                     result_name=None,
                     RoleName=predecessor.name,
@@ -503,7 +503,9 @@ class AwsIamInstanceProfile(AwsResource, BaseInstanceProfile):
         return True
 
     def delete_resource(self, client: AwsClient) -> bool:
-        client.call(service="iam", action="delete_instance_profile", result_name=None, InstanceProfileName=self.name)
+        client.call(
+            aws_service="iam", action="delete_instance_profile", result_name=None, InstanceProfileName=self.name
+        )
         return True
 
 

--- a/plugins/aws/resoto_plugin_aws/resource/kinesis.py
+++ b/plugins/aws/resoto_plugin_aws/resource/kinesis.py
@@ -101,7 +101,7 @@ class AwsKinesisStream(AwsResource):
 
         for stream_name in json:
             stream_description = builder.client.get(
-                service="kinesis",
+                aws_service="kinesis",
                 action="describe-stream",
                 result_name="StreamDescription",
                 StreamName=stream_name,
@@ -113,7 +113,7 @@ class AwsKinesisStream(AwsResource):
 
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
         client.call(
-            service=self.api_spec.service,
+            aws_service=self.api_spec.service,
             action="add_tags_to_stream",
             result_name=None,
             StreamName=self.name,
@@ -123,7 +123,7 @@ class AwsKinesisStream(AwsResource):
 
     def delete_resource_tag(self, client: AwsClient, key: str) -> bool:
         client.call(
-            service=self.api_spec.service,
+            aws_service=self.api_spec.service,
             action="remove_tags_from_stream",
             result_name=None,
             StreamName=self.name,
@@ -133,7 +133,7 @@ class AwsKinesisStream(AwsResource):
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
-            service=self.api_spec.service,
+            aws_service=self.api_spec.service,
             action="delete_stream",
             result_name=None,
             StreamName=self.name,

--- a/plugins/aws/resoto_plugin_aws/resource/kms.py
+++ b/plugins/aws/resoto_plugin_aws/resource/kms.py
@@ -111,7 +111,7 @@ class AwsKmsKey(AwsResource, BaseAccessKey):
 
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
         client.call(
-            service="kms",
+            aws_service="kms",
             action="tag-resource",
             result_name=None,
             KeyId=self.id,
@@ -120,19 +120,23 @@ class AwsKmsKey(AwsResource, BaseAccessKey):
         return True
 
     def delete_resource_tag(self, client: AwsClient, key: str) -> bool:
-        client.call(service="kms", action="untag-resource", result_name=None, KeyId=self.id, TagKeys=[key])
+        client.call(aws_service="kms", action="untag-resource", result_name=None, KeyId=self.id, TagKeys=[key])
         return True
 
     def delete_resource(self, client: AwsClient) -> bool:
         if self.access_key_status == "Disabled":
             client.call(
-                service="kms", action="schedule-key-deletion", result_name=None, KeyId=self.id, PendingWindowInDays=7
+                aws_service="kms",
+                action="schedule-key-deletion",
+                result_name=None,
+                KeyId=self.id,
+                PendingWindowInDays=7,
             )
             return True
         if self.access_key_status == "PendingDeletion":
             return True
 
-        client.call(service="kms", action="disable-key", result_name=None, KeyId=self.id)
+        client.call(aws_service="kms", action="disable-key", result_name=None, KeyId=self.id)
         return True
 
     @staticmethod

--- a/plugins/aws/resoto_plugin_aws/resource/lambda_.py
+++ b/plugins/aws/resoto_plugin_aws/resource/lambda_.py
@@ -292,7 +292,7 @@ class AwsLambdaFunction(AwsResource, BaseServerlessFunction):
 
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
         client.call(
-            service=self.api_spec.service,
+            aws_service=self.api_spec.service,
             action="tag_resource",
             result_name=None,
             Resource=self.arn,
@@ -302,7 +302,7 @@ class AwsLambdaFunction(AwsResource, BaseServerlessFunction):
 
     def delete_resource_tag(self, client: AwsClient, key: str) -> bool:
         client.call(
-            service=self.api_spec.service,
+            aws_service=self.api_spec.service,
             action="untag_resource",
             result_name=None,
             Resource=self.arn,
@@ -311,7 +311,9 @@ class AwsLambdaFunction(AwsResource, BaseServerlessFunction):
         return True
 
     def delete_resource(self, client: AwsClient) -> bool:
-        client.call(service=self.api_spec.service, action="delete_function", result_name=None, FunctionName=self.arn)
+        client.call(
+            aws_service=self.api_spec.service, action="delete_function", result_name=None, FunctionName=self.arn
+        )
         return True
 
 

--- a/plugins/aws/resoto_plugin_aws/resource/rds.py
+++ b/plugins/aws/resoto_plugin_aws/resource/rds.py
@@ -19,7 +19,7 @@ class RdsTaggable:
         if isinstance(self, AwsResource):
             if spec := self.api_spec:
                 client.call(
-                    service=spec.service,
+                    aws_service=spec.service,
                     action="add_tags_to_resource",
                     result_name=None,
                     ResourceName=self.arn,
@@ -33,7 +33,7 @@ class RdsTaggable:
         if isinstance(self, AwsResource):
             if spec := self.api_spec:
                 client.call(
-                    service=spec.service,
+                    aws_service=spec.service,
                     action="remove_tags_from_resource",
                     result_name=None,
                     ResourceName=self.arn,
@@ -485,7 +485,7 @@ class AwsRdsInstance(RdsTaggable, AwsResource, BaseDatabase):
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
-            service=self.api_spec.service,
+            aws_service=self.api_spec.service,
             action="delete_db_instance",
             result_name=None,
             DBInstanceIdentifier=self.id,

--- a/plugins/aws/resoto_plugin_aws/resource/redshift.py
+++ b/plugins/aws/resoto_plugin_aws/resource/redshift.py
@@ -444,7 +444,7 @@ class AwsRedshiftCluster(AwsResource):
 
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
         client.call(
-            service=self.api_spec.service,
+            aws_service=self.api_spec.service,
             action="create_tags",
             result_name=None,
             ResourceName=self.arn,
@@ -454,7 +454,7 @@ class AwsRedshiftCluster(AwsResource):
 
     def delete_resource_tag(self, client: AwsClient, key: str) -> bool:
         client.call(
-            service=self.api_spec.service,
+            aws_service=self.api_spec.service,
             action="delete_tags",
             result_name=None,
             ResourceName=self.arn,
@@ -464,7 +464,7 @@ class AwsRedshiftCluster(AwsResource):
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
-            service=self.api_spec.service,
+            aws_service=self.api_spec.service,
             action="delete_cluster",
             result_name=None,
             ClusterIdentifier=self.id,

--- a/plugins/aws/resoto_plugin_aws/resource/route53.py
+++ b/plugins/aws/resoto_plugin_aws/resource/route53.py
@@ -109,7 +109,7 @@ class AwsRoute53Zone(AwsResource, BaseDNSZone):
 
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
         client.call(
-            service="route53",
+            aws_service="route53",
             action="change-tags-for-resource",
             result_name=None,
             ResourceType="hostedzone",
@@ -120,7 +120,7 @@ class AwsRoute53Zone(AwsResource, BaseDNSZone):
 
     def delete_resource_tag(self, client: AwsClient, key: str) -> bool:
         client.call(
-            service="route53",
+            aws_service="route53",
             action="change-tags-for-resource",
             result_name=None,
             ResourceType="hostedzone",
@@ -130,7 +130,7 @@ class AwsRoute53Zone(AwsResource, BaseDNSZone):
         return True
 
     def delete_resource(self, client: AwsClient) -> bool:
-        client.call(service="route53", action="delete-hosted-zone", result_name=None, Id=self.id.rsplit("/", 1)[-1])
+        client.call(aws_service="route53", action="delete-hosted-zone", result_name=None, Id=self.id.rsplit("/", 1)[-1])
         return True
 
 

--- a/plugins/aws/resoto_plugin_aws/resource/s3.py
+++ b/plugins/aws/resoto_plugin_aws/resource/s3.py
@@ -38,7 +38,11 @@ class AwsS3Bucket(AwsResource, BaseBucket):
     def _set_tags(self, client: AwsClient, tags: Dict[str, str]) -> bool:
         tag_set = [{"Key": k, "Value": v} for k, v in tags.items()]
         client.call(
-            service="s3", action="put-bucket-tagging", result_name=None, Bucket=self.name, Tagging={"TagSet": tag_set}
+            aws_service="s3",
+            action="put-bucket-tagging",
+            result_name=None,
+            Bucket=self.name,
+            Tagging={"TagSet": tag_set},
         )
         return True
 
@@ -46,7 +50,9 @@ class AwsS3Bucket(AwsResource, BaseBucket):
         """Fetch the S3 buckets tags from the AWS API."""
         tags: Dict[str, str] = {}
         try:
-            response = client.call(service="s3", action="get-bucket-tagging", result_name="TagSet", Bucket=self.name)
+            response = client.call(
+                aws_service="s3", action="get-bucket-tagging", result_name="TagSet", Bucket=self.name
+            )
             tags = tags_as_dict(response)  # type: ignore
         except botocore.exceptions.ClientError as e:
             if e.response["Error"]["Code"] != "NoSuchTagSet":
@@ -67,7 +73,7 @@ class AwsS3Bucket(AwsResource, BaseBucket):
         return self._set_tags(client, tags)
 
     def delete_resource(self, client: AwsClient) -> bool:
-        client.call(service="s3", action="delete_bucket", result_name=None, Bucket=self.name)
+        client.call(aws_service="s3", action="delete_bucket", result_name=None, Bucket=self.name)
         return True
 
 

--- a/plugins/aws/resoto_plugin_aws/resource/service_quotas.py
+++ b/plugins/aws/resoto_plugin_aws/resource/service_quotas.py
@@ -121,7 +121,7 @@ class AwsServiceQuota(AwsResource, BaseQuota):
 
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
         client.call(
-            service="service-quotas",
+            aws_service="service-quotas",
             action="tag_resource",
             result_name=None,
             ResourceARN=self.arn,
@@ -131,7 +131,7 @@ class AwsServiceQuota(AwsResource, BaseQuota):
 
     def delete_resource_tag(self, client: AwsClient, key: str) -> bool:
         client.call(
-            service="service-quotas",
+            aws_service="service-quotas",
             action="untag_resource",
             result_name=None,
             ResourceARN=self.arn,

--- a/plugins/aws/resoto_plugin_aws/resource/sqs.py
+++ b/plugins/aws/resoto_plugin_aws/resource/sqs.py
@@ -102,15 +102,19 @@ class AwsSqsQueue(AwsResource):
             )
 
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
-        client.call(service="sqs", action="tag-queue", result_name=None, QueueUrl=self.sqs_queue_url, Tags={key: value})
+        client.call(
+            aws_service="sqs", action="tag-queue", result_name=None, QueueUrl=self.sqs_queue_url, Tags={key: value}
+        )
         return True
 
     def delete_resource_tag(self, client: AwsClient, key: str) -> bool:
-        client.call(service="sqs", action="untag-queue", result_name=None, QueueUrl=self.sqs_queue_url, TagKeys=[key])
+        client.call(
+            aws_service="sqs", action="untag-queue", result_name=None, QueueUrl=self.sqs_queue_url, TagKeys=[key]
+        )
         return True
 
     def delete_resource(self, client: AwsClient) -> bool:
-        client.call(service="sqs", action="delete-queue", result_name=None, QueueUrl=self.sqs_queue_url)
+        client.call(aws_service="sqs", action="delete-queue", result_name=None, QueueUrl=self.sqs_queue_url)
         return True
 
 


### PR DESCRIPTION
# Description

The use of `service` conflicts when `service` is used as a parameter otherwise.

# To-Dos

- [x] Lint and test with `tox`
- [ ] Document new or updated functionality (someengineering/resoto.com#XXXX)



# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
