### PR TITLE
[resotolib][fix] return closest parent class

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,8 @@
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
-    "python.formatting.provider": "black"
+    "python.formatting.provider": "black",
+    "cSpell.words": [
+        "popleft"
+    ]
 }

--- a/plugins/aws/resoto_plugin_aws/__init__.py
+++ b/plugins/aws/resoto_plugin_aws/__init__.py
@@ -338,7 +338,7 @@ def authenticated(account: AwsAccount) -> bool:
 def get_client(config: Config, resource: BaseResource) -> AwsClient:
     account = resource.account()
     assert isinstance(account, AwsAccount)
-    return AwsClient(config.aws, account.id, role=account.role, profile=account.profile, region=resource.region().name)
+    return AwsClient(config.aws, account.id, role=account.role, profile=account.profile, region=resource.region().id)
 
 
 def current_account_id(profile: Optional[str] = None) -> str:

--- a/resotolib/resotolib/graph/__init__.py
+++ b/resotolib/resotolib/graph/__init__.py
@@ -36,7 +36,7 @@ from typing import Dict, Iterator, List, Tuple, Optional, Union
 from io import BytesIO
 from typeguard import check_type
 from time import time
-from collections import defaultdict, namedtuple
+from collections import defaultdict, namedtuple, deque
 from attrs import define, fields
 
 
@@ -330,18 +330,14 @@ class Graph(networkx.MultiDiGraph):
         This is being used to search up the graph and e.g. find the account that the
         graph node is a member of.
         """
-        ret = None
-        try:
-            for predecessor_node in list(self.predecessors(node)):
-                if isinstance(predecessor_node, cls):
-                    ret = predecessor_node
-                else:
-                    ret = self.search_first_parent_class(predecessor_node, cls)
-                if ret:
-                    break
-        except RecursionError:
-            log.exception(f"Recursive search error triggered for node {node}'s parent class {cls}")
-        return ret
+        queue = deque()
+        queue.append(node)
+        while queue:
+            current = queue.popleft()
+            if isinstance(current, cls):
+                return current
+            queue.extend(self.predecessors(current))
+        return None
 
     @metrics_graph_resolve_deferred_connections.time()
     def resolve_deferred_connections(self):


### PR DESCRIPTION
# Description

Returns the closest parent class instead of first best.
Also fixes aws client to use region id instead of name.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
