### PR TITLE
[resotolib][fix] Make resotolib win32 compatible again

### DIFF
--- a/resotolib/resotolib/proc.py
+++ b/resotolib/resotolib/proc.py
@@ -1,10 +1,8 @@
 import gc
 import os
 import re
-import resource
 import time
 import sys
-import fcntl
 from typing import Optional, Dict, List
 
 import psutil
@@ -15,6 +13,12 @@ from resotolib.event import dispatch_event, Event, EventType
 from signal import signal, Signals, SIGTERM, SIGINT
 
 from resotolib.utils import iec_size_format
+
+try:
+    import resource
+    import fcntl
+except ImportError:
+    pass
 
 try:
     from psutil import cpu_count


### PR DESCRIPTION
# Description

Resoto used to work on Windows, but over time this compatibility got forgotten. This quick fix makes it so that `resh` starts on Windows again. All the code that uses these two modules already checks for the OS, so is prepared for the modules to be missing. Worker and Metrics also seem to work, though I didn't test all plugins and config hot-reload might not work. Core fails with a jq lib compile error. But the main thing was to get `resh` working again.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
