### PR TITLE
[aws] Add methods to handle missing ARNs/IDs

### DIFF
--- a/plugins/aws/resoto_plugin_aws/resource/apigateway.py
+++ b/plugins/aws/resoto_plugin_aws/resource/apigateway.py
@@ -400,7 +400,6 @@ class AwsApiGatewayRestApi(ApiGatewayTaggable, AwsResource):
             builder.add_node(api_instance, js)
             for deployment in builder.client.list("apigateway", "get-deployments", "items", restApiId=api_instance.id):
                 deploy_instance = AwsApiGatewayDeployment.from_api(deployment)
-                # deploy_instance.arn = api_instance.arn + "/deployments/" + deploy_instance.id
                 deploy_instance.set_arn(
                     builder=builder,
                     account="",

--- a/plugins/aws/resoto_plugin_aws/resource/athena.py
+++ b/plugins/aws/resoto_plugin_aws/resource/athena.py
@@ -10,7 +10,6 @@ from resotolib.types import Json
 from resoto_plugin_aws.aws_client import AwsClient
 from resoto_plugin_aws.utils import ToDict
 from typing import Type, cast
-from resoto_plugin_aws.utils import arn_partition
 
 
 @define(eq=False, slots=False)
@@ -99,9 +98,10 @@ class AwsAthenaWorkGroup(AwsResource):
                 return None
 
             workgroup = cls.from_api(result)
-            r_id = builder.region.id
-            a_id = builder.account.id
-            workgroup.arn = f"arn:{arn_partition(builder.region)}:athena:{r_id}:{a_id}:workgroup/{workgroup.name}"
+            workgroup.set_arn(
+                builder=builder,
+                resource=f"workgroup/{workgroup.name}",
+            )
 
             return cast(AwsAthenaWorkGroup, workgroup)
 
@@ -194,9 +194,7 @@ class AwsAthenaDataCatalog(AwsResource):
             if result is None:
                 return None
             catalog = cls.from_api(result)
-            r_id = builder.region.id
-            a_id = builder.account.id
-            catalog.arn = f"arn:{arn_partition(builder.region)}:athena:{r_id}:{a_id}:datacatalog/{catalog.name}"
+            catalog.set_arn(builder=builder, resource=f"datacatalog/{catalog.name}")
             return cast(AwsAthenaDataCatalog, catalog)
 
         def add_tags(data_catalog: AwsAthenaDataCatalog) -> None:

--- a/plugins/aws/resoto_plugin_aws/resource/base.py
+++ b/plugins/aws/resoto_plugin_aws/resource/base.py
@@ -16,6 +16,7 @@ from boto3.exceptions import Boto3Error
 from resoto_plugin_aws.config import AwsConfig
 from resoto_plugin_aws.aws_client import AwsClient
 from resoto_plugin_aws.resource.pricing import AwsPricingPrice
+from resoto_plugin_aws.utils import arn_partition
 from resotolib.baseresources import (
     BaseResource,
     EdgeType,
@@ -65,6 +66,24 @@ class AwsResource(BaseResource, ABC):
 
     # The AWS specific identifier of the resource. Not available for all resources.
     arn: Optional[str] = None
+
+    def set_arn(
+        self,
+        builder: GraphBuilder,
+        region: Optional[str] = None,
+        service: Optional[str] = None,
+        account: Optional[str] = None,
+        resource: str = "",
+    ) -> None:
+        aws_region = builder.region
+        partition = arn_partition(aws_region)
+        if region is None:
+            region = aws_region.id
+        if service is None and self.api_spec:
+            service = self.api_spec.service
+        if account is None:
+            account = builder.account.id
+        self.arn = f"arn:{partition}:{service}:{region}:{account}:{resource}"
 
     # TODO: implement me
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:

--- a/plugins/aws/resoto_plugin_aws/resource/base.py
+++ b/plugins/aws/resoto_plugin_aws/resource/base.py
@@ -67,24 +67,6 @@ class AwsResource(BaseResource, ABC):
     # The AWS specific identifier of the resource. Not available for all resources.
     arn: Optional[str] = None
 
-    def set_arn(
-        self,
-        builder: GraphBuilder,
-        region: Optional[str] = None,
-        service: Optional[str] = None,
-        account: Optional[str] = None,
-        resource: str = "",
-    ) -> None:
-        aws_region = builder.region
-        partition = arn_partition(aws_region)
-        if region is None:
-            region = aws_region.id
-        if service is None and self.api_spec:
-            service = self.api_spec.service
-        if account is None:
-            account = builder.account.id
-        self.arn = f"arn:{partition}:{service}:{region}:{account}:{resource}"
-
     # TODO: implement me
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
         raise NotImplementedError
@@ -137,6 +119,24 @@ class AwsResource(BaseResource, ABC):
                 "api_spec",
             ),
         )
+
+    def set_arn(
+        self,
+        builder: GraphBuilder,
+        region: Optional[str] = None,
+        service: Optional[str] = None,
+        account: Optional[str] = None,
+        resource: str = "",
+    ) -> None:
+        aws_region = builder.region
+        partition = arn_partition(aws_region)
+        if region is None:
+            region = aws_region.id
+        if service is None and self.api_spec:
+            service = self.api_spec.service
+        if account is None:
+            account = builder.account.id
+        self.arn = f"arn:{partition}:{service}:{region}:{account}:{resource}"
 
     @classmethod
     def from_json(cls: Type[AwsResourceType], json: Json) -> AwsResourceType:

--- a/plugins/aws/resoto_plugin_aws/resource/base.py
+++ b/plugins/aws/resoto_plugin_aws/resource/base.py
@@ -138,6 +138,12 @@ class AwsResource(BaseResource, ABC):
             account = builder.account.id
         self.arn = f"arn:{partition}:{service}:{region}:{account}:{resource}"
 
+    @staticmethod
+    def id_from_arn(arn: str) -> str:
+        if "/" in arn:
+            return arn.rsplit("/")[-1]
+        return arn.rsplit(":")[-1]
+
     @classmethod
     def from_json(cls: Type[AwsResourceType], json: Json) -> AwsResourceType:
         return from_js(json, cls)

--- a/plugins/aws/resoto_plugin_aws/resource/ecs.py
+++ b/plugins/aws/resoto_plugin_aws/resource/ecs.py
@@ -14,7 +14,7 @@ from resoto_plugin_aws.resource.kms import AwsKmsKey
 from resoto_plugin_aws.resource.s3 import AwsS3Bucket
 from resotolib.baseresources import EdgeType, ModelReference
 from resotolib.graph import Graph
-from resotolib.json_bender import Bender, S, Bend, ForallBend
+from resotolib.json_bender import F, Bender, S, Bend, ForallBend
 from resotolib.types import Json
 from resotolib.utils import chunks
 from resoto_plugin_aws.utils import TagsValue, ToDict
@@ -89,7 +89,7 @@ class AwsEcsCapacityProvider(EcsTaggable, AwsResource):
         "successors": {"default": ["aws_autoscaling_group"]},
     }
     mapping: ClassVar[Dict[str, Bender]] = {
-        "id": S("capacityProviderArn"),
+        "id": S("name"),
         "name": S("name"),
         "tags": S("tags", default=[]) >> ToDict(key="key", value="value"),
         "arn": S("capacityProviderArn"),
@@ -331,7 +331,7 @@ class AwsEcsTask(EcsTaggable, AwsResource):
         },
     }
     mapping: ClassVar[Dict[str, Bender]] = {
-        "id": S("taskArn"),
+        "id": S("taskArn") >> F(AwsResource.id_from_arn),
         "tags": S("tags", default=[]) >> ToDict(key="key", value="value"),
         "ctime": S("createdAt"),
         "arn": S("taskArn"),
@@ -812,7 +812,7 @@ class AwsEcsTaskDefinition(EcsTaggable, AwsResource):
         "predecessors": {"default": ["aws_iam_role"], "delete": ["aws_iam_role"]},
     }
     mapping: ClassVar[Dict[str, Bender]] = {
-        "id": S("taskDefinitionArn"),
+        "id": S("taskDefinitionArn") >> F(AwsResource.id_from_arn),
         "tags": S("tags", default=[]) >> ToDict(key="key", value="value"),
         "name": S("tags", default=[]) >> TagsValue("Name").or_else(S("taskDefinitionArn")),
         "ctime": S("registeredAt"),
@@ -1376,7 +1376,7 @@ class AwsEcsContainerInstance(EcsTaggable, AwsResource):
         "successors": {"default": ["aws_ec2_instance"], "delete": ["aws_ec2_instance"]},
     }
     mapping: ClassVar[Dict[str, Bender]] = {
-        "id": S("containerInstanceArn"),
+        "id": S("containerInstanceArn") >> F(AwsResource.id_from_arn),
         "tags": S("tags", default=[]) >> ToDict(),
         "name": S("containerInstanceArn"),
         "ctime": S("registeredAt"),

--- a/plugins/aws/resoto_plugin_aws/resource/redshift.py
+++ b/plugins/aws/resoto_plugin_aws/resource/redshift.py
@@ -13,7 +13,6 @@ from datetime import datetime
 from resotolib.types import Json
 from resoto_plugin_aws.resource.ec2 import AwsEc2Vpc, AwsEc2SecurityGroup, AwsEc2Subnet
 from resoto_plugin_aws.resource.iam import AwsIamRole
-from resoto_plugin_aws.utils import arn_partition
 
 
 @define(eq=False, slots=False)
@@ -419,9 +418,7 @@ class AwsRedshiftCluster(AwsResource):
     def collect(cls: Type[AwsResource], json: List[Json], builder: GraphBuilder) -> None:
         for js in json:
             cluster = cls.from_api(js)
-            r_id = builder.region.id
-            a_id = builder.account.id
-            cluster.arn = f"arn:{arn_partition(builder.region)}:redshift:{r_id}:{a_id}:cluster:{cluster.id}"
+            cluster.set_arn(builder=builder, resource=f"cluster:{cluster.id}")
             builder.add_node(cluster, js)
 
     def connect_in_graph(self, builder: GraphBuilder, source: Json) -> None:

--- a/plugins/aws/resoto_plugin_aws/resource/s3.py
+++ b/plugins/aws/resoto_plugin_aws/resource/s3.py
@@ -9,7 +9,6 @@ from resoto_plugin_aws.aws_client import AwsClient
 from resoto_plugin_aws.utils import tags_as_dict
 
 from resotolib.types import Json
-from resoto_plugin_aws.utils import arn_partition
 
 
 @define(eq=False, slots=False)
@@ -31,7 +30,7 @@ class AwsS3Bucket(AwsResource, BaseBucket):
 
         for js in json:
             bucket = cls.from_api(js)
-            bucket.arn = f"arn:{arn_partition(builder.region)}:s3:::{bucket.name}"
+            bucket.set_arn(builder=builder, region="", account="", resource=bucket.name)
             builder.add_node(bucket, js)
             builder.submit_work(add_tags, bucket, builder.client)
 

--- a/plugins/aws/test/resources/ecs_test.py
+++ b/plugins/aws/test/resources/ecs_test.py
@@ -54,3 +54,4 @@ def test_ecs_task_definition() -> None:
     assert len(builder.resources_of(AwsEcsTaskDefinition)) == 1
     assert first.family == "nginx-sample-stack"
     assert first.revision == 1
+    assert first.id == "nginx-sample-stack:1"

--- a/plugins/aws/test/resources/files/ecs/describe-capacity-providers__sampleCapacityProvider_TAGS.json
+++ b/plugins/aws/test/resources/files/ecs/describe-capacity-providers__sampleCapacityProvider_TAGS.json
@@ -1,7 +1,7 @@
 {
     "capacityProviders": [
         {
-            "capacityProviderArn": "string",
+            "capacityProviderArn": "arn:aws:ecs:us-west-2:123456789012:capacity-provider/MyCapacityProvider",
             "name": "sampleCapacityProvider",
             "status": "ACTIVE",
             "autoScalingGroupProvider": {


### PR DESCRIPTION
# Description

Introduces
- a method on `AwsResource` to construct the ARN of a resource instance.
- a static method on `AwsResource` to extract the ID from a given ARN

# To-Dos

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`
- [ ] Document new or updated functionality (someengineering/resoto.com#XXXX)


# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
