### PR TITLE
[resotolib][fix] When searching for parent nodes only check them once

### DIFF
--- a/resotolib/resotolib/graph/__init__.py
+++ b/resotolib/resotolib/graph/__init__.py
@@ -330,12 +330,15 @@ class Graph(networkx.MultiDiGraph):
         This is being used to search up the graph and e.g. find the account that the
         graph node is a member of.
         """
-        queue = deque()
-        queue.extend(self.predecessors(node))
+        queue = deque([self.predecessors(node)])
+        already_checked = set()
         while queue:
             current = queue.popleft()
+            if current in already_checked:
+                continue
             if isinstance(current, cls):
                 return current
+            already_checked.add(current)
             queue.extend(self.predecessors(current))
         return None
 

--- a/resotolib/resotolib/graph/__init__.py
+++ b/resotolib/resotolib/graph/__init__.py
@@ -334,12 +334,12 @@ class Graph(networkx.MultiDiGraph):
         already_checked = set()
         while queue:
             current = queue.popleft()
-            if current in already_checked:
-                continue
             if isinstance(current, cls):
                 return current
-            already_checked.add(current)
-            queue.extend(self.predecessors(current))
+            for n in self.predecessors(current):
+                if n not in already_checked:
+                    already_checked.add(n)
+                    queue.append(n)
         return None
 
     @metrics_graph_resolve_deferred_connections.time()

--- a/resotolib/resotolib/graph/__init__.py
+++ b/resotolib/resotolib/graph/__init__.py
@@ -331,7 +331,7 @@ class Graph(networkx.MultiDiGraph):
         graph node is a member of.
         """
         queue = deque(self.predecessors(node))
-        already_checked = set()
+        already_checked = set(self.predecessors(node))
         while queue:
             current = queue.popleft()
             if isinstance(current, cls):

--- a/resotolib/resotolib/graph/__init__.py
+++ b/resotolib/resotolib/graph/__init__.py
@@ -330,7 +330,7 @@ class Graph(networkx.MultiDiGraph):
         This is being used to search up the graph and e.g. find the account that the
         graph node is a member of.
         """
-        queue = deque([self.predecessors(node)])
+        queue = deque(self.predecessors(node))
         already_checked = set()
         while queue:
             current = queue.popleft()


### PR DESCRIPTION
# Description

There could be multiple paths to a node which would currently result in them being checked multiple times.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
