### PR TITLE
[plugins/aws][fix] include set identifier in _keys() for RRSets

### DIFF
--- a/plugins/aws/resoto_plugin_aws/resource/route53.py
+++ b/plugins/aws/resoto_plugin_aws/resource/route53.py
@@ -217,7 +217,7 @@ class AwsRoute53ResourceRecordSet(AwsResource, BaseDNSRecordSet):
     record_traffic_policy_instance_id: Optional[str] = field(default=None)
     record_cidr_routing_config: Optional[AwsRoute53CidrRoutingConfig] = field(default=None)
 
-    def _keys(self) -> tuple:
+    def _keys(self) -> tuple[str, str, str, str, str, str, str, str, str, Optional[str]]:
         if self._graph is None:
             raise RuntimeError(f"_keys() called on {self.rtdname} before resource was added to graph")
         return (

--- a/plugins/aws/resoto_plugin_aws/resource/route53.py
+++ b/plugins/aws/resoto_plugin_aws/resource/route53.py
@@ -217,5 +217,21 @@ class AwsRoute53ResourceRecordSet(AwsResource, BaseDNSRecordSet):
     record_traffic_policy_instance_id: Optional[str] = field(default=None)
     record_cidr_routing_config: Optional[AwsRoute53CidrRoutingConfig] = field(default=None)
 
+    def _keys(self) -> tuple:
+        if self._graph is None:
+            raise RuntimeError(f"_keys() called on {self.rtdname} before resource was added to graph")
+        return (
+            self.kind,
+            self.cloud().id,
+            self.account().id,
+            self.region().id,
+            self.zone().id,
+            self.dns_zone().id,
+            self.id,
+            self.name,
+            self.record_type,
+            self.record_set_identifier,
+        )
+
 
 resources: List[Type[AwsResource]] = [AwsRoute53Zone, AwsRoute53ResourceRecord, AwsRoute53ResourceRecordSet]


### PR DESCRIPTION
# Description

This includes the set identifier in the `_keys()` method, which is used to create the unique ID.

API response for location balanced RRSets:
```
        {
            "Name": "hello-rr.example.com.",
            "Type": "CNAME",
            "SetIdentifier": "eu-central",
            "Weight": 33,
            "TTL": 172800,
            "ResourceRecords": [
                {
                    "Value": "hello.eu-central.example.com."
                }
            ]
        },
        {
            "Name": "hello-rr.example.com.",
            "Type": "CNAME",
            "SetIdentifier": "us-east",
            "Weight": 33,
            "TTL": 172800,
            "ResourceRecords": [
                {
                    "Value": "hello.us-east.example.com."
                }
            ]
        },
        {
            "Name": "hello-rr.example.com.",
            "Type": "CNAME",
            "SetIdentifier": "us-west",
            "Weight": 33,
            "TTL": 172800,
            "ResourceRecords": [
                {
                    "Value": "hello.us-west.example.com."
                }
            ]
        },
```

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
