### PR TITLE
[ci][chore] Update CI for versioned docs

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -262,9 +262,62 @@ jobs:
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
+  edge-docs:
+    name: Update edge API Documentation
+    if: github.ref_type == 'branch' # on every commit to main
+    needs:
+      - build
+      - split-build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Check out someengineering/resoto.com
+        uses: actions/checkout@v3
+        with:
+          repository: someengineering/resoto.com
+          path: resoto.com
+          token: ${{ secrets.SOME_CI_PAT }}
+
+      - name: Update edge API YAML
+        shell: bash
+        run: |
+          cp resotocore/resotocore/static/api-doc.yaml resoto.com/openapi/resotocore-edge.yml
+
+      - name: Modify edge API YAML
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq e -i '.servers[0].url = "http://localhost:8900" | del(.servers[0].description)' resoto.com/openapi/resotocore-edge.yml
+
+      - name: Format
+        working-directory: ./resoto.com
+        run: |
+          yarn install --frozen-lockfile
+          yarn format
+
+      - name: Create someengineering/resoto.com pull request
+        uses: peter-evans/create-pull-request@v4
+        env:
+          HUSKY: 0
+        with:
+          path: resoto.com
+          commit-message: "feat(docs): update edge API documentation"
+          title: "feat(docs): update edge API documentation"
+          body: |
+            Updates `edge` Resoto Core API documentation to reflect changes in [${{ github.sha }}](https://github.com/someengineering/resoto/commit/${{ github.sha }}).
+          labels: |
+            🤖 bot
+          branch: api-docs # stable branch name so any additional commits to main update the existing PR instead of creating a new one
+          delete-branch: true
+          token: ${{ secrets.SOME_CI_PAT }}
+          committer: C.K. <98986935+some-ci@users.noreply.github.com>
+          author: C.K. <98986935+some-ci@users.noreply.github.com>
+
   release:
     name: Create Release
-    if: github.event_name != 'pull_request'
+    if: github.ref_type == 'tag' # on tagging of releases and prereleases
     needs:
       - split-build
     runs-on: ubuntu-latest
@@ -272,7 +325,6 @@ jobs:
     steps:
       - name: Determine release type
         id: release_type
-        if: github.ref_type == 'tag'
         shell: bash
         run: |
           if [[ ${{ github.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -294,13 +346,11 @@ jobs:
           token: ${{ secrets.SOME_CI_PAT }}
 
       - name: Set up Python
-        if: github.ref_type == 'tag'
         uses: actions/setup-python@v2
         with:
           python-version: 3.x
 
       - name: Generate release notes
-        if: github.ref_type == 'tag'
         id: release_notes
         shell: bash
         run: |
@@ -318,27 +368,17 @@ jobs:
           echo ::set-output name=link::$link
 
       - name: Update released version & API YAML
-        if: github.ref_type == 'tag' && steps.release_type.outputs.prerelease == 'false'
+        if: steps.release_type.outputs.prerelease == 'false'
         shell: bash
         run: |
           cp resotocore/resotocore/static/api-doc.yaml resoto.com/openapi/resotocore.yml
           echo '{"version": "${{ steps.release_notes.outputs.tag }}", "link": "${{ steps.release_notes.outputs.link }}"}' > resoto.com/latestRelease.json
 
       - name: Modify released API YAML
-        if: github.ref_type == 'tag' && steps.release_type.outputs.prerelease == 'false'
+        if: steps.release_type.outputs.prerelease == 'false'
         uses: mikefarah/yq@master
         with:
           cmd: yq e -i '.servers[0].url = "http://localhost:8900" | del(.servers[0].description)' resoto.com/openapi/resotocore.yml
-
-      - name: Update edge API YAML
-        shell: bash
-        run: |
-          cp resotocore/resotocore/static/api-doc.yaml resoto.com/openapi/resotocore-edge.yml
-
-      - name: Modify edge API YAML
-        uses: mikefarah/yq@master
-        with:
-          cmd: yq e -i '.servers[0].url = "http://localhost:8900" | del(.servers[0].description)' resoto.com/openapi/resotocore-edge.yml
 
       - name: Format
         working-directory: ./resoto.com
@@ -346,8 +386,7 @@ jobs:
           yarn install --frozen-lockfile
           yarn format
 
-      - name: Create someengineering/resoto.com pull request for release
-        if: github.ref_type == 'tag' && steps.release_type.outputs.prerelease == 'false'
+      - name: Create someengineering/resoto.com pull request
         uses: peter-evans/create-pull-request@v4
         env:
           HUSKY: 0
@@ -356,7 +395,7 @@ jobs:
           commit-message: "feat(news): ${{ steps.release_notes.outputs.tag }} release notes"
           title: "feat(news): ${{ steps.release_notes.outputs.tag }} release notes"
           body: |
-            Adds automatically generated release notes for [`${{ steps.release_notes.outputs.tag }}`](https://github.com/someengineering/resoto/releases/tag/${{ steps.release_notes.outputs.tag }}). Also updates Resoto Core API documentation.
+            Adds automatically generated release notes for [`${{ steps.release_notes.outputs.tag }}`](https://github.com/someengineering/resoto/releases/tag/${{ steps.release_notes.outputs.tag }}).
           labels: |
             🤖 bot
           branch: ${{ steps.release_notes.outputs.tag }}
@@ -365,27 +404,7 @@ jobs:
           committer: C.K. <98986935+some-ci@users.noreply.github.com>
           author: C.K. <98986935+some-ci@users.noreply.github.com>
 
-      - name: Create someengineering/resoto.com pull request for edge
-        if: github.ref_type != 'tag' || steps.release_type.outputs.prerelease == 'true'
-        uses: peter-evans/create-pull-request@v4
-        env:
-          HUSKY: 0
-        with:
-          path: resoto.com
-          commit-message: "feat(docs): update edge API documentation"
-          title: "feat(docs): update edge API documentation"
-          body: |
-            Updates `edge` Resoto Core API documentation to reflect changes in [${{ github.sha }}](https://github.com/someengineering/resoto/commit/${{ github.sha }}).
-          labels: |
-            🤖 bot
-          branch: api-docs
-          delete-branch: true
-          token: ${{ secrets.SOME_CI_PAT }}
-          committer: C.K. <98986935+some-ci@users.noreply.github.com>
-          author: C.K. <98986935+some-ci@users.noreply.github.com>
-
       - name: Create release
-        if: github.ref_type == 'tag'
         uses: ncipollo/release-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -305,7 +305,7 @@ jobs:
           commit-message: "feat(docs): update edge API documentation"
           title: "feat(docs): update edge API documentation"
           body: |
-            Updates `edge` Resoto Core API documentation to reflect changes in [${{ github.sha }}](https://github.com/someengineering/resoto/commit/${{ github.sha }}).
+            Updates `edge` Resoto Core API documentation to reflect changes in [`${{ github.sha }}`](https://github.com/someengineering/resoto/commit/${{ github.sha }}).
           labels: |
             🤖 bot
           branch: api-docs # stable branch name so any additional commits to main update the existing PR instead of creating a new one

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -264,7 +264,7 @@ jobs:
 
   release:
     name: Create Release
-    if: github.ref_type == 'tag'
+    if: github.event_name != 'pull_request'
     needs:
       - split-build
     runs-on: ubuntu-latest
@@ -272,6 +272,7 @@ jobs:
     steps:
       - name: Determine release type
         id: release_type
+        if: github.ref_type == 'tag'
         shell: bash
         run: |
           if [[ ${{ github.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -287,132 +288,104 @@ jobs:
 
       - name: Check out someengineering/resoto.com
         uses: actions/checkout@v3
-        if: steps.release_type.outputs.prerelease == 'false'
         with:
           repository: someengineering/resoto.com
           path: resoto.com
           token: ${{ secrets.SOME_CI_PAT }}
 
       - name: Set up Python
+        if: github.ref_type == 'tag'
         uses: actions/setup-python@v2
-        if: steps.release_type.outputs.prerelease == 'false'
         with:
           python-version: 3.x
 
       - name: Generate release notes
+        if: github.ref_type == 'tag'
         id: release_notes
         shell: bash
         run: |
           mapfile -t tags < <(echo $(curl -sL https://api.github.com/repos/someengineering/resoto/tags?per_page=1) | jq -r '(.[] | .name)')
           echo ::set-output name=tag::${tags[0]}
-          if [[ ${{ github.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            prev_release=$(echo $(curl -sL https://api.github.com/repos/someengineering/resoto/releases/latest) | jq -r '.tag_name')
-            year=$(date +'%Y')
-            date=$(date +'%m-%d')
-            dir="resoto.com/news/${year}/${date}-v${tags[0]}"
-            file="${dir}/index.md"
-            mkdir -p $dir
-            python tools/release_notes.py ${prev_release} ${tags[0]} > $file
-            cat $file
-            echo ::set-output name=file::$file
-          fi
+          prev_release=$(echo $(curl -sL https://api.github.com/repos/someengineering/resoto/releases/latest) | jq -r '.tag_name')
+          year=$(date +'%Y')
+          date=$(date +'%m-%d')
+          dir="resoto.com/news/${year}"
+          mkdir -p $dir
+          file="${dir}/${date}-${tags[0]}.md"
+          python tools/release_notes.py ${prev_release} ${tags[0]} > $file
+          echo ::set-output name=file::$file
+          link="https://resoto.com/news/$(date +'%Y/%m/%d')/${tags[0]}"
+          echo ::set-output name=link::$link
 
-      - name: Modify resotocore API YAML
+      - name: Update released version & API YAML
+        if: github.ref_type == 'tag' && steps.release_type.outputs.prerelease == 'false'
+        shell: bash
+        run: |
+          cp resotocore/resotocore/static/api-doc.yaml resoto.com/openapi/resotocore.yml
+          echo '"${{ steps.release_notes.outputs.tag }}"' > resoto.com/latestRelease.json
+
+      - name: Modify released API YAML
+        if: github.ref_type == 'tag' && steps.release_type.outputs.prerelease == 'false'
         uses: mikefarah/yq@master
-        if: steps.release_type.outputs.prerelease == 'false'
         with:
           cmd: yq e -i '.servers[0].url = "http://localhost:8900" | del(.servers[0].description)' resoto.com/openapi/resotocore.yml
 
+      - name: Update edge API YAML
+        shell: bash
+        run: |
+          cp resotocore/resotocore/static/api-doc.yaml resoto.com/openapi/resotocore-edge.yml
+
+      - name: Modify edge API YAML
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq e -i '.servers[0].url = "http://localhost:8900" | del(.servers[0].description)' resoto.com/openapi/resotocore-edge.yml
+
       - name: Format
-        if: steps.release_type.outputs.prerelease == 'false'
         working-directory: ./resoto.com
         run: |
           yarn install --frozen-lockfile
           yarn format
 
-      - name: Create someengineering/resoto.com pull request
+      - name: Create someengineering/resoto.com pull request for release
+        if: github.ref_type == 'tag' && steps.release_type.outputs.prerelease == 'false'
         uses: peter-evans/create-pull-request@v4
-        if: steps.release_type.outputs.prerelease == 'false'
         env:
           HUSKY: 0
         with:
           path: resoto.com
-          commit-message: "feat(news): v${{ steps.release_notes.outputs.tag }} release notes"
-          title: "feat(news): v${{ steps.release_notes.outputs.tag }} release notes"
+          commit-message: "feat(news): ${{ steps.release_notes.outputs.tag }} release notes"
+          title: "feat(news): ${{ steps.release_notes.outputs.tag }} release notes"
           body: |
-            Adds automatically generated release notes for [v${{ steps.release_notes.outputs.tag }}](https://github.com/someengineering/resoto/releases/tag/${{ steps.release_notes.outputs.tag }}).
+            Adds automatically generated release notes for [`${{ steps.release_notes.outputs.tag }}`](https://github.com/someengineering/resoto/releases/tag/${{ steps.release_notes.outputs.tag }}). Also updates Resoto Core API documentation.
           labels: |
             🤖 bot
-          branch: release/v${{ steps.release_notes.outputs.tag }}
+          branch: ${{ steps.release_notes.outputs.tag }}
           delete-branch: true
           token: ${{ secrets.SOME_CI_PAT }}
           committer: C.K. <98986935+some-ci@users.noreply.github.com>
           author: C.K. <98986935+some-ci@users.noreply.github.com>
 
-      - name: Check out someengineering/helm-charts
-        uses: actions/checkout@v3
-        if: steps.release_type.outputs.prerelease == 'false'
-        with:
-          repository: someengineering/helm-charts
-          path: helm-charts
-          token: ${{ secrets.SOME_CI_PAT }}
-
-      - name: Get current chart version
-        id: current_chart_version
-        uses: mikefarah/yq@master
-        if: steps.release_type.outputs.prerelease == 'false'
-        with:
-          cmd: yq '.version' helm-charts/charts/resoto/Chart.yaml
-
-      - name: Get new chart version
-        id: new_chart_version
-        uses: WyriHaximus/github-action-next-semvers@v1
-        if: steps.release_type.outputs.prerelease == 'false'
-        with:
-          version: ${{ steps.current_chart_version.outputs.result }}
-
-      - name: Update appVersion and bump chart version
-        uses: mikefarah/yq@master
-        if: steps.release_type.outputs.prerelease == 'false'
-        with:
-          cmd: yq e -i '.version = "${{ steps.new_chart_version.outputs.patch }}" | .appVersion = "${{ steps.release_notes.outputs.tag }}"' helm-charts/charts/resoto/Chart.yaml
-
-      - name: Set up Helm
-        if: steps.release_type.outputs.prerelease == 'false'
-        uses: azure/setup-helm@v1
-        with:
-          version: v3.8.1
-
-      - name: Install helm-docs
-        if: steps.release_type.outputs.prerelease == 'false'
-        uses: supplypike/setup-bin@v1
-        with:
-          uri: https://github.com/norwoodj/helm-docs/releases/download/v1.11.0/helm-docs_1.11.0_Linux_x86_64.tar.gz
-          name: helm-docs
-          version: "1.11.0"
-
-      - name: Generate helm-charts README.md
-        if: steps.release_type.outputs.prerelease == 'false'
-        run: (cd helm-charts && helm-docs)
-
-      - name: Create someengineering/helm-charts pull request
+      - name: Create someengineering/resoto.com pull request for edge
+        if: github.ref_type != 'tag' || steps.release_type.outputs.prerelease == 'true'
         uses: peter-evans/create-pull-request@v4
-        if: steps.release_type.outputs.prerelease == 'false'
+        env:
+          HUSKY: 0
         with:
-          path: helm-charts
-          commit-message: "chore: bump appVersion to ${{ steps.release_notes.outputs.tag }}"
-          title: "chore: bump appVersion to ${{ steps.release_notes.outputs.tag }}"
+          path: resoto.com
+          commit-message: "feat(docs): update edge API documentation"
+          title: "feat(docs): update edge API documentation"
           body: |
-            Bumps Resoto version to [${{ steps.release_notes.outputs.tag }}](https://github.com/someengineering/resoto/releases/tag/${{ steps.release_notes.outputs.tag }}).
+            Updates `edge` Resoto Core API documentation to reflect changes in [${{ github.sha }}](https://github.com/someengineering/resoto/commit/${{ github.sha }}).
           labels: |
             🤖 bot
-          branch: release/v${{ steps.release_notes.outputs.tag }}
+          branch: api-docs
           delete-branch: true
           token: ${{ secrets.SOME_CI_PAT }}
           committer: C.K. <98986935+some-ci@users.noreply.github.com>
           author: C.K. <98986935+some-ci@users.noreply.github.com>
 
       - name: Create release
+        if: github.ref_type == 'tag'
         uses: ncipollo/release-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -266,7 +266,6 @@ jobs:
     name: Update edge API Documentation
     if: github.ref_type == 'branch' # on every commit to main
     needs:
-      - build
       - split-build
     runs-on: ubuntu-latest
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -314,7 +314,7 @@ jobs:
           file="${dir}/${date}-${tags[0]}.md"
           python tools/release_notes.py ${prev_release} ${tags[0]} > $file
           echo ::set-output name=file::$file
-          link="https://resoto.com/news/$(date +'%Y/%m/%d')/${tags[0]}"
+          link="$(date +'%Y/%m/%d')/${tags[0]}"
           echo ::set-output name=link::$link
 
       - name: Update released version & API YAML
@@ -322,7 +322,7 @@ jobs:
         shell: bash
         run: |
           cp resotocore/resotocore/static/api-doc.yaml resoto.com/openapi/resotocore.yml
-          echo '"${{ steps.release_notes.outputs.tag }}"' > resoto.com/latestRelease.json
+          echo '{"version": "${{ steps.release_notes.outputs.tag }}", "link": "${{ steps.release_notes.outputs.link }}"}' > resoto.com/latestRelease.json
 
       - name: Modify released API YAML
         if: github.ref_type == 'tag' && steps.release_type.outputs.prerelease == 'false'
@@ -393,7 +393,7 @@ jobs:
           body: |
             ### Release Notes
 
-            ${{ steps.release_notes.outputs.link }}
+            https://resoto.com/news/${{ steps.release_notes.outputs.link }}
 
             ### Docker Images
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -281,12 +281,12 @@ jobs:
           path: resoto.com
           token: ${{ secrets.SOME_CI_PAT }}
 
-      - name: Update edge API YAML
+      - name: Update resotocore API YAML
         shell: bash
         run: |
           cp resotocore/resotocore/static/api-doc.yaml resoto.com/openapi/resotocore-edge.yml
 
-      - name: Modify edge API YAML
+      - name: Modify resotocore API YAML
         uses: mikefarah/yq@master
         with:
           cmd: yq e -i '.servers[0].url = "http://localhost:8900" | del(.servers[0].description)' resoto.com/openapi/resotocore-edge.yml
@@ -367,14 +367,14 @@ jobs:
           link="$(date +'%Y/%m/%d')/${tags[0]}"
           echo ::set-output name=link::$link
 
-      - name: Update released version & API YAML
+      - name: Update released version & resotocore API YAML
         if: steps.release_type.outputs.prerelease == 'false'
         shell: bash
         run: |
           cp resotocore/resotocore/static/api-doc.yaml resoto.com/openapi/resotocore.yml
           echo '{"version": "${{ steps.release_notes.outputs.tag }}", "link": "${{ steps.release_notes.outputs.link }}"}' > resoto.com/latestRelease.json
 
-      - name: Modify released API YAML
+      - name: Modify resotocore API YAML
         if: steps.release_type.outputs.prerelease == 'false'
         uses: mikefarah/yq@master
         with:
@@ -399,6 +399,69 @@ jobs:
           labels: |
             🤖 bot
           branch: ${{ steps.release_notes.outputs.tag }}
+          delete-branch: true
+          token: ${{ secrets.SOME_CI_PAT }}
+          committer: C.K. <98986935+some-ci@users.noreply.github.com>
+          author: C.K. <98986935+some-ci@users.noreply.github.com>
+
+      - name: Check out someengineering/helm-charts
+        uses: actions/checkout@v3
+        if: steps.release_type.outputs.prerelease == 'false'
+        with:
+          repository: someengineering/helm-charts
+          path: helm-charts
+          token: ${{ secrets.SOME_CI_PAT }}
+
+      - name: Get current chart version
+        id: current_chart_version
+        uses: mikefarah/yq@master
+        if: steps.release_type.outputs.prerelease == 'false'
+        with:
+          cmd: yq '.version' helm-charts/charts/resoto/Chart.yaml
+
+      - name: Get new chart version
+        id: new_chart_version
+        uses: WyriHaximus/github-action-next-semvers@v1
+        if: steps.release_type.outputs.prerelease == 'false'
+        with:
+          version: ${{ steps.current_chart_version.outputs.result }}
+
+      - name: Update appVersion and bump chart version
+        uses: mikefarah/yq@master
+        if: steps.release_type.outputs.prerelease == 'false'
+        with:
+          cmd: yq e -i '.version = "${{ steps.new_chart_version.outputs.patch }}" | .appVersion = "${{ steps.release_notes.outputs.tag }}"' helm-charts/charts/resoto/Chart.yaml
+
+      - name: Set up Helm
+        if: steps.release_type.outputs.prerelease == 'false'
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.8.1
+
+      - name: Install helm-docs
+        if: steps.release_type.outputs.prerelease == 'false'
+        uses: supplypike/setup-bin@v1
+        with:
+          uri: https://github.com/norwoodj/helm-docs/releases/download/v1.11.0/helm-docs_1.11.0_Linux_x86_64.tar.gz
+          name: helm-docs
+          version: "1.11.0"
+
+      - name: Generate helm-charts README.md
+        if: steps.release_type.outputs.prerelease == 'false'
+        run: (cd helm-charts && helm-docs)
+
+      - name: Create someengineering/helm-charts pull request
+        uses: peter-evans/create-pull-request@v4
+        if: steps.release_type.outputs.prerelease == 'false'
+        with:
+          path: helm-charts
+          commit-message: "chore: bump appVersion to ${{ steps.release_notes.outputs.tag }}"
+          title: "chore: bump appVersion to ${{ steps.release_notes.outputs.tag }}"
+          body: |
+            Bumps Resoto version to [${{ steps.release_notes.outputs.tag }}](https://github.com/someengineering/resoto/releases/tag/${{ steps.release_notes.outputs.tag }}).
+          labels: |
+            🤖 bot
+          branch: release/v${{ steps.release_notes.outputs.tag }}
           delete-branch: true
           token: ${{ secrets.SOME_CI_PAT }}
           committer: C.K. <98986935+some-ci@users.noreply.github.com>

--- a/tools/release_notes.py
+++ b/tools/release_notes.py
@@ -86,7 +86,7 @@ def show_log(from_tag: str, to_tag: str):
 
     print("---\ntags: [release notes]\n---")
 
-    print(f"\n# v{to_tag}")
+    print(f"\n# {to_tag}")
 
     print("\n## What's Changed")
     # define sort order for groups: order of group names and then the rest


### PR DESCRIPTION
# Description

someengineering/resoto.com#350 adds docs versioning.

- Latest release version is now tracked locally in the [someengineering/resoto.com](https://github.com/someengineering/resoto.com) repo, so `latestRelease.json` needs to be updated with the tag and release notes link when publishing a new stable release
- API docs for latest stable release _and_ main/edge are now maintained separately in the [someengineering/resoto.com](https://github.com/someengineering/resoto.com) repo, so these two files both need to be updated as appropriate (main/edge version on every commit)

This PR also fixes these issues:
- API docs were not being updated at all
- We weren't publishing release notes for prereleases, which would result in a weird empty "Release Notes" section with no link on GitHub
- Remove `v` version prefix throughout for consistency

**Note 1:** [peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request) exits silently when there are no changes. It will also update the existing branch/PR, which is why the non-release PR action specifies a static branch name.

**Note 2:** We haven't been merging CI and release note generator changes into the releases/2.4 branch. This should probably be handled so that any further 2.X releases properly handle website updates.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
