### PR TITLE
[plugins/aws][fix] Exception handling for individual resource kinds and rename of progress prefix

### DIFF
--- a/plugins/aws/resoto_plugin_aws/__init__.py
+++ b/plugins/aws/resoto_plugin_aws/__init__.py
@@ -365,7 +365,7 @@ def set_account_name(account: AwsAccount) -> None:
         pass
 
 
-def set_account_names(accounts: List[AwsAccount]):
+def set_account_names(accounts: List[AwsAccount]) -> None:
     if len(accounts) == 0:
         return
     max_workers = len(accounts) if len(accounts) < Config.aws.account_pool_size else Config.aws.account_pool_size

--- a/plugins/aws/resoto_plugin_aws/__init__.py
+++ b/plugins/aws/resoto_plugin_aws/__init__.py
@@ -61,8 +61,9 @@ class AWSCollectorPlugin(BaseCollectorPlugin):
     def collect(self) -> None:
         log.debug("plugin: AWS collecting resources")
         assert self.core_feedback, "core_feedback is not set"
+        cloud = Cloud(id=self.cloud, name="AWS")
 
-        accounts = get_accounts(self.core_feedback.with_context("aws"))
+        accounts = get_accounts(self.core_feedback.with_context(cloud.id))
         if len(accounts) == 0:
             log.error("No accounts found")
             return
@@ -91,7 +92,8 @@ class AWSCollectorPlugin(BaseCollectorPlugin):
                     self.regions(profile=account.profile),
                     ArgumentParser.args,
                     Config.running_config,
-                    self.core_feedback.with_context("aws", account.id),
+                    self.core_feedback.with_context(cloud.id, account.dname),
+                    cloud,
                 )
                 for account in accounts
             ]
@@ -349,6 +351,28 @@ def current_account_id(profile: Optional[str] = None) -> str:
     return session.client("sts").get_caller_identity().get("Account")  # type: ignore
 
 
+def set_account_name(account: AwsAccount) -> None:
+    try:
+        account_aliases = (
+            aws_session(account.id, account.role, account.profile)
+            .client("iam")
+            .list_account_aliases()
+            .get("AccountAliases", [])
+        )
+        if len(account_aliases) > 0:
+            account.name = account_aliases[0]
+    except Exception:
+        pass
+
+
+def set_account_names(accounts: List[AwsAccount]):
+    if len(accounts) == 0:
+        return
+    max_workers = len(accounts) if len(accounts) < Config.aws.account_pool_size else Config.aws.account_pool_size
+    with futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        executor.map(set_account_name, accounts)
+
+
 def get_accounts(core_feedback: CoreFeedback) -> List[AwsAccount]:
     accounts = []
     profiles = [None]
@@ -419,6 +443,7 @@ def get_accounts(core_feedback: CoreFeedback) -> List[AwsAccount]:
         except botocore.exceptions.BotoCoreError as e:
             core_feedback.error(f"Unable to get accounts for profile {profile}: {e}", log)
 
+    set_account_names(accounts)
     return accounts
 
 
@@ -454,7 +479,12 @@ def all_regions(profile: Optional[str] = None) -> List[str]:
 
 @log_runtime
 def collect_account(
-    account: AwsAccount, regions: List[str], args: Namespace, running_config: RunningConfig, feedback: CoreFeedback
+    account: AwsAccount,
+    regions: List[str],
+    args: Namespace,
+    running_config: RunningConfig,
+    feedback: CoreFeedback,
+    cloud: Cloud,
 ) -> Optional[Graph]:
     collector_name = f"aws_{account.id}"
     resotolib.proc.set_thread_name(collector_name)
@@ -471,7 +501,7 @@ def collect_account(
 
     log.debug(f"Starting new collect process for account {account.dname}")
 
-    aac = AwsAccountCollector(Config.aws, Cloud(id="aws", name="AWS"), account, regions, feedback)
+    aac = AwsAccountCollector(Config.aws, cloud, account, regions, feedback)
     try:
         aac.collect()
     except botocore.exceptions.ClientError as e:

--- a/plugins/aws/resoto_plugin_aws/aws_client.py
+++ b/plugins/aws/resoto_plugin_aws/aws_client.py
@@ -188,22 +188,22 @@ class AwsClient:
         elif code.lower().startswith("accessdenied"):
             log_error(
                 f"Access denied to call service {aws_service} with action {action} code {code} "
-                f"in account {self.account_id} region {self.region}",
+                f"in account {self.account_id} region {self.region}.",
                 as_warning=True,
             )
         elif code == "UnauthorizedOperation":
             log_error(
                 f"Call to {aws_service} action {action} in account {self.account_id} region {self.region}"
-                " is not authorized! Give up."
+                " is not authorized! Giving up."
             )
             raise e  # not allowed to collect in account/region
         elif code in RetryableErrors:
-            log_error(f"Call to {aws_service} action {action} has been retried too many times. Give up.")
+            log_error(f"Call to {aws_service} action {action} has been retried too many times. Giving up.")
             raise e  # already have been retried, give up here
         else:
             log_error(
                 f"An AWS API error {code} occurred during resource collection of {aws_service} action {action} in "  # noqa: E501
-                f"account {self.account_id} region {self.region} - skipping resources"
+                f"account {self.account_id} region {self.region} - skipping resources."
             )
 
     @cached_property

--- a/plugins/aws/resoto_plugin_aws/collector.py
+++ b/plugins/aws/resoto_plugin_aws/collector.py
@@ -179,6 +179,7 @@ class AwsAccountCollector:
                     )
                     self.core_feedback.error(msg, log)
                     return None
+
         try:
             regional_thread_name = f"aws_{self.account.id}_{region.id}"
             set_thread_name(regional_thread_name)

--- a/plugins/aws/test/collector_test.py
+++ b/plugins/aws/test/collector_test.py
@@ -65,7 +65,7 @@ def test_collect_region(
 
     with caplog.at_level(logging.ERROR):
         account_collector.collect_region(AwsRegion(id="us-east-1", name="us-east-1"), builder)
-    assert "Not authorized to collect resources in account 123 region us-east-1" in caplog.text
+    assert "Not authorized to collect aws_redshift_cluster resources in account 123 region us-east-1 - skipping resource" in caplog.text
 
 
 def test_all_called_apis() -> None:

--- a/plugins/aws/test/collector_test.py
+++ b/plugins/aws/test/collector_test.py
@@ -65,7 +65,10 @@ def test_collect_region(
 
     with caplog.at_level(logging.ERROR):
         account_collector.collect_region(AwsRegion(id="us-east-1", name="us-east-1"), builder)
-    assert "Not authorized to collect aws_redshift_cluster resources in account 123 region us-east-1 - skipping resource" in caplog.text
+    assert (
+        "Not authorized to collect aws_redshift_cluster resources"
+        " in account 123 region us-east-1 - skipping resource"
+    ) in caplog.text
 
 
 def test_all_called_apis() -> None:


### PR DESCRIPTION
# Description

Update of the AWS collector:
- Handle exceptions on a kind level instead of aborting the entire region when an individual kind is not allowed to be collected.
- Update progress to use account name & id instead of just the id

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
