### PR TITLE
[resotocore][feat] Add /system/data endpoint that returns SystemData for the UI

### DIFF
--- a/resotocore/resotocore/__main__.py
+++ b/resotocore/resotocore/__main__.py
@@ -160,6 +160,7 @@ def with_config(
         cli,
         template_expander,
         config,
+        system_data,
     )
     event_emitter = emit_recurrent_events(
         event_sender, model, subscriptions, worker_task_queue, message_bus, timedelta(hours=1), timedelta(hours=1)


### PR DESCRIPTION

# Description

Add /system/data endpoint that returns SystemData for the UI

# To-Dos

Currently the web/api_tests.py checks the `/system/*` endpoints by utilizing resotoclient functions.
Resotoclient in turn uses these `/system/` endoints to provide `ready()` and `ping()`.
I would merge this PR to provide the `/system/data/` endpoint, then extend `resotoclient` to provide the `data()` function. And then update the resotocore tests to call `data()` and check that it contains `system_id`.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
