### PR TITLE
[aws][fix] Coerce to correct parameter type

### DIFF
--- a/resotocore/resotocore/cli/cli.py
+++ b/resotocore/resotocore/cli/cli.py
@@ -460,7 +460,7 @@ class CLI:
                 # only parse properties, if there are any declared
                 if alias.parameters:
                     props.update(key_values_parser.parse(alias_cmd.args or ""))
-                undefined = [k for k, v in props.items() if v is None]
+                undefined = [k for k, v in props.items() if k != "args" and v is None]
                 if undefined:
                     raise AttributeError(f"Alias {alias_cmd.cmd} missing attributes: {', '.join(undefined)}")
                 rendered = alias.render(props)


### PR DESCRIPTION
# Description

```shell
> search is(aws_ec2_instance)  | aws ec2 stop-instances --instance-ids {id}
```

`instance-ids` has to be of type list, even if it is called for a single instance.
Coerce to correct type based on the service model.


# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
