### PR TITLE
[resotoworker][feat] Expose list of loaded collectors

### DIFF
--- a/resotoworker/requirements.txt
+++ b/resotoworker/requirements.txt
@@ -1,3 +1,4 @@
 resotolib==3.0.0a0
 tenacity==8.1.0
 CherryPy==18.8.0
+setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/resotoworker/requirements.txt
+++ b/resotoworker/requirements.txt
@@ -1,2 +1,3 @@
 resotolib==3.0.0a0
 tenacity==8.1.0
+CherryPy==18.8.0

--- a/resotoworker/resotoworker/__main__.py
+++ b/resotoworker/resotoworker/__main__.py
@@ -2,7 +2,7 @@ import multiprocessing
 import os
 import sys
 import threading
-import cherrypy
+import cherrypy  # type: ignore
 import time
 from functools import partial
 from queue import Queue
@@ -297,16 +297,21 @@ def add_args(arg_parser: ArgumentParser) -> None:
 
 
 class WorkerWebApp(WebApp):
-    def __init__(self, *args, plugin_loader: PluginLoader, **kwargs) -> None:
+    def __init__(self, *args, plugin_loader: PluginLoader, **kwargs) -> None:  # type: ignore
         super().__init__(*args, **kwargs)
         self.plugin_loader = plugin_loader
 
-    @cherrypy.expose
-    @cherrypy.tools.json_out()
-    @cherrypy.tools.allow(methods=["GET"])
-    def info(self):
-        collectors: List[str] = [plugin.cloud for plugin in self.plugin_loader.plugins(PluginType.COLLECTOR)]
-        return {"collectors": collectors}
+    @cherrypy.expose  # type: ignore
+    @cherrypy.tools.json_out()  # type: ignore
+    @cherrypy.tools.allow(methods=["GET"])  # type: ignore
+    def info(self) -> Dict[str, Any]:
+        active_collectors: List[str] = [
+            plugin.cloud for plugin in self.plugin_loader.plugins(PluginType.COLLECTOR)  # type: ignore
+        ]
+        all_collectors: List[str] = [
+            plugin.cloud for plugin in self.plugin_loader.all_plugins(PluginType.COLLECTOR)  # type: ignore
+        ]
+        return {"active_collectors": active_collectors, "all_collectors": all_collectors}
 
 
 if __name__ == "__main__":

--- a/resotoworker/resotoworker/__main__.py
+++ b/resotoworker/resotoworker/__main__.py
@@ -304,7 +304,7 @@ class WorkerWebApp(WebApp):
     @cherrypy.expose  # type: ignore
     @cherrypy.tools.json_out()  # type: ignore
     @cherrypy.tools.allow(methods=["GET"])  # type: ignore
-    def info(self) -> Dict[str, Any]:
+    def info(self) -> Dict[str, List[str]]:
         active_collectors: List[str] = [
             plugin.cloud for plugin in self.plugin_loader.plugins(PluginType.COLLECTOR)  # type: ignore
         ]

--- a/resotoworker/resotoworker/config.py
+++ b/resotoworker/resotoworker/config.py
@@ -14,7 +14,7 @@ class ResotoWorkerConfig:
     kind: ClassVar[str] = "resotoworker"
     collector: List[str] = field(
         factory=lambda: ["example"],
-        metadata={"description": "List of collectors to run"},
+        metadata={"description": "List of collectors to run", "restart_required": True},
     )
     graph: str = field(
         default="resoto",

--- a/resotoworker/resotoworker/pluginloader.py
+++ b/resotoworker/resotoworker/pluginloader.py
@@ -81,9 +81,13 @@ class PluginLoader:
 
         return self._plugins.get(plugin_type, [])  # type: ignore
 
-    def all_plugins(self) -> List[Union[Type[BasePlugin], Type[BaseActionPlugin], Type[BasePostCollectPlugin]]]:
+    def all_plugins(
+        self, plugin_type: Optional[PluginType] = None
+    ) -> List[Union[Type[BasePlugin], Type[BaseActionPlugin], Type[BasePostCollectPlugin]]]:
         if not self._initialized:
             self.find_plugins()
+        if plugin_type is not None:
+            return self._plugins.get(plugin_type, [])  # type: ignore
         return [plugin for plugins in self._plugins.values() for plugin in plugins]
 
     def add_plugin_args(self, arg_parser: ArgumentParser) -> None:


### PR DESCRIPTION
# Description

- Expose list of loaded collectors on a `/info` endpoint
- Fix config reload bug

Example output:
```
$ curl -k https://localhost:9956/info | jq .
{
  "active_collectors": [
    "aws"
  ],
  "all_collectors": [
    "aws",
    "gcp",
    "slack",
    "onelogin",
    "k8s",
    "onprem",
    "github",
    "dockerhub",
    "random",
    "example",
    "vsphere",
    "digitalocean"
  ]
}
```

This is so that the list of collectors no longer has to be hard coded in https://github.com/someengineering/resoto.com/blob/main/tools/export_model_images.py#L13

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
