### PR TITLE
[resotocore][feat] Maintain history of nodes and make it available via CLI/API

### DIFF
--- a/resotocore/.pylintrc
+++ b/resotocore/.pylintrc
@@ -74,7 +74,8 @@ disable=
     duplicate-code, # pylint also checks duplicated import statements - does not make any sense
     too-many-boolean-expressions,
     no-member,
-    unsupported-binary-operation
+    unsupported-binary-operation,
+    too-many-branches
 
 
 [REPORTS]

--- a/resotocore/resotocore/analytics/__init__.py
+++ b/resotocore/resotocore/analytics/__init__.py
@@ -31,6 +31,7 @@ class CoreEvent:
     GraphDBWiped = "graphdb.wiped"
     CLICommand = "cli.command"
     Query = "graphdb.query"
+    HistoryQuery = "graphdb.query.history"
     ModelInfo = "model.info"
     SubscriberInfo = "subscriber.info"
     WorkerQueueInfo = "worker-queue.info"

--- a/resotocore/resotocore/cli/command.py
+++ b/resotocore/resotocore/cli/command.py
@@ -393,19 +393,19 @@ class HistoryPart(SearchCLIPart):
 
     ## Examples
     ```shell
-    # Show all nodes changed on 1.1.2020 between 03:00 and 06:00 (UTC)
+    # Show all nodes changed on 1.1.2022 between 03:00 and 06:00 (UTC)
     > history --after 2022-01-01T03:00:00Z --before 2022-01-02T06:00:00Z
-    kind=kubernetes_config_map, id=73616434 name=leader, changed_at=2022-01-01T03:00:59Z, change=node_updated, cloud=k8s
-    kind=aws_vpc, id=vpc-1, name=resoto-eks, changed_at=2022-01-01T04:40:59Z, change=node_deleted, cloud=aws
+    change=node_updated, changed_at=2022-01-01T03:00:59Z, kind=kubernetes_config_map, id=73616434 name=leader, cloud=k8s
+    change=node_deleted, changed_at=2022-01-01T04:40:59Z, kind=aws_vpc, id=vpc-1, name=resoto-eks, cloud=aws
 
-    # Show all nodes created on 1.1.2020 between 03:00 and 06:00 (UTC)
+    # Show all nodes created on 1.1.2022 between 03:00 and 06:00 (UTC)
     > history --change node_created --after 2022-01-01T03:00:00Z --before 2022-01-02T06:00:00Z
-    kind=aws_iam_role, id=AROA, name=some-role, changed_at=2022-01-01T05:40:59Z, change=node_created, cloud=aws
+    change=node_created, changed_at=2022-01-01T05:40:59Z, kind=aws_iam_role, id=AROA, name=some-role, cloud=aws
 
     # Show all changes to kubernetes resources in the kube-system namespace
     > history is(kubernetes_resource) and namespace=kube-system
-    kind=kubernetes_role, name=eks, namespace=kube-system, change=node_created, changed_at=2022-11-18T12:00:49Z
-    kind=kubernetes_config_map, name=cert, namespace=kube-system, change=node_updated, changed_at=2022-11-18T12:00:50Z
+    change=node_created, changed_at=2022-11-18T12:00:49Z, kind=kubernetes_role, name=eks, namespace=kube-system
+    change=node_updated, changed_at=2022-11-18T12:00:50Z, kind=kubernetes_config_map, name=cert, namespace=kube-system
     ```
     """
 

--- a/resotocore/resotocore/core_config.py
+++ b/resotocore/resotocore/core_config.py
@@ -316,6 +316,10 @@ class GraphUpdateConfig(ConfigObject):
         default=4 * 3600,
         metadata={"description": "If a graph update takes longer than this duration, the update is aborted."},
     )
+    keep_history: bool = field(
+        default=True,
+        metadata={"description": "If true, changes of the graph are stored and are available via history."},
+    )
 
     def merge_max_wait_time(self) -> timedelta:
         return timedelta(seconds=self.merge_max_wait_time_seconds)

--- a/resotocore/resotocore/db/arango_query.py
+++ b/resotocore/resotocore/db/arango_query.py
@@ -77,11 +77,14 @@ ancestor_merges = {
 array_marker_in_path_regexp = re.compile(r"\[]|\[[*]](?=[.])")
 
 
-def to_query(db: Any, query_model: QueryModel, with_edges: bool = False) -> Tuple[str, Json]:
+def to_query(
+    db: Any, query_model: QueryModel, with_edges: bool = False, from_collection: Optional[str] = None
+) -> Tuple[str, Json]:
     count: Dict[str, int] = defaultdict(lambda: 0)
     query = query_model.query
     bind_vars: Json = {}
-    cursor, query_str = query_string(db, query, query_model, db.vertex_name, with_edges, bind_vars, count)
+    start = from_collection or db.vertex_name
+    cursor, query_str = query_string(db, query, query_model, start, with_edges, bind_vars, count)
     return f"""{query_str} FOR result in {cursor} RETURN UNSET(result, {unset_props})""", bind_vars
 
 

--- a/resotocore/resotocore/db/db_access.py
+++ b/resotocore/resotocore/db/db_access.py
@@ -112,7 +112,7 @@ class DbAccess(ABC):
         else:
             if not no_check and not self.database.has_graph(name):
                 raise NoSuchGraph(name)
-            graph_db = ArangoGraphDB(self.db, name, self.adjust_node)
+            graph_db = ArangoGraphDB(self.db, name, self.adjust_node, self.config.graph_update)
             event_db = EventGraphDB(graph_db, self.event_sender)
             self.graph_dbs[name] = event_db
             return event_db

--- a/resotocore/resotocore/db/model.py
+++ b/resotocore/resotocore/db/model.py
@@ -56,5 +56,12 @@ class GraphUpdate(ABC):
             f"{self.edges_updated},{self.edges_deleted}]]"
         )
 
+    def __str__(self) -> str:
+        return (
+            f"GraphUpdate(nodes_created={self.nodes_created}, nodes_updated={self.nodes_updated}, "
+            f"nodes_deleted={self.nodes_deleted}, edges_created={self.edges_created}, "
+            f"edges_updated={self.edges_updated}, edges_deleted={self.edges_deleted})"
+        )
+
     def __eq__(self, other: Any) -> bool:
         return self.__dict__ == other.__dict__ if isinstance(other, GraphUpdate) else False

--- a/resotocore/resotocore/model/db_updater.py
+++ b/resotocore/resotocore/model/db_updater.py
@@ -168,7 +168,7 @@ class DbUpdaterProcess(Process):
             log.info(f"Import process started: {self.pid}")
             result = asyncio.run(self.setup_and_merge())
             self.write_queue.put(Result(result))
-            log.info(f"Update process done: {self.pid} Exit.")
+            log.info(f"Update process done: {self.pid}. {result} Exit.")
             shutdown_process(0)
         except Exception as ex:
             # not all exceptions can be pickled. Use string representation.

--- a/resotocore/resotocore/query/model.py
+++ b/resotocore/resotocore/query/model.py
@@ -192,9 +192,6 @@ class Term(abc.ABC):
     def __and__(self, other: Term) -> Term:
         return self.and_term(other)
 
-    def __eq__(self, other: Any) -> bool:
-        return self.__dict__ == other.__dict__ if isinstance(other, Term) else False
-
     def not_term(self) -> NotTerm:
         return NotTerm(self)
 
@@ -312,6 +309,7 @@ class Term(abc.ABC):
             raise AttributeError(f"Can not parse json into query: {js}")
 
 
+@define(order=True, hash=True, frozen=True)
 class AllTerm(Term):
     _instance = None
 
@@ -975,6 +973,9 @@ class Query:
         Returns a list of all predicates in this query.
         """
         return [pred for part in self.parts for pred in part.predicates]
+
+    def find_terms(self, fn: Callable[[Term], bool]) -> List[Term]:
+        return [t for p in self.parts for t in p.term.find_terms(fn)]
 
     def analytics(self) -> Tuple[Dict[str, int], Dict[str, List[str]]]:
         counters: Dict[str, int] = defaultdict(lambda: 0)

--- a/resotocore/resotocore/static/api-doc.yaml
+++ b/resotocore/resotocore/static/api-doc.yaml
@@ -1200,6 +1200,220 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/EstimatedSearchCost"
+  /graph/{graph_id}/search/history/list:
+    post:
+      summary: "Search all history events and return them."
+      description: |
+        Search all history events and return them.
+        A section can be defined (defaults to `/` == root) to interpret relative property paths.
+        Example: is(volume) and (reported.age>23d or desired.clean==true or metadata.version==2)
+      tags:
+        - graph_search
+      parameters:
+        - name: graph_id
+          in: path
+          example: resoto
+          description: "The identifier of the graph"
+          required: true
+          schema:
+            type: string
+        - name: section
+          in: query
+          description: "The name of the section used for all property paths. If not defined root is assumed."
+          required: false
+          schema:
+            type: string
+            enum:
+              - reported
+              - desired
+              - metadata
+        - name: count
+          in: query
+          description: "Optional parameter to get a Ck-Element-Count header which returns the number of returned json elements"
+          required: false
+          schema:
+            type: boolean
+            default: true
+        - name: before
+          in: query
+          description: "Optional parameter to get all history events before the given timestamp"
+          required: false
+          schema:
+            type: string
+            format: date-time
+        - name: after
+          in: query
+          description: "Optional parameter to get all history events after the given timestamp"
+          required: false
+          schema:
+              type: string
+              format: date-time
+        - name: change
+          in: query
+          description: "Optional parameter to get all history events with the given change type"
+          required: false
+          schema:
+              type: string
+              enum:
+              - node_created
+              - node_updated
+              - node_deleted
+      requestBody:
+        description: "The search to perform"
+        content:
+          text/plain:
+            schema:
+              type: string
+              example: is(volume) and reported.volume_size>100
+      responses:
+        "200":
+          description: "The result of this search in the defined format"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Node"
+            application/x-ndjson:
+              schema:
+                $ref: "#/components/schemas/Node"
+              example: |
+                {"type": "node", "id": "root", "revision": "123", "reported": {"kind": "graph_root", "id": "root", "tags": {}, "name": "root"}}
+                {"type": "node", "id": "cloud_id",  "revision": "12", "reported": {"kind": "cloud", "id": "onelogin", "tags": {}, "name": "onelogin", "ctime": "2021-12-14T08:49:52Z", "age": "6d7h"}}
+                {"type": "edge", "from": "root", "to": "cloud_id", "edge_type": "default"}
+            text/plain:
+              example: |
+                reported:
+                  kind: graph_root
+                  id: root
+                  tags: {}
+                  name: root
+                metadata:
+                  cleaned: false
+                  phantom: true
+                  protected: false
+            application/yaml:
+              example: |
+                id: root
+                type: node
+                revision: _daGy-Bu---
+                reported:
+                    kind: graph_root
+                    id: root
+                    tags: { }
+                    name: root
+                metadata:
+                    python_type: resotolib.baseresources.GraphRoot
+                    cleaned: false
+                    phantom: true
+                    protected: false
+                kinds:
+                    - graph_root
+                ---
+                id: 2RZlTX9yzeBwTNT_H1KZVA
+                type: node
+                revision: _daGy-Bi---
+                reported:
+                    kind: cloud
+                    id: onelogin
+                    tags: { }
+                    name: onelogin
+                    ctime: '2021-12-14T08:49:52Z'
+                    age: 6d7h
+                metadata:
+                    python_type: resotolib.baseresources.Cloud
+                    cleaned: false
+                    phantom: false
+                    protected: false
+                    descendant_summary:
+                        onelogin_account: 1
+                        onelogin_region: 1
+                        onelogin_user: 1034
+                    descendant_count: 1036
+                ancestors:
+                    cloud:
+                        reported:
+                            name: onelogin
+                            id: onelogin
+                kinds:
+                    - cloud
+                    - base_cloud
+                    - resource
+                ---
+                type: edge
+                from: root
+                to: 2RZlTX9yzeBwTNT_H1KZVA
+                edge_type: default
+
+  /graph/{graph_id}/search/history/aggregate:
+    post:
+      summary: "Search and aggregate history events and return the aggregation result."
+      description: |
+        Search and aggregate history events and return the aggregation result.
+        A section can be defined (defaults to `/` == root) to interpret relative property paths.
+        Example: is(volume) and (reported.age>23d or desired.clean==true or metadata.version==2)
+      tags:
+        - graph_search
+      parameters:
+        - name: graph_id
+          in: path
+          description: "The identifier of the graph"
+          example: resoto
+          required: true
+          schema:
+            type: string
+        - name: section
+          in: query
+          description: "The name of the section used for all property paths. If not defined root is assumed."
+          required: false
+          schema:
+            type: string
+            enum:
+              - reported
+              - desired
+              - metadata
+        - name: before
+          in: query
+          description: "Optional parameter to get all history events before the given timestamp"
+          required: false
+          schema:
+            type: string
+            format: date-time
+        - name: after
+          in: query
+          description: "Optional parameter to get all history events after the given timestamp"
+          required: false
+          schema:
+            type: string
+            format: date-time
+        - name: change
+          in: query
+          description: "Optional parameter to get all history events with the given change type"
+          required: false
+          schema:
+            type: string
+            enum:
+              - node_created
+              - node_updated
+              - node_deleted
+      requestBody:
+        description: "The aggregation search to perform"
+        content:
+          text/plain:
+            schema:
+              type: string
+              example: |
+                aggregate(reported.kind: sum(1) as nodes): is(node)
+      responses:
+        "200":
+          description: "The result of this search in the defined format"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Aggregated"
+            application/x-ndjson:
+              schema:
+                $ref: "#/components/schemas/Aggregated"
   # endregion
 
   # region events

--- a/resotocore/resotocore/util.py
+++ b/resotocore/resotocore/util.py
@@ -29,7 +29,7 @@ from typing import (
     Sequence,
 )
 
-from dateutil.parser import isoparse
+from dateutil.parser import isoparse, parse as parse_date
 from resotolib.asynchronous import periodic
 
 from resotolib.durations import parse_duration
@@ -87,6 +87,20 @@ def utc_str(dt: datetime = utc()) -> str:
 
 def from_utc(date_string: str) -> datetime:
     return isoparse(date_string)
+
+
+def parse_utc(date_string: str) -> datetime:
+    try:
+        dt = datetime.fromisoformat(date_string)
+    except Exception:
+        dt = parse_date(date_string)
+    if (
+        not dt.tzinfo
+        or dt.tzinfo.utcoffset(None) is None
+        or dt.tzinfo.utcoffset(None).total_seconds() != 0  # type: ignore
+    ):
+        dt = dt.astimezone(timezone.utc)
+    return dt
 
 
 def duration(d: str) -> timedelta:

--- a/resotocore/resotocore/util.py
+++ b/resotocore/resotocore/util.py
@@ -78,6 +78,10 @@ def utc() -> datetime:
 
 
 def utc_str(dt: datetime = utc()) -> str:
+    if dt.tzinfo is not None and dt.tzname() != "UTC":
+        offset = dt.tzinfo.utcoffset(dt)
+        if offset is not None and offset.total_seconds() != 0:
+            dt = (dt - offset).replace(tzinfo=timezone.utc)
     return dt.strftime(UTC_Date_Format)
 
 

--- a/resotocore/resotocore/web/api.py
+++ b/resotocore/resotocore/web/api.py
@@ -188,7 +188,8 @@ class Api:
                 web.post(prefix + "/graph/{graph_id}/search/list", self.query_list),
                 web.post(prefix + "/graph/{graph_id}/search/graph", self.query_graph_stream),
                 web.post(prefix + "/graph/{graph_id}/search/aggregate", self.query_aggregation),
-                web.post(prefix + "/graph/{graph_id}/search/history", self.query_history),
+                web.post(prefix + "/graph/{graph_id}/search/history/list", self.query_history),
+                web.post(prefix + "/graph/{graph_id}/search/history/aggregate", self.query_history),
                 # maintain the graph
                 web.patch(prefix + "/graph/{graph_id}/nodes", self.update_nodes),
                 web.post(prefix + "/graph/{graph_id}/merge", self.merge_graph),

--- a/resotocore/resotocore/web/api.py
+++ b/resotocore/resotocore/web/api.py
@@ -765,8 +765,8 @@ class Api:
         async with await graph_db.search_history(
             query=query_model,
             change=HistoryChange[change] if change else None,
-            before=parse_utc(after) if after else None,
-            after=parse_utc(before) if before else None,
+            before=parse_utc(before) if before else None,
+            after=parse_utc(after) if after else None,
         ) as gen:
             return await self.stream_response_from_gen(request, gen)
 

--- a/resotocore/resotocore/web/api.py
+++ b/resotocore/resotocore/web/api.py
@@ -73,7 +73,7 @@ from resotocore.task.model import Subscription
 from resotocore.task.subscribers import SubscriptionHandler
 from resotocore.task.task_handler import TaskHandlerService
 from resotocore.types import Json, JsonElement
-from resotocore.util import uuid_str, force_gen, rnd_str, if_set, duration, utc_str, from_utc
+from resotocore.util import uuid_str, force_gen, rnd_str, if_set, duration, utc_str, parse_utc
 from resotocore.web.certificate_handler import CertificateHandler
 from resotocore.web.content_renderer import result_binary_gen, single_result
 from resotocore.web.directives import (
@@ -759,14 +759,14 @@ class Api:
 
     async def query_history(self, request: Request) -> StreamResponse:
         graph_db, query_model = await self.graph_query_model_from_request(request)
-        start = request.query.get("start")
-        until = request.query.get("until")
+        before = request.query.get("before")
+        after = request.query.get("after")
         change = request.query.get("change")
         async with await graph_db.search_history(
             query=query_model,
             change=HistoryChange[change] if change else None,
-            start=from_utc(start) if start else None,
-            until=from_utc(until) if until else None,
+            before=parse_utc(after) if after else None,
+            after=parse_utc(before) if before else None,
         ) as gen:
             return await self.stream_response_from_gen(request, gen)
 

--- a/resotocore/tests/resotocore/cli/cli_test.py
+++ b/resotocore/tests/resotocore/cli/cli_test.py
@@ -240,7 +240,7 @@ async def test_create_query_parts(cli: CLI) -> None:
     assert commands[0].commands[0].name == "execute_search"
     assert (
         commands[0].executable_commands[0].arg
-        == f'(reported.some_int == 0 and reported.identifier =~ "9_") {sort} -default[1:]-> all {sort}'
+        == f"'(reported.some_int == 0 and reported.identifier =~ \"9_\") {sort} -default[1:]-> all {sort}'"
     )
     commands = await cli.evaluate_cli_command("search some_int==0 | descendants")
     assert "-default[1:]->" in commands[0].executable_commands[0].arg  # type: ignore
@@ -264,25 +264,25 @@ async def test_create_query_parts(cli: CLI) -> None:
     commands = await cli.evaluate_cli_command("search some_int==0 | aggregate foo, bla as bla: sum(bar)")
     assert (
         commands[0].executable_commands[0].arg
-        == f"aggregate(reported.foo, reported.bla as bla: sum(reported.bar)):reported.some_int == 0 {sort}"
+        == f"'aggregate(reported.foo, reported.bla as bla: sum(reported.bar)):reported.some_int == 0 {sort}'"
     )
 
     # multiple head/tail commands are combined correctly
     commands = await cli.evaluate_cli_command("search is(volume) | head -10 | tail -5 | head -3")
-    assert commands[0].executable_commands[0].arg == f'is("volume") {sort} limit 5, 3'
+    assert commands[0].executable_commands[0].arg == f"'is(\"volume\") {sort} limit 5, 3'"
     commands = await cli.evaluate_cli_command("search is(volume) sort name asc | head -10 | tail -5 | head -3")
-    assert commands[0].executable_commands[0].arg == 'is("volume") sort reported.name asc limit 5, 3'
+    assert commands[0].executable_commands[0].arg == "'is(\"volume\") sort reported.name asc limit 5, 3'"
     commands = await cli.evaluate_cli_command("search is(volume) | head -10 | tail -5 | head -3 | tail 10 | head 100")
-    assert commands[0].executable_commands[0].arg == f'is("volume") {sort} limit 5, 3'
+    assert commands[0].executable_commands[0].arg == f"'is(\"volume\") {sort} limit 5, 3'"
     commands = await cli.evaluate_cli_command("search is(volume) | tail -10")
     assert (
         commands[0].executable_commands[0].arg
-        == f'is("volume") sort reported.kind desc, reported.name desc, reported.id desc limit 10 reversed '
+        == f"'is(\"volume\") sort reported.kind desc, reported.name desc, reported.id desc limit 10 reversed '"
     )
     commands = await cli.evaluate_cli_command("search is(volume) sort name | tail -10 | head 5")
-    assert commands[0].executable_commands[0].arg == 'is("volume") sort reported.name desc limit 5, 5 reversed '
+    assert commands[0].executable_commands[0].arg == "'is(\"volume\") sort reported.name desc limit 5, 5 reversed '"
     commands = await cli.evaluate_cli_command("search is(volume) sort name | tail -10 | head 5 | head 3 | tail 2")
-    assert commands[0].executable_commands[0].arg == 'is("volume") sort reported.name desc limit 7, 2 reversed '
+    assert commands[0].executable_commands[0].arg == "'is(\"volume\") sort reported.name desc limit 7, 2 reversed '"
 
 
 @pytest.mark.asyncio

--- a/resotocore/tests/resotocore/core_config_test.py
+++ b/resotocore/tests/resotocore/core_config_test.py
@@ -164,7 +164,7 @@ def config_json() -> Json:
                     }
                 ],
             },
-            "graph_update": {"abort_after_seconds": 1234, "merge_max_wait_time_seconds": 4321},
+            "graph_update": {"abort_after_seconds": 1234, "merge_max_wait_time_seconds": 4321, "keep_history": True},
             "runtime": {
                 "usage_metrics": False,
                 "debug": True,

--- a/resotocore/tests/resotocore/db/graphdb_test.py
+++ b/resotocore/tests/resotocore/db/graphdb_test.py
@@ -13,6 +13,7 @@ from arango.typings import Json
 from networkx import MultiDiGraph
 
 from resotocore.analytics import AnalyticsEventSender, CoreEvent, InMemoryEventSender
+from resotocore.core_config import GraphUpdateConfig
 from resotocore.db.async_arangodb import AsyncArangoDB
 from resotocore.db.graphdb import ArangoGraphDB, GraphDB, EventGraphDB
 
@@ -249,7 +250,7 @@ def test_db(local_client: ArangoClient, system_db: StandardDatabase) -> Standard
 @pytest.fixture
 async def graph_db(test_db: StandardDatabase) -> ArangoGraphDB:
     async_db = AsyncArangoDB(test_db)
-    graph_db = ArangoGraphDB(async_db, "ns", NoAdjust())
+    graph_db = ArangoGraphDB(async_db, "ns", NoAdjust(), GraphUpdateConfig())
     await graph_db.create_update_schema()
     await async_db.truncate(graph_db.in_progress)
     return graph_db

--- a/resotocore/tests/resotocore/web/api_test.py
+++ b/resotocore/tests/resotocore/web/api_test.py
@@ -308,7 +308,7 @@ async def test_cli(core_client: ApiClient) -> None:
 
     # list all cli commands
     info = AccessJson(await core_client.cli_info())
-    assert len(info.commands) == 39
+    assert len(info.commands) == 40
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description

When a new graph snapshot is delivered, Resoto computes the list of changes based on the current state of the internal graph. The changes get applied to the snapshot.

This PR will store the changes as own entity in a separate data collection.
This data collection only maintains the list of changes of a defined time (14 days by default).

The changes can be accessed via the API:
- `/graph/{graph_id}/search/history/list` to search and return the history nodes
- `/graph/{graph_id}/search/history/aggregate` to search and aggregate the history nodes

The changes can be accessed via the CLI:
```shell
# Aggregate the number of changes by kind
> history | count /change
node_deleted: 32
node_updated: 208
node_created: 518
total matched: 758
total unmatched: 0

# Show all nodes changed on 1.1.2022 between 03:00 and 06:00 (UTC)
> history --after 2022-01-01T03:00:00Z --before 2022-01-02T06:00:00Z
change=node_updated, changed_at=2022-01-01T03:00:59Z, kind=kubernetes_config_map, id=73616434 name=leader,  cloud=k8s
change=node_deleted, changed_at=2022-01-01T04:40:59Z, kind=aws_vpc, id=vpc-1, name=resoto-eks, cloud=aws

# Show all nodes created on 1.1.2022 between 03:00 and 06:00 (UTC)
> history --change node_created --after 2022-01-01T03:00:00Z --before 2022-01-02T06:00:00Z
change=node_created, changed_at=2022-01-01T05:40:59Z, kind=aws_iam_role, id=AROA, name=some-role, cloud=aws

# Show all changes to kubernetes resources in the kube-system namespace
> history is(kubernetes_resource) and namespace=kube-system
change=node_created, changed_at=2022-11-18T12:00:49Z, kind=kubernetes_role, name=eks, namespace=kube-system
change=node_updated, changed_at=2022-11-18T12:00:50Z kind=kubernetes_config_map, name=cert, namespace=kube-system
```

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`
- [x] Write API-Doc for the new endpoints
- [ ] Document new or updated functionality (someengineering/resoto.com#XXXX)

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
