### PR TITLE
[docker][fix] Optimize swap space

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -30,12 +30,18 @@ jobs:
       - name: Create swap for ARM builds
         if: github.ref_type == 'tag' # on tagging of releases and prereleases
         run: |
-          echo "Creating swap file for ARM builds"
-          time sudo dd if=/dev/zero of=/swapfile1 bs=10M count=2000
-          sudo chmod 600 /swapfile1
-          sudo mkswap /swapfile1
-          sudo swapon /swapfile1
-          free -h
+          echo "Creating 20GB swap files for ARM builds"
+          sudo swapoff -a
+          sudo rm -f /mnt/swapfile
+          time sudo dd if=/dev/zero of=/mnt/swapfile bs=10M count=1000
+          sudo chmod 600 /mnt/swapfile
+          sudo mkswap /mnt/swapfile
+          sudo swapon /mnt/swapfile
+          time sudo dd if=/dev/zero of=/swapfile bs=10M count=1000
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          free -m
 
       - name: Set build platforms
         id: platform


### PR DESCRIPTION
# Description

Optimize swap space.
The Cryptography ARM64 build requires more than the 10G swap we had previously. With 20G it went through but then failed with an out of disk space error later on. This splits the swap space across two different mount points.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
