### PR TITLE
[resotocore][feat] Maintain the list of workflow tasks

### DIFF
--- a/resotocore/resotocore/cli/command.py
+++ b/resotocore/resotocore/cli/command.py
@@ -3868,6 +3868,12 @@ class WorkflowsCommand(CLICommand):
     task_started_at: '2022-11-04T08:31:01Z'
     duration: 87.786464
     errors: 19
+
+    # show the log of a specific workflow run
+    > workflows log 037f23c6-5c1b-11ed-bb8b-dad780437c53
+    2022-11-04T08:31:01Z: collect: collect: aws: 882347060974: collect-global: in progress
+    [aws:123456789] Access Denied to aws_account 123456789
+    [aws:234567890] An AWS UnauthorizedOperation error occurred while collecting account test
     ```
     """
 

--- a/resotocore/resotocore/cli/command.py
+++ b/resotocore/resotocore/cli/command.py
@@ -15,8 +15,6 @@ from asyncio import Future, Task
 from asyncio.subprocess import Process
 from collections import defaultdict
 from contextlib import suppress
-
-from attrs import define, field
 from datetime import timedelta
 from functools import partial, lru_cache
 from itertools import dropwhile, chain
@@ -45,20 +43,9 @@ from aiohttp import ClientTimeout, JsonPayload, BasicAuth
 from aiostream import stream, pipe
 from aiostream.aiter_utils import is_async_iterable
 from aiostream.core import Stream
+from attrs import define, field
+from dateutil import parser as date_parser
 from parsy import Parser, string
-from resotolib.x509 import write_cert_to_file, write_key_to_file
-from resotolib.utils import safe_members_in_tarfile, get_local_tzinfo
-from resotolib.parse_util import (
-    double_quoted_or_simple_string_dp,
-    space_dp,
-    make_parser,
-    variable_dp,
-    literal_dp,
-    comma_p,
-    variable_p,
-    equals_p,
-    json_value_p,
-)
 from rich.padding import Padding
 from rich.panel import Panel
 from rich.table import Table
@@ -78,7 +65,6 @@ from resotocore.cli import (
     js_value_at,
     js_value_get,
 )
-from resotocore.ids import ConfigId, TaskId
 from resotocore.cli.model import (
     CLICommand,
     CLIContext,
@@ -100,9 +86,14 @@ from resotocore.cli.model import (
 )
 from resotocore.cli.tip_of_the_day import SuggestionPolicy, SuggestionStrategy, get_suggestion_strategy
 from resotocore.config import ConfigEntity
+from resotocore.db.async_arangodb import AsyncCursor
 from resotocore.db.model import QueryModel
+from resotocore.db.runningtaskdb import RunningTaskData
 from resotocore.dependencies import system_info
 from resotocore.error import CLIParseError, ClientError, CLIExecutionError
+from resotocore.ids import ConfigId, TaskId
+from resotocore.ids import TaskDescriptorId
+from resotocore.message_bus import ActionInfo
 from resotocore.model.graph_access import Section, EdgeTypes
 from resotocore.model.model import (
     Model,
@@ -141,7 +132,19 @@ from resotocore.web.content_renderer import (
     respond_cytoscape,
 )
 from resotocore.worker_task_queue import WorkerTask, WorkerTaskName
-from resotocore.ids import TaskDescriptorId
+from resotolib.parse_util import (
+    double_quoted_or_simple_string_dp,
+    space_dp,
+    make_parser,
+    variable_dp,
+    literal_dp,
+    comma_p,
+    variable_p,
+    equals_p,
+    json_value_p,
+)
+from resotolib.utils import safe_members_in_tarfile, get_local_tzinfo
+from resotolib.x509 import write_cert_to_file, write_key_to_file
 
 log = logging.getLogger(__name__)
 
@@ -3748,12 +3751,18 @@ class WorkflowsCommand(CLICommand):
     workflows show <id>
     workflows run <id>
     workflows running
+    workflows history
+    workflows history <id> --started-before <date> --started-after <date> --has-errors --limit <num>
+    workflows log <workflow-run-id>
     ```
 
     - `workflows list`: get the list of all workflows in the system
     - `workflows show <id>`: show the current definition of the workflow defined by given identifier.
     - `workflows run <id>`: run the workflow as if the trigger would be triggered.
     - `workflows running`: show all currently running workflows.
+    - `workflows history`: aggregated history of all workflows.
+    - `workflows history <id>`: show all runs of this workflow based on defined filter criteria.
+    - `workflows log <workflow-run-id>`: show the log of the workflow run.
 
     The workflows that currently available are all hard-wired into resotocore.
     We will support user defined workflows in the future.
@@ -3765,6 +3774,10 @@ class WorkflowsCommand(CLICommand):
 
     ## Options
     - `--id` <id> [optional]: The identifier of this workflow.
+    - `--started-before` <date> [optional]: Filter for workflow runs that started before this date.
+    - `--started-after` <date> [optional]: Filter for workflow runs that started after this date.
+    - `--has-errors` [optional]: Filter for workflow runs that have errors.
+    - `--limit` <num> [optional]: Limit the number of workflow runs to show.
 
     ## Examples
 
@@ -3822,9 +3835,39 @@ class WorkflowsCommand(CLICommand):
 
     # show all currently running workflows
     > workflows running
-    workflow: collect
-    started_at: '2022-02-15T17:08:02Z'
-    task-id: d54f92b8-8e81-11ec-8fc0-dad780437c54
+    workflow: collect_and_cleanup
+    started: '2022-11-04T12:33:32Z'
+    task-id: e514fbd2-5c3c-11ed-894d-dad780437c53
+    progress: 16%
+    current-step: collect
+    step-info:
+      collect:
+        digitalocean:
+          '10225075': in progress
+        aws:
+          '882347060974':
+            collect-global: in progress
+        k8s: done
+
+    # show the history of all workflows
+    > workflows history
+    collect:
+      count: 264
+      last_run: '2022-11-04T12:33:32Z'
+      runs_with_errors: 1
+      average_duration: 18s
+    collect_and_cleanup:
+      count: 3416
+      last_run: '2022-11-04T12:00:00Z'
+      runs_with_errors: 0
+      average_duration: 34s
+
+    # show the history of a specific workflow
+    > workflows history collect --started-after 2022-11-03 --started-before 2022-11-05 --has-errors --limit 10
+    id: 037f23c6-5c1b-11ed-bb8b-dad780437c53
+    task_started_at: '2022-11-04T08:31:01Z'
+    duration: 87.786464
+    errors: 19
     ```
     """
 
@@ -3841,6 +3884,14 @@ class WorkflowsCommand(CLICommand):
             "list": [],
             "run": [ArgInfo(None, help_text="<workflow-id>")],
             "running": [],
+            "history": [
+                ArgInfo(None, help_text="<workflow-id>"),
+                ArgInfo("--started-before", help_text="<date>", value_hint="date", expects_value=True),
+                ArgInfo("--started-after", help_text="<date>", value_hint="date", expects_value=True),
+                ArgInfo("--limit", help_text="<number of entries>", expects_value=True),
+                ArgInfo("--has-errors"),
+            ],
+            "log": [ArgInfo(None, help_text="<workflow-run-id>")],
         }
 
     def parse(self, arg: Optional[str] = None, ctx: CLIContext = EmptyContext, **kwargs: Any) -> CLISource:
@@ -3888,9 +3939,8 @@ class WorkflowsCommand(CLICommand):
                     if rt.is_active
                     else {"progress": "done"}
                 )
-                # show messages only if there are messages to show
-                messages = {"messages": [msg.info() for msg in rt.info_messages]} if rt.info_messages else {}
-
+                # only show the number of error messages, not the actual messages (it can get big)
+                messages = {"errors": f"{len(rt.info_messages)} errors"} if rt.info_messages else {}
                 return {
                     "workflow": rt.descriptor.id,
                     "started": to_json(rt.task_started_at),
@@ -3901,9 +3951,61 @@ class WorkflowsCommand(CLICommand):
 
             return len(tasks), stream.iterate(info(t) for t in tasks if isinstance(t.descriptor, Workflow))
 
+        async def show_log(wf_id: str) -> Tuple[int, AsyncIterator[JsonElement]]:
+            rtd = await self.dependencies.db_access.running_task_db.get(wf_id)
+            if rtd:
+                messages = [msg.info() for msg in rtd.info_messages() if isinstance(msg, ActionInfo)]
+                if messages:
+                    return len(messages), stream.iterate(messages)
+                else:
+                    return 0, stream.just("No error messages for this run.")
+            else:
+                return 0, stream.just(f"No workflow task with this id: {wf_id}")
+
+        def running_task_data(rtd: RunningTaskData) -> Json:
+            result = {
+                "id": rtd.id,
+                "task_started_at": to_json(rtd.task_started_at),
+                "duration": to_json(rtd.task_duration),
+            }
+            if rtd.has_error or rtd.has_info:
+                result["errors"] = len(rtd.info_messages())
+            return result
+
+        async def history_aggregation() -> Stream:
+            info = await self.dependencies.db_access.running_task_db.aggregated_history()
+            return stream.just(info)
+
+        async def history_of(history_args: List[str]) -> Tuple[int, Stream]:
+            parser = NoExitArgumentParser()
+            parser.add_argument("workflow")
+            parser.add_argument("--started-after", dest="started_after", type=date_parser.parse)
+            parser.add_argument("--started-before", dest="started_before", type=date_parser.parse)
+            parser.add_argument("--has-errors", dest="has_errors", action="store_true", default=None)
+            parser.add_argument("--limit", type=int, default=10)
+            parsed = parser.parse_args(history_args)
+            context = await self.dependencies.db_access.running_task_db.filtered(
+                descriptor_id=parsed.workflow,
+                started_after=parsed.started_after,
+                started_before=parsed.started_before,
+                with_error=parsed.has_errors,
+                limit=parsed.limit,
+            )
+            cursor: AsyncCursor = context.cursor
+            try:
+                return cursor.count() or 0, stream.map(cursor, running_task_data)
+            finally:
+                cursor.close()
+
         args = re.split("\\s+", arg, maxsplit=1) if arg else []
         if arg and len(args) == 2 and args[0] == "show":
             return CLISource.single(partial(show_workflow, args[1].strip()))
+        elif arg and len(args) == 1 and args[0] == "history":
+            return CLISource.single(history_aggregation)
+        elif arg and len(args) == 2 and args[0] == "history":
+            return CLISource(partial(history_of, re.split("\\s+", args[1])))
+        elif arg and len(args) == 2 and args[0] == "log":
+            return CLISource(partial(show_log, args[1].strip()))
         elif arg and len(args) == 2 and args[0] == "run":
             return CLISource.single(partial(run_workflow, args[1].strip()))
         elif arg and len(args) == 1 and args[0] == "running":

--- a/resotocore/resotocore/db/async_arangodb.py
+++ b/resotocore/resotocore/db/async_arangodb.py
@@ -34,8 +34,8 @@ from resotocore.util import identity
 log = logging.getLogger(__name__)
 
 
-class AsyncCursor(AsyncIterator[Json]):
-    def __init__(self, cursor: Cursor, trafo: Optional[Callable[[Json], Optional[Json]]]):
+class AsyncCursor(AsyncIterator[Any]):
+    def __init__(self, cursor: Cursor, trafo: Optional[Callable[[Json], Optional[Any]]]):
         self.cursor = cursor
         self.visited_node: Set[str] = set()
         self.visited_edge: Set[str] = set()
@@ -46,7 +46,7 @@ class AsyncCursor(AsyncIterator[Json]):
         self.on_hold: Optional[Json] = None
         self.get_next: Callable[[], Awaitable[Optional[Json]]] = self.next_filtered if trafo else self.next_from_db
 
-    async def __anext__(self) -> Json:
+    async def __anext__(self) -> Any:
         # if there is an on-hold element: unset and return it
         # background: a graph node contains vertex and edge information.
         # since this method can only return one element at a time, the edge is put on-hold for vertex+edge data.
@@ -138,7 +138,7 @@ class AsyncCursor(AsyncIterator[Json]):
 
 
 class AsyncCursorContext(AsyncContextManager[AsyncCursor]):
-    def __init__(self, cursor: Cursor, trafo: Optional[Callable[[Json], Optional[Json]]]):
+    def __init__(self, cursor: Cursor, trafo: Optional[Callable[[Json], Optional[Any]]]):
         self._cursor = cursor
         self._trafo = trafo
 
@@ -161,7 +161,7 @@ class AsyncArangoDBBase:
     async def aql_cursor(
         self,
         query: str,
-        trafo: Optional[Callable[[Json], Optional[Json]]] = None,
+        trafo: Optional[Callable[[Json], Optional[Any]]] = None,
         count: bool = False,
         batch_size: Optional[int] = None,
         ttl: Optional[Number] = None,

--- a/resotocore/resotocore/db/runningtaskdb.py
+++ b/resotocore/resotocore/db/runningtaskdb.py
@@ -2,20 +2,40 @@ from __future__ import annotations
 
 import logging
 from abc import abstractmethod
-from attrs import define, field
-from datetime import datetime
-from typing import Sequence, Optional
+from functools import partial
 
-from resotocore.db.async_arangodb import AsyncArangoDB
+from attrs import define, field
+from datetime import datetime, timedelta
+from typing import Sequence, Optional, List, AsyncGenerator, Dict
+
+from jsons import JsonsError
+
+from resotocore.db.async_arangodb import AsyncArangoDB, AsyncCursorContext
 from resotocore.db.entitydb import EntityDb, ArangoEntityDb
 from resotocore.ids import TaskId, TaskDescriptorId
-from resotocore.message_bus import Message
-from resotocore.model.typed_model import to_js
+from resotocore.message_bus import Message, ActionInfo
+from resotocore.model.typed_model import to_js, from_js
 from resotocore.task.task_description import RunningTask
-from resotocore.types import Json
-from resotocore.util import utc
+from resotocore.types import Json, JsonElement
+from resotocore.util import utc, utc_str
 
 log = logging.getLogger(__name__)
+
+
+@define(order=True, hash=True, frozen=True)
+class RunningTaskStepInfo:
+    step_name: str
+    timed_out: bool = False
+    started_at: Optional[datetime] = None
+    finished_at: Optional[datetime] = None
+
+    @staticmethod
+    def from_task(task: RunningTask) -> List[RunningTaskStepInfo]:
+        return [
+            RunningTaskStepInfo(name, s.timed_out, s.started_at, s.finished_at)
+            for name, s in task.states.items()
+            if name not in ("task_start", "task_end")
+        ]
 
 
 @define(order=True, hash=True, frozen=True)
@@ -32,10 +52,18 @@ class RunningTaskData:
     current_state_name: str = field(default="start")
     # the state of the current state exported as json
     current_state_snapshot: Json = field(factory=dict)
+    # base state of every step
+    step_states: List[RunningTaskStepInfo] = field(factory=list)
     # the timestamp when the step has been started
     task_started_at: datetime = field(factory=utc)
-    # the timestamp when the step has been started
-    step_started_at: datetime = field(factory=utc)
+    # duration of the task
+    task_duration: Optional[timedelta] = None
+    # indicates if this task is still active
+    done: bool = False
+    # indicates if this task had warnings
+    has_info: bool = False
+    # indicates if this task had errors
+    has_error: bool = False
 
     @staticmethod
     def data(wi: RunningTask) -> RunningTaskData:
@@ -46,18 +74,40 @@ class RunningTaskData:
             wi.received_messages,
             wi.current_state.name,
             wi.current_state.export_state(),
+            RunningTaskStepInfo.from_task(wi),
             wi.task_started_at,
-            wi.step_started_at,
+            wi.task_duration,
+            not wi.is_active,
+            any(True for msg in wi.info_messages if isinstance(msg, ActionInfo) and msg.level == "info"),
+            any(True for msg in wi.info_messages if isinstance(msg, ActionInfo) and msg.level == "error"),
         )
 
 
 class RunningTaskDb(EntityDb[str, RunningTaskData]):
     @abstractmethod
-    async def update_state(self, wi: RunningTask, message: Optional[Message]) -> None:
+    def all_running(self) -> AsyncGenerator[RunningTaskData, None]:
+        pass
+
+    @abstractmethod
+    async def update_state(self, wi: RunningTask, message: Optional[Message] = None) -> None:
         pass
 
     @abstractmethod
     async def insert(self, task: RunningTask) -> RunningTaskData:
+        pass
+
+    @abstractmethod
+    async def filtered(
+        self,
+        *,
+        task_id: Optional[TaskId] = None,
+        descriptor_name: Optional[str] = None,
+        started_from: Optional[datetime] = None,
+        started_until: Optional[datetime] = None,
+        with_info: Optional[bool] = None,
+        with_error: Optional[bool] = None,
+        limit: Optional[int] = None,
+    ) -> AsyncCursorContext:
         pass
 
 
@@ -65,11 +115,47 @@ class ArangoRunningTaskDb(ArangoEntityDb[str, RunningTaskData], RunningTaskDb):
     def __init__(self, db: AsyncArangoDB, collection: str):
         super().__init__(db, collection, RunningTaskData, lambda k: k.id)
 
-    async def update_state(self, wi: RunningTask, message: Optional[Message]) -> None:
+    async def create_update_schema(self) -> None:
+        await super().create_update_schema()
+        collection = self.db.collection(self.collection_name)
+        indexes = {idx["name"]: idx for idx in collection.indexes()}
+        # descriptor_id, descriptor_name, done, created_at
+        id_idx = f"{self.collection_name}_id_done"
+        if id_idx not in indexes:
+            collection.add_persistent_index(
+                ["task_descriptor_id", "task_descriptor_name", "task_started_at", "has_info", "has_error", "done"],
+                sparse=False,
+                name=id_idx,
+            )
+        # ttl index to get rid of old entries
+        ttl_idx = f"{self.collection_name}_ttl"
+        if ttl_idx not in indexes:
+            collection.add_ttl_index(
+                ["task_started_at"],
+                expiry_time=int(timedelta(days=60).total_seconds()),
+                in_background=True,
+                name=ttl_idx,
+            )
+
+    async def all_running(self) -> AsyncGenerator[RunningTaskData, None]:
+        aql = f"""FOR doc IN {self.collection_name} FILTER doc.done == false RETURN doc"""
+        async with await self.db.aql_cursor(aql) as cursor:
+            async for element in cursor:
+                try:
+                    yield from_js(element, RunningTaskData)
+                except JsonsError:
+                    log.warning(f"Not able to parse {element} into RunningTaskData. Ignore.")
+
+    async def update_state(self, wi: RunningTask, message: Optional[Message] = None) -> None:
         bind = {
             "id": f"{self.collection_name}/{wi.id}",
             "current_state_name": wi.current_state.name,
             "current_state_snapshot": wi.current_state.export_state(),
+            "step_states": to_js(RunningTaskStepInfo.from_task(wi)),
+            "task_duration": to_js(wi.task_duration),
+            "has_info": any(True for msg in wi.info_messages if isinstance(msg, ActionInfo) and msg.level == "info"),
+            "has_error": any(True for msg in wi.info_messages if isinstance(msg, ActionInfo) and msg.level == "error"),
+            "done": not wi.is_active,
         }
         if message:
             bind["message"] = to_js(message)
@@ -79,6 +165,42 @@ class ArangoRunningTaskDb(ArangoEntityDb[str, RunningTaskData], RunningTaskDb):
 
         await self.db.aql(aql, bind_vars=bind)
 
+    async def filtered(
+        self,
+        *,
+        task_id: Optional[TaskId] = None,
+        descriptor_name: Optional[str] = None,
+        started_from: Optional[datetime] = None,
+        started_until: Optional[datetime] = None,
+        with_info: Optional[bool] = None,
+        with_error: Optional[bool] = None,
+        limit: Optional[int] = None,
+    ) -> AsyncCursorContext:
+        filters: List[str] = []
+        bind: Dict[str, JsonElement] = {}
+        if task_id:
+            filters.append("doc.id == @task_id")
+            bind["task_id"] = task_id
+        if descriptor_name:
+            filters.append("doc.task_descriptor_name == @descriptor_name")
+            bind["descriptor_name"] = descriptor_name
+        if started_from:
+            filters.append("doc.task_started_at >= @started_from")
+            bind["started_from"] = utc_str(started_from)
+        if started_until:
+            filters.append("doc.task_started_at <= @started_until")
+            bind["started_until"] = utc_str(started_until)
+        if with_info is not None:
+            filters.append("doc.has_info == @with_info")
+            bind["with_info"] = with_info
+        if with_error is not None:
+            filters.append("doc.has_error == @with_error")
+            bind["with_error"] = with_error
+        filter_stmt = " FILTER " + (" AND ".join(filters)) if filters else ""
+        limit_stmt = f" LIMIT {limit}" if limit else ""
+        aql = f"""FOR doc IN {self.collection_name}{filter_stmt}{limit_stmt} RETURN doc"""
+        return await self.db.aql_cursor(query=aql, bind_vars=bind, trafo=partial(from_js, clazz=RunningTaskData))
+
     async def insert(self, task: RunningTask) -> RunningTaskData:
         return await self.update(RunningTaskData.data(task))
 
@@ -87,7 +209,12 @@ class ArangoRunningTaskDb(ArangoEntityDb[str, RunningTaskData], RunningTaskDb):
         LET doc = Document(@id)
         UPDATE doc WITH {{
             current_state_name: @current_state_name,
-            current_state_snapshot: @current_state_snapshot
+            current_state_snapshot: @current_state_snapshot,
+            step_states: @step_states,
+            task_duration: @task_duration,
+            has_info: @has_info,
+            has_error: @has_error,
+            done: @done
         }} IN {self.collection_name}
         """
 
@@ -97,6 +224,11 @@ class ArangoRunningTaskDb(ArangoEntityDb[str, RunningTaskData], RunningTaskDb):
         UPDATE doc WITH {{
             current_state_name: @current_state_name,
             current_state_snapshot: @current_state_snapshot,
+            step_states: @step_states,
+            task_duration: @task_duration,
+            has_info: @has_info,
+            has_error: @has_error,
+            done: @done,
             received_messages: APPEND(doc.received_messages, @message)
         }} IN {self.collection_name}
         """

--- a/resotocore/resotocore/util.py
+++ b/resotocore/resotocore/util.py
@@ -96,6 +96,21 @@ def uuid_str(from_object: Optional[Any] = None) -> str:
         return str(uuid.uuid1())
 
 
+def partition_by(f: Callable[[AnyT], bool], iterable: Iterable[AnyT]) -> Tuple[List[AnyT], List[AnyT]]:
+    """
+    Partition a list based on provided function.
+    :param f: the function to test every element.
+    :param iterable: the iterable to walk.
+    :return: a tuple with two lists. The first list contains all elements for which the function returned True
+             the second list contains all elements for which the function returned False.
+    """
+    left: List[AnyT] = []
+    right: List[AnyT] = []
+    for p in iterable:
+        (left if f(p) else right).append(p)
+    return left, right
+
+
 def group_by(f: Callable[[AnyT], AnyR], iterable: Iterable[AnyT]) -> Dict[AnyR, List[AnyT]]:
     """
     Group iterable by key provided by given key function.

--- a/resotocore/resotocore/web/api.py
+++ b/resotocore/resotocore/web/api.py
@@ -73,7 +73,7 @@ from resotocore.task.model import Subscription
 from resotocore.task.subscribers import SubscriptionHandler
 from resotocore.task.task_handler import TaskHandlerService
 from resotocore.types import Json, JsonElement
-from resotocore.util import uuid_str, force_gen, rnd_str, if_set, duration
+from resotocore.util import uuid_str, force_gen, rnd_str, if_set, duration, utc_str
 from resotocore.web.certificate_handler import CertificateHandler
 from resotocore.web.content_renderer import result_binary_gen, single_result
 from resotocore.web.directives import (
@@ -460,6 +460,7 @@ class Api:
             js = json.loads(msg)
             if "data" in js:
                 js["data"]["subscriber_id"] = listener_id
+                js["data"]["received_at"] = utc_str()
             message: Message = from_js(js, Message)
             if isinstance(message, Action):
                 raise AttributeError("Actors should not emit action messages. ")

--- a/resotocore/tests/resotocore/cli/command_test.py
+++ b/resotocore/tests/resotocore/cli/command_test.py
@@ -388,6 +388,22 @@ async def test_workflows_command(cli: CLI, task_handler: TaskHandlerService, tes
     for rt in await task_handler.running_tasks():
         await task_handler.delete_running_task(rt)
 
+    # access the history of all workflows
+    history = AccessJson.wrap_list(await execute("workflows history"))
+    assert len(history) == 1
+    assert history[0].sleep_workflow.count == 1
+    assert history[0].test_workflow.count == 1
+
+    # access the history of a specific workflow
+    history_test = AccessJson.wrap_list(await execute("workflows history test_workflow"))
+    assert len(history_test) == 1
+    wf_run = history_test[0]
+    assert all(n in wf_run for n in ["id", "task_started_at", "duration"])
+
+    # access the log of a specific workflow run
+    task_log = await execute(f"workflows log {wf_run['id']}")
+    assert len(task_log) == 1
+
 
 @pytest.mark.asyncio
 async def test_jobs_command(cli: CLI, task_handler: TaskHandlerService, job_db: JobDb) -> None:

--- a/resotocore/tests/resotocore/db/runningtaskdb_test.py
+++ b/resotocore/tests/resotocore/db/runningtaskdb_test.py
@@ -1,21 +1,17 @@
 from datetime import timedelta
+from typing import List, Dict, Tuple, Any
 
 import pytest
 from arango.database import StandardDatabase
-from typing import List, Dict, Tuple, Any
 
 from resotocore.db import runningtaskdb
 from resotocore.db.async_arangodb import AsyncArangoDB
 from resotocore.db.runningtaskdb import RunningTaskData, RunningTaskDb, RunningTaskStepInfo
-from resotocore.message_bus import ActionDone
-from resotocore.util import utc
-from resotocore.task.model import Subscriber
 from resotocore.ids import TaskId, SubscriberId, TaskDescriptorId
-
-from resotocore.task.task_description import RunningTask
-
-# noinspection PyUnresolvedReferences
-from tests.resotocore.task.task_description_test import workflow_instance, test_workflow
+from resotocore.message_bus import ActionDone
+from resotocore.task.model import Subscriber
+from resotocore.task.task_description import RunningTask, Workflow
+from resotocore.util import utc, utc_str
 
 # noinspection PyUnresolvedReferences
 from tests.resotocore.db.graphdb_test import test_db, local_client, system_db
@@ -23,11 +19,16 @@ from tests.resotocore.db.graphdb_test import test_db, local_client, system_db
 # noinspection PyUnresolvedReferences
 from tests.resotocore.message_bus_test import message_bus, all_events
 
+# noinspection PyUnresolvedReferences
+from tests.resotocore.task.task_description_test import workflow_instance, test_workflow
+
+now = utc()
+
 
 @pytest.fixture
 async def running_task_db(test_db: StandardDatabase) -> RunningTaskDb:
     async_db = AsyncArangoDB(test_db)
-    task_db = runningtaskdb.running_task_db(async_db, "running_task")
+    task_db = runningtaskdb.running_task_db(async_db, "running_tasks")
     await task_db.create_update_schema()
     await task_db.wipe()
     return task_db
@@ -40,13 +41,14 @@ def instances() -> List[RunningTaskData]:
     return [
         RunningTaskData(
             TaskId(f"task_{a}"),
-            TaskDescriptorId(str(a)),
+            TaskDescriptorId("task_123"),
             "task_123",
+            Workflow.__name__,
             messages,
             "start",
             state_data,
-            [RunningTaskStepInfo(f"step_{a}", False, utc(), utc()) for a in range(0, 3)],
-            task_started_at=utc(),
+            [RunningTaskStepInfo(f"step_{a}", False, now, now) for a in range(0, 3)],
+            task_started_at=now,
             task_duration=timedelta(seconds=10),
             done=a > 5,
             has_info=a > 6,
@@ -80,16 +82,25 @@ async def test_filtered(running_task_db: RunningTaskDb, instances: List[RunningT
 
     assert len(await filtered_list()) == len(instances)
     assert len(await filtered_list(limit=1)) == 1
-    assert len(await filtered_list(descriptor_name="task_123")) == len(instances)
+    assert len(await filtered_list(descriptor_id="task_123")) == len(instances)
     assert await filtered_list(task_id=TaskId("task_1")) == [TaskId("task_1")]
-    assert len(await filtered_list(started_from=utc() + timedelta(minutes=1))) == 0
-    assert len(await filtered_list(started_from=utc() - timedelta(minutes=1))) == 10
-    assert len(await filtered_list(started_until=utc() + timedelta(minutes=1))) == 10
-    assert len(await filtered_list(started_until=utc() - timedelta(minutes=1))) == 0
+    assert len(await filtered_list(started_after=now + timedelta(minutes=1))) == 0
+    assert len(await filtered_list(started_after=now - timedelta(minutes=1))) == 10
+    assert len(await filtered_list(started_before=now + timedelta(minutes=1))) == 10
+    assert len(await filtered_list(started_before=now - timedelta(minutes=1))) == 0
     assert len(await filtered_list(with_info=True)) == 3
     assert len(await filtered_list(with_info=False)) == 7
     assert len(await filtered_list(with_error=True)) == 2
     assert len(await filtered_list(with_error=False)) == 8
+
+
+@pytest.mark.asyncio
+async def test_aggregated(running_task_db: RunningTaskDb, instances: List[RunningTaskData]) -> None:
+    await running_task_db.update_many(instances)
+    res = await running_task_db.aggregated_history()
+    assert res == {
+        "task_123": {"count": 10, "last_run": utc_str(now), "runs_with_errors": 2, "average_duration": "10s"}
+    }
 
 
 @pytest.mark.asyncio

--- a/resotocore/tests/resotocore/task/task_handler_test.py
+++ b/resotocore/tests/resotocore/task/task_handler_test.py
@@ -183,6 +183,9 @@ async def test_recover_workflow(
         assert len(wf2.tasks) == 1
         wfi = list(wf2.tasks.values())[0]
         assert wfi.current_state.name == "act"
+        s1 = await wf2.list_all_pending_actions_for(sub1)
+        s2 = await wf2.list_all_pending_actions_for(sub2)
+        s3 = await wf2.list_all_pending_actions_for(sub3)
         assert (await wf2.list_all_pending_actions_for(sub1)) == []
         assert (await wf2.list_all_pending_actions_for(sub2)) == [Action("collect", wfi.id, "act", {})]
         assert (await wf2.list_all_pending_actions_for(sub3)) == []

--- a/resotocore/tests/resotocore/util_test.py
+++ b/resotocore/tests/resotocore/util_test.py
@@ -15,6 +15,7 @@ from resotocore.util import (
     rnd_str,
     del_value_in_path,
     deep_merge,
+    partition_by,
 )
 
 
@@ -23,6 +24,12 @@ def not_in_path(name: str, *other: str) -> bool:
         if shutil.which(n) is None:
             return True
     return False
+
+
+def test_partition_by() -> None:
+    even, odd = partition_by(lambda x: x % 2 == 0, range(10))
+    assert even == [0, 2, 4, 6, 8]
+    assert odd == [1, 3, 5, 7, 9]
 
 
 def test_access_json() -> None:


### PR DESCRIPTION
# Description

With this PR workflow runs are maintained in the database after the task is finished.
The `workflows` command is adapted to filter the list of past runs:

```bash
# show the history of all workflows
> workflows history
collect:
  count: 264
  last_run: '2022-11-04T12:33:32Z'
  runs_with_errors: 1
  average_duration: 18s
collect_and_cleanup:
  count: 3416
  last_run: '2022-11-04T12:00:00Z'
  runs_with_errors: 0
  average_duration: 34s

# show the history of a specific workflow
> workflows history collect --started-after 2022-11-03 --started-before 2022-11-05 --has-errors --limit 10
id: 037f23c6-5c1b-11ed-bb8b-dad780437c53
task_started_at: '2022-11-04T08:31:01Z'
duration: 87.786464
errors: 19

# show the log of a specific workflow run
> workflows log 037f23c6-5c1b-11ed-bb8b-dad780437c53
2022-11-04T08:31:01Z: collect: collect: aws: 882347060974: collect-global: in progress
[aws:123456789] Access Denied to aws_account 123456789
[aws:234567890] An AWS UnauthorizedOperation error occurred while collecting account test
```

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
