### PR TITLE
[resotocore][feat] Improve TSDB proxy behaviour

### DIFF
--- a/resotocore/resotocore/static/api-doc.yaml
+++ b/resotocore/resotocore/static/api-doc.yaml
@@ -30,6 +30,8 @@ tags:
     description: Endpoints to get information about the system.
   - name: debug
     description: Endpoints to debug the system.
+  - name: tsdb
+    description: Endpoints to access the time series database.
 
 paths:
 
@@ -2085,6 +2087,198 @@ paths:
                 example: pong
 
   # endregion
+
+  # region tsdb
+
+  /tsdb/{path}:
+    get:
+      summary: Proxy request to a configured tsdb server.
+      parameters:
+        - name: path
+          description: "Note: swagger does not allow to define a nested path with slashes."
+          in: path
+          required: true
+          schema:
+            type: string
+            example: "api/v1/metadata"
+      tags:
+        - tsdb
+      responses:
+        "404":
+          description: "If the response is coming from Resoto (no ResotoVia header), this means that tsdb is not configured, so a request can not be made."
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "404: No tsdb defined. No tsdb defined. Adjust resoto.core configuration."
+        "502":
+          description: "If the response is coming from Resoto (no ResotoVia header), this means that the configured tsdb server can not be reached."
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "502. tsdb server is not reachable"
+        default:
+            headers:
+              ViaResoto:
+                description: |
+                  This header indicates, that the response is created by the tsdb server and Resoto is only a proxy.
+                  Depending on this header: you have to interpret the response differently.
+                schema:
+                  type: string
+                  example: "1.1 node1"
+            description: "The response from the tsdb."
+    put:
+      summary: Proxy request to a configured tsdb server.
+      parameters:
+        - name: path
+          description: "Note: swagger does not allow to define a nested path with slashes."
+          in: path
+          required: true
+          schema:
+            type: string
+            example: "api/v1/metadata"
+      tags:
+        - tsdb
+      responses:
+        "404":
+          description: "If the response is coming from Resoto (no ResotoVia header), this means that tsdb is not configured, so a request can not be made."
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "404: No tsdb defined. No tsdb defined. Adjust resoto.core configuration."
+        "502":
+          description: "If the response is coming from Resoto (no ResotoVia header), this means that the configured tsdb server can not be reached."
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "502. tsdb server is not reachable"
+        default:
+          headers:
+            ViaResoto:
+              description: |
+                This header indicates, that the response is created by the tsdb server and Resoto is only a proxy.
+                Depending on this header: you have to interpret the response differently.
+              schema:
+                type: string
+                example: "1.1 node1"
+          description: "The response from the tsdb."
+    post:
+      summary: Proxy request to a configured tsdb server.
+      parameters:
+        - name: path
+          description: "Note: swagger does not allow to define a nested path with slashes."
+          in: path
+          required: true
+          schema:
+            type: string
+            example: "api/v1/metadata"
+      tags:
+        - tsdb
+      responses:
+        "404":
+          description: "If the response is coming from Resoto (no ResotoVia header), this means that tsdb is not configured, so a request can not be made."
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "404: No tsdb defined. No tsdb defined. Adjust resoto.core configuration."
+        "502":
+          description: "If the response is coming from Resoto (no ResotoVia header), this means that the configured tsdb server can not be reached."
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "502. tsdb server is not reachable"
+        default:
+          headers:
+            ViaResoto:
+              description: |
+                This header indicates, that the response is created by the tsdb server and Resoto is only a proxy.
+                Depending on this header: you have to interpret the response differently.
+              schema:
+                type: string
+                example: "1.1 node1"
+          description: "The response from the tsdb."
+    delete:
+      summary: Proxy request to a configured tsdb server.
+      parameters:
+        - name: path
+          description: "Note: swagger does not allow to define a nested path with slashes."
+          in: path
+          required: true
+          schema:
+            type: string
+            example: "api/v1/metadata"
+      tags:
+        - tsdb
+      responses:
+        "404":
+          description: "If the response is coming from Resoto (no ResotoVia header), this means that tsdb is not configured, so a request can not be made."
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "404: No tsdb defined. No tsdb defined. Adjust resoto.core configuration."
+        "502":
+          description: "If the response is coming from Resoto (no ResotoVia header), this means that the configured tsdb server can not be reached."
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "502. tsdb server is not reachable"
+        default:
+          headers:
+            ViaResoto:
+              description: |
+                This header indicates, that the response is created by the tsdb server and Resoto is only a proxy.
+                Depending on this header: you have to interpret the response differently.
+              schema:
+                type: string
+                example: "1.1 node1"
+          description: "The response from the tsdb."
+    patch:
+      summary: Proxy request to a configured tsdb server.
+      parameters:
+        - name: path
+          description: "Note: swagger does not allow to define a nested path with slashes."
+          in: path
+          required: true
+          schema:
+            type: string
+            example: "api/v1/metadata"
+      tags:
+        - tsdb
+      responses:
+        "404":
+          description: "If the response is coming from Resoto (no ResotoVia header), this means that tsdb is not configured, so a request can not be made."
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "404: No tsdb defined. No tsdb defined. Adjust resoto.core configuration."
+        "502":
+          description: "If the response is coming from Resoto (no ResotoVia header), this means that the configured tsdb server can not be reached."
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "502. tsdb server is not reachable"
+        default:
+          headers:
+            ViaResoto:
+              description: |
+                This header indicates, that the response is created by the tsdb server and Resoto is only a proxy.
+                Depending on this header: you have to interpret the response differently.
+              schema:
+                type: string
+                example: "1.1 node1"
+          description: "The response from the tsdb."
+
+  # endregion
+
 components:
   schemas:
     AnalyticsEvent:

--- a/resotocore/resotocore/web/api.py
+++ b/resotocore/resotocore/web/api.py
@@ -171,9 +171,6 @@ class Api:
             if self.config.api.ui_path and Path(self.config.api.ui_path).exists()
             else [web.get(f"{prefix}/ui/index.html", self.no_ui)]
         )
-        tsdb_route = (
-            [web.route(METH_ANY, prefix + "/tsdb/{tail:.+}", tsdb(self))] if self.config.api.tsdb_proxy_url else []
-        )
         self.app.add_routes(
             [
                 # Model operations
@@ -255,8 +252,9 @@ class Api:
                 web.get(prefix + "/ui", self.forward("/ui/index.html")),
                 web.get(prefix + "/ui/", self.forward("/ui/index.html")),
                 web.get(prefix + "/debug/ui/{commit}/{path:.+}", self.serve_debug_ui),
+                # tsdb operations
+                web.route(METH_ANY, prefix + "/tsdb/{tail:.+}", tsdb(self)),
                 *ui_route,
-                *tsdb_route,
             ]
         )
         SwaggerFile(

--- a/resotocore/resotocore/web/tsdb.py
+++ b/resotocore/resotocore/web/tsdb.py
@@ -1,11 +1,24 @@
 import logging
+from functools import lru_cache
+from socket import gethostname
 from typing import Callable, Awaitable
 
+from aiohttp import ClientConnectionError
 from aiohttp.web import HTTPNotFound, Request, StreamResponse
+from aiohttp.web_exceptions import HTTPBadGateway
+
 from resotocore.web import api  # pylint: disable=unused-import # prevent circular import
 from resotocore.web.directives import enable_compression
 
 log = logging.getLogger(__name__)
+
+
+@lru_cache(1)
+def hostname() -> str:
+    try:
+        return gethostname()
+    except Exception:
+        return "localhost"
 
 
 # Proxy request to configured tsdb endpoint
@@ -17,28 +30,35 @@ def tsdb(api_handler: "api.Api") -> Callable[[Request], Awaitable[StreamResponse
             in_headers.popall("Content-Length", "none")
             in_headers.popall("Content-Encoding", "none")
             url = f'{api_handler.config.api.tsdb_proxy_url}/{request.match_info["tail"]}'
-            async with api_handler.session.request(
-                request.method,
-                url,
-                params=request.query,
-                headers=in_headers,
-                compress="deflate",
-                data=request.content,
-                ssl=api_handler.cert_handler.client_context,
-            ) as cr:
-                log.info(f"Proxy tsdb request to: {url} resulted in status={cr.status}")
-                headers = cr.headers.copy()
-                # since we stream the content (chunked), we are not allowed to set the content length.
-                headers.popall("Content-Length", "none")
-                headers.popall("Content-Encoding", "none")
-                response = StreamResponse(status=cr.status, reason=cr.reason, headers=headers)
-                enable_compression(request, response)
-                await response.prepare(request)
-                async for data in cr.content.iter_chunked(1024 * 1024):
-                    await response.write(data)
-                await response.write_eof()
-                return response
+            try:
+                async with api_handler.session.request(
+                    request.method,
+                    url,
+                    params=request.query,
+                    headers=in_headers,
+                    compress="deflate",
+                    data=request.content,
+                    ssl=api_handler.cert_handler.client_context,
+                ) as cr:
+                    log.info(f"Proxy tsdb request to: {url} resulted in status={cr.status}")
+                    headers = cr.headers.copy()
+                    # since we stream the content (chunked), we are not allowed to set the content length.
+                    headers.popall("Content-Length", "none")
+                    headers.popall("Content-Encoding", "none")
+                    via = f"{request.version.major}.{request.version.minor} {hostname()}"
+                    headers["Via"] = via
+                    headers["ViaResoto"] = via  # the via header might be set by other instances ase well
+                    response = StreamResponse(status=cr.status, reason=cr.reason, headers=headers)
+                    enable_compression(request, response)
+                    await response.prepare(request)
+                    async for data in cr.content.iter_chunked(1024 * 1024):
+                        await response.write(data)
+                    await response.write_eof()
+                    return response
+            except ClientConnectionError as e:
+                log.warning(f"Proxy tsdb request to: {url} resulted in error={e}")
+                raise HTTPBadGateway(text="tsdb server is not reachable") from e
         else:
-            raise HTTPNotFound(text="No tsdb defined. Configure with --tsdb_proxy_url start parameter.")
+            raise HTTPNotFound(text="No tsdb defined. Adjust resoto.core configuration.")
 
     return proxy_request


### PR DESCRIPTION
# Description

- ViaResoto Header defines if the response is created by Resoto or downstream
- 404 if tsdb is not configured
- 502 if tsdb is not reachable

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
