### PR TITLE
[plugins][feat] support deferred edges between kubernetes and AWS

### DIFF
--- a/plugins/aws_k8s/resoto_plugin_aws_k8s/__init__.py
+++ b/plugins/aws_k8s/resoto_plugin_aws_k8s/__init__.py
@@ -31,6 +31,37 @@ def link_k8s_cluster_to_eks_cluster(graph: Graph, resource: BaseResource) -> Non
         )
 
 
+def link_node_to_ec2_instance(graph: Graph, resource: BaseResource) -> None:
+    if resource.kind == "kubernetes_node":
+        if (pid := rgetattr(resource, "node_spec.provider_id", None)) and (pid.startswith("aws://")):
+            _, ec2_zone_and_instance_id = pid.split("aws://")
+            ec2_instance_id = ec2_zone_and_instance_id.split("/")[2]
+            graph.add_deferred_edge(
+                BySearchCriteria(f"is(aws_ec2_instance) and reported.id={ec2_instance_id}"),
+                ByNodeId(resource.chksum),
+            )
+
+
+def link_service_to_elb(graph: Graph, resource: BaseResource) -> None:
+    if resource.kind == "kubernetes_service":
+        if (rgetattr(resource, "service_spec.type", None) == "LoadBalancer") and (
+            ingresses := rgetattr(resource, "service_status.load_balancer.ingress", None)
+        ):
+            for ingress in ingresses:
+                if elb_hostname := rgetattr(ingress, "hostname", None):
+                    graph.add_deferred_edge(
+                        BySearchCriteria(f"is(aws_elb) and reported.id={elb_hostname}"), ByNodeId(resource.chksum)
+                    )
+
+
+def link_pv_to_ebs_volume(graph: Graph, resource: BaseResource) -> None:
+    if resource.kind == "kubernetes_persistent_volume":
+        if vol_id := rgetattr(resource, "persistent_volume_spec.aws_elastic_block_store.volume_id", None):
+            graph.add_deferred_edge(
+                BySearchCriteria(f"is(aws_ec2_volume) and reported.id={vol_id}"), ByNodeId(resource.chksum)
+            )
+
+
 class AWSK8sCollectorPlugin(BasePostCollectPlugin):
     name = "aws_k8s"
     activate_with: Set[str] = {"aws", "k8s"}
@@ -41,5 +72,8 @@ class AWSK8sCollectorPlugin(BasePostCollectPlugin):
             if isinstance(node, BaseResource):
                 link_k8s_node_to_aws_nodegroup(graph, node)
                 link_k8s_cluster_to_eks_cluster(graph, node)
+                link_pv_to_ebs_volume(graph, node)
+                link_service_to_elb(graph, node)
+                link_node_to_ec2_instance(graph, node)
             else:
                 log.warn(f"Node {node} is not a BaseResource")

--- a/plugins/aws_k8s/resoto_plugin_aws_k8s/__init__.py
+++ b/plugins/aws_k8s/resoto_plugin_aws_k8s/__init__.py
@@ -14,7 +14,7 @@ def rgetattr(obj: Any, attr: str, *args: Any) -> Any:
     return functools.reduce(_getattr, [obj] + attr.split("."))
 
 
-def link_k8s_node_to_aws_nodegroup(graph: Graph, resource: BaseResource) -> None:
+def link_k8s_node_to_aws_nodegroup_or_ec2_instance(graph: Graph, resource: BaseResource) -> None:
     if resource.kind == "kubernetes_node":
         if (labels := rgetattr(resource, "labels", {})) and (nodegroup := labels.get("eks.amazonaws.com/nodegroup")):
             graph.add_deferred_edge(
@@ -66,10 +66,9 @@ class AWSK8sCollectorPlugin(BasePostCollectPlugin):
         log.info("plugin: collecting AWS to k8s edges")
         for node in graph.nodes:
             if isinstance(node, BaseResource):
-                link_k8s_node_to_aws_nodegroup(graph, node)
+                link_k8s_node_to_aws_nodegroup_or_ec2_instance(graph, node)
                 link_k8s_cluster_to_eks_cluster(graph, node)
                 link_pv_to_ebs_volume(graph, node)
                 link_service_to_elb(graph, node)
-                link_node_to_ec2_instance(graph, node)
             else:
                 log.warn(f"Node {node} is not a BaseResource")

--- a/plugins/aws_k8s/test/test_collector.py
+++ b/plugins/aws_k8s/test/test_collector.py
@@ -5,29 +5,6 @@ from typing import ClassVar
 from types import SimpleNamespace
 
 
-# class KubernetesService(BaseResource):
-#     kind: ClassVar[str] = "kubernetes_service"
-#     id = "123"
-#     service_spec = SimpleNamespace(type = "LoadBalancer")
-#     service_status = SimpleNamespace(load_balancer = SimpleNamespace(ingress = [{"hostname": "miau"}]))
-#     # labels = {"eks.amazonaws.com/nodegroup": "main"}
-
-#     def delete(self, graph: Graph) -> bool:
-#         return False
-
-
-# def test_post_collect() -> None:
-
-#     plugin = AWSK8sCollectorPlugin()
-
-#     node = KubernetesService(id="123")
-
-#     graph = Graph(root=node)
-#     plugin.post_collect(graph)
-
-#     assert len(graph.deferred_edges) == 1
-
-
 class KubernetesNode(BaseResource):
     kind: ClassVar[str] = "kubernetes_node"
     node_spec = SimpleNamespace(provider_id="aws:///eu-central-1a/123")

--- a/plugins/aws_k8s/test/test_collector.py
+++ b/plugins/aws_k8s/test/test_collector.py
@@ -27,6 +27,7 @@ from types import SimpleNamespace
 
 #     assert len(graph.deferred_edges) == 1
 
+
 class KubernetesNode(BaseResource):
     kind: ClassVar[str] = "kubernetes_node"
     node_spec = SimpleNamespace(provider_id="aws:///eu-central-1a/123")
@@ -37,7 +38,7 @@ class KubernetesNode(BaseResource):
 
 def test_post_collect() -> None:
 
-    plugin =  AWSK8sCollectorPlugin()
+    plugin = AWSK8sCollectorPlugin()
 
     node = KubernetesNode(id="123")
 

--- a/plugins/aws_k8s/test/test_collector.py
+++ b/plugins/aws_k8s/test/test_collector.py
@@ -2,11 +2,34 @@ from resoto_plugin_aws_k8s import AWSK8sCollectorPlugin
 from resotolib.baseresources import BaseResource
 from resotolib.graph import Graph
 from typing import ClassVar
+from types import SimpleNamespace
 
+
+# class KubernetesService(BaseResource):
+#     kind: ClassVar[str] = "kubernetes_service"
+#     id = "123"
+#     service_spec = SimpleNamespace(type = "LoadBalancer")
+#     service_status = SimpleNamespace(load_balancer = SimpleNamespace(ingress = [{"hostname": "miau"}]))
+#     # labels = {"eks.amazonaws.com/nodegroup": "main"}
+
+#     def delete(self, graph: Graph) -> bool:
+#         return False
+
+
+# def test_post_collect() -> None:
+
+#     plugin = AWSK8sCollectorPlugin()
+
+#     node = KubernetesService(id="123")
+
+#     graph = Graph(root=node)
+#     plugin.post_collect(graph)
+
+#     assert len(graph.deferred_edges) == 1
 
 class KubernetesNode(BaseResource):
     kind: ClassVar[str] = "kubernetes_node"
-    labels = {"eks.amazonaws.com/nodegroup": "test-nodegroup"}
+    node_spec = SimpleNamespace(provider_id="aws:///eu-central-1a/123")
 
     def delete(self, graph: Graph) -> bool:
         return False
@@ -14,7 +37,7 @@ class KubernetesNode(BaseResource):
 
 def test_post_collect() -> None:
 
-    plugin = AWSK8sCollectorPlugin()
+    plugin =  AWSK8sCollectorPlugin()
 
     node = KubernetesNode(id="123")
 

--- a/plugins/k8s/resoto_plugin_k8s/resources.py
+++ b/plugins/k8s/resoto_plugin_k8s/resources.py
@@ -1264,12 +1264,24 @@ class KubernetesPersistentVolumeStatus:
     reason: Optional[str] = field(default=None)
 
 
+@define(eq=False, slots=False)
+class KubernetesPersistentVolumeSpecAwsElasticBlockStore:
+    kind: ClassVar[str] = "kubernetes_persistent_volume_spec_aws_elastic_block_store"
+    mapping: ClassVar[Dict[str, Bender]] = {
+        "volume_id": S("volumeID"),
+        "fs_type": S("fsType"),
+    }
+    volume_id: Optional[str] = field(default=None)
+    fs_type: Optional[str] = field(default=None)
+
+
 @define
 class KubernetesPersistentVolumeSpec:
     kind: ClassVar[str] = "kubernetes_persistent_volume_spec"
     mapping: ClassVar[Dict[str, Bender]] = {
         "access_modes": S("accessModes", default=[]),
-        "aws_elastic_block_store": S("awsElasticBlockStore"),
+        "aws_elastic_block_store": S("awsElasticBlockStore")
+        >> Bend(KubernetesPersistentVolumeSpecAwsElasticBlockStore.mapping),
         "azure_disk": S("azureDisk"),
         "azure_file": S("azureFile"),
         "capacity": S("capacity"),
@@ -1300,7 +1312,7 @@ class KubernetesPersistentVolumeSpec:
         "vsphere_volume": S("vsphereVolume"),
     }
     access_modes: List[str] = field(factory=list)
-    aws_elastic_block_store: Optional[str] = field(default=None)
+    aws_elastic_block_store: Optional[KubernetesPersistentVolumeSpecAwsElasticBlockStore] = field(default=None)
     azure_disk: Optional[str] = field(default=None)
     azure_file: Optional[str] = field(default=None)
     capacity: Optional[str] = field(default=None)


### PR DESCRIPTION
# Description

Plugin now supports the following third party/deferred edges:

- `kubernetes_cluster <-> aws_eks_cluster`
- `kubernetes_persistent_volume <-> aws_ec2_volume`
- `kubernetes_node <-> aws_eks_nodegroup`,
- `kubernetes_node <-> aws_ec2_instance`,
- `kubernetes_service <-> aws_elb`

# To-Dos

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`
- [ ] Document new or updated functionality (someengineering/resoto.com#XXXX)

# Issues Fixed

<!-- If this PR will fix/resolve an open issue on the repository, please reference it below. -->
<!-- (Otherwise, feel free to delete this section.) -->

- part of #943 

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
