### PR TITLE
[resotocore][fix] Display no more than 25 result items in Jira issue

### DIFF
--- a/resotocore/resotocore/core_config.py
+++ b/resotocore/resotocore/core_config.py
@@ -226,7 +226,7 @@ def alias_templates() -> List[AliasTemplateConfig]:
             "Send the result of a search to Jira",
             # defines the fields to show in the message
             'jq ({{key}} + ": " + {{value}}) | head 26 | chunk 26 | '
-            'jq "((.[:25] | join(\"\n\")) + (if .[25] then \"\n... (results truncated)\" else \"\" end))" | '
+            'jq "((.[:25] | join("\n")) + (if .[25] then "\n... (results truncated)" else "" end))" | '
             # define the Jira webhook json
             "jq {fields: { "
             'summary: "{{title}}", '

--- a/resotocore/resotocore/core_config.py
+++ b/resotocore/resotocore/core_config.py
@@ -225,7 +225,7 @@ def alias_templates() -> List[AliasTemplateConfig]:
             "jira",
             "Send the result of a search to Jira",
             # defines the fields to show in the message
-            'jq ({{key}} + ": " + {{value}}) | chunk 25 | jq join("\n") | '
+            'jq ({{key}} + ": " + {{value}}) | chunk 1000 | jq join("\n") | '
             # define the Jira webhook json
             "jq {fields: { "
             'summary: "{{title}}", '

--- a/resotocore/resotocore/core_config.py
+++ b/resotocore/resotocore/core_config.py
@@ -225,7 +225,8 @@ def alias_templates() -> List[AliasTemplateConfig]:
             "jira",
             "Send the result of a search to Jira",
             # defines the fields to show in the message
-            'jq ({{key}} + ": " + {{value}}) | chunk 1000 | jq join("\n") | '
+            'jq ({{key}} + ": " + {{value}}) | head 26 | chunk 26 | '
+            'jq "((.[:25] | join(\"\n\")) + (if .[25] then \"\n... (results truncated)\" else \"\" end))" | '
             # define the Jira webhook json
             "jq {fields: { "
             'summary: "{{title}}", '

--- a/resotocore/tests/resotocore/cli/command_test.py
+++ b/resotocore/tests/resotocore/cli/command_test.py
@@ -893,20 +893,8 @@ async def test_jira_alias(cli: CLI, echo_http_server: Tuple[int, List[Tuple[Requ
         f'search is(bla) | jira url="http://localhost:{port}/success" title=test message="test message" username=test token=test project_id=10000 reporter_id=test',
         stream.list,
     )
-    # 100 times bla, jira allows 25 fields -> 4 requests
-    assert result == [["4 requests with status 200 sent."]]
-    assert len(requests) == 4
-    print(requests[0][1])
-    assert requests[0][1] == {
-        "fields": {
-            "summary": "test",
-            "issuetype": {"id": "10001"},
-            "project": {"id": "10000"},
-            "description": "test message\n\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\n\nIssue created by Resoto",
-            "reporter": {"id": "test"},
-            "labels": ["created-by-resoto"],
-        }
-    }
+    assert result == [["1 requests with status 200 sent."]]
+    assert len(requests) == 1
 
 
 @pytest.mark.asyncio

--- a/resotocore/tests/resotocore/cli/command_test.py
+++ b/resotocore/tests/resotocore/cli/command_test.py
@@ -895,6 +895,17 @@ async def test_jira_alias(cli: CLI, echo_http_server: Tuple[int, List[Tuple[Requ
     )
     assert result == [["1 requests with status 200 sent."]]
     assert len(requests) == 1
+    print(requests[0][1])
+    assert requests[0][1] == {
+        "fields": {
+            "summary": "test",
+            "issuetype": {"id": "10001"},
+            "project": {"id": "10000"},
+            "description": "test message\n\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\nbla: yes or no\n... (results truncated)\n\nIssue created by Resoto",
+            "reporter": {"id": "test"},
+            "labels": ["created-by-resoto"],
+        }
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description

Display no more than 25 result items and show note if the results have been truncated.

Issue created with 5 result items:
<img width="496" alt="image" src="https://user-images.githubusercontent.com/66877958/195808116-bb176c94-ee87-4b19-be75-24757f513d56.png">

Issue created with > 25 result items:
<img width="389" alt="image" src="https://user-images.githubusercontent.com/66877958/195808439-fae46c35-b82f-4797-9844-098e9a6b1b52.png">


# To-Dos

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`
- [x] Document new or updated functionality (someengineering/resoto.com#380)


# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
