### PR TITLE
[resotocore][feat] Config Service should allow testing updates using a dry run

### DIFF
--- a/resotocore/resotocore/config/__init__.py
+++ b/resotocore/resotocore/config/__init__.py
@@ -101,11 +101,11 @@ class ConfigHandler(ABC):
         pass
 
     @abstractmethod
-    async def put_config(self, cfg: ConfigEntity, validate: bool = True) -> ConfigEntity:
+    async def put_config(self, cfg: ConfigEntity, *, validate: bool = True, dry_run: bool = False) -> ConfigEntity:
         pass
 
     @abstractmethod
-    async def patch_config(self, cfg: ConfigEntity) -> ConfigEntity:
+    async def patch_config(self, cfg: ConfigEntity, *, validate: bool = True, dry_run: bool = False) -> ConfigEntity:
         pass
 
     @abstractmethod

--- a/resotocore/resotocore/config/core_config_handler.py
+++ b/resotocore/resotocore/config/core_config_handler.py
@@ -127,7 +127,7 @@ class CoreConfigHandler:
             updated = deep_merge(empty, existing.config) if existing else empty
             updated = migrate_config(updated)
             if existing is None or updated != existing.config:
-                await self.config_handler.put_config(ConfigEntity(ResotoCoreConfigId, updated), False)
+                await self.config_handler.put_config(ConfigEntity(ResotoCoreConfigId, updated), validate=False)
                 log.info("Default resoto config updated.")
         except Exception as ex:
             log.error(f"Could not update resoto default configuration: {ex}", exc_info=ex)
@@ -138,7 +138,7 @@ class CoreConfigHandler:
             existing_commands = await self.config_handler.get_config(ResotoCoreCommandsConfigId)
             if existing_commands is None:
                 await self.config_handler.put_config(
-                    ConfigEntity(ResotoCoreCommandsConfigId, CustomCommandsConfig().json()), False
+                    ConfigEntity(ResotoCoreCommandsConfigId, CustomCommandsConfig().json()), validate=False
                 )
                 log.info("Default resoto commands config updated.")
         except Exception as ex:

--- a/resotocore/resotocore/static/api-doc.yaml
+++ b/resotocore/resotocore/static/api-doc.yaml
@@ -1711,6 +1711,14 @@ paths:
             In case it is not defined or not set to false, every configuaration value is validated.
           schema:
             type: boolean
+        - name: dry_run
+          required: false
+          in: query
+          description: |
+            This parameter can be used to test if the config could be updated without really changing it.
+            It will perform all validations but not store the new value.
+          schema:
+            type: boolean
       requestBody:
         content:
           application/json:
@@ -1744,6 +1752,22 @@ paths:
           description: the identifier of the config to get.
           schema:
             type: string
+        - name: validate
+          required: false
+          in: query
+          description: |
+            This parameter can be used to turn off config validation.
+            In case it is not defined or not set to false, every configuaration value is validated.
+          schema:
+            type: boolean
+        - name: dry_run
+          required: false
+          in: query
+          description: |
+            This parameter can be used to test if the config could be patched without really changing it.
+            It will perform all validations but not store the new value.
+          schema:
+            type: boolean
       requestBody:
         content:
           application/json:

--- a/resotocore/resotocore/web/api.py
+++ b/resotocore/resotocore/web/api.py
@@ -312,15 +312,22 @@ class Api:
     async def put_config(self, request: Request) -> StreamResponse:
         config_id = ConfigId(request.match_info["config_id"])
         validate = request.query.get("validate", "true").lower() != "false"
+        dry_run = request.query.get("dry_run", "false").lower() == "true"
         config = await self.json_from_request(request)
-        result = await self.config_handler.put_config(ConfigEntity(config_id, config), validate)
+        result = await self.config_handler.put_config(
+            ConfigEntity(config_id, config), validate=validate, dry_run=dry_run
+        )
         headers = {"Resoto-Config-Revision": result.revision}
         return await single_result(request, result.config, headers)
 
     async def patch_config(self, request: Request) -> StreamResponse:
         config_id = ConfigId(request.match_info["config_id"])
+        validate = request.query.get("validate", "true").lower() != "false"
+        dry_run = request.query.get("dry_run", "false").lower() == "true"
         patch = await self.json_from_request(request)
-        updated = await self.config_handler.patch_config(ConfigEntity(config_id, patch))
+        updated = await self.config_handler.patch_config(
+            ConfigEntity(config_id, patch), validate=validate, dry_run=dry_run
+        )
         headers = {"Resoto-Config-Revision": updated.revision}
         return await single_result(request, updated.config, headers)
 

--- a/resotocore/tests/resotocore/config/config_handler_service_test.py
+++ b/resotocore/tests/resotocore/config/config_handler_service_test.py
@@ -105,6 +105,20 @@ async def test_config_change_event(config_handler: ConfigHandlerService) -> None
 
 
 @pytest.mark.asyncio
+async def test_dry_run(config_handler: ConfigHandlerService) -> None:
+    config_id = ConfigId("test_dry_run")
+    entity = ConfigEntity(config_id, {"test": True})
+
+    # put dry run -> config is not stored
+    assert await config_handler.put_config(entity, dry_run=True) == entity
+    assert await config_handler.get_config(config_id) is None
+
+    # patch dry run -> config is not stored
+    assert await config_handler.patch_config(entity, dry_run=True) == entity
+    assert await config_handler.get_config(config_id) is None
+
+
+@pytest.mark.asyncio
 async def test_config_change_analytics(config_handler: ConfigHandler) -> None:
 
     config_id = ConfigId("test")

--- a/resotocore/tests/resotocore/config/core_config_handler_test.py
+++ b/resotocore/tests/resotocore/config/core_config_handler_test.py
@@ -103,6 +103,9 @@ async def test_detect_usage_metrics_turned_off(
 ) -> None:
     # make sure usage metrics are enabled
     core_config_handler_started.config.runtime.usage_metrics = True
+    await config_handler.patch_config(
+        ConfigEntity(ResotoCoreConfigId, {ResotoCoreRoot: {"runtime": {"usage_metrics": True}}})
+    )
     # disable usage metrics
     await config_handler.patch_config(
         ConfigEntity(ResotoCoreConfigId, {ResotoCoreRoot: {"runtime": {"usage_metrics": False}}})


### PR DESCRIPTION

# Description

Define `dry_run=true` on put and patch operations to perform the requested change without changing the data.

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`
- [x] Document new or updated functionality 

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
