### PR TITLE
[plugins/aws][fix] Ignore NoSuchEntity in get-account-password-policy

### DIFF
--- a/plugins/aws/resoto_plugin_aws/collector.py
+++ b/plugins/aws/resoto_plugin_aws/collector.py
@@ -215,7 +215,7 @@ class AwsAccountCollector:
         self.account.global_endpoint_token_version = int(sm.get("GlobalEndpointTokenVersion", 0))
         self.account.server_certificates = int(sm.get("ServerCertificates", 0))
 
-        # client returns None when there is no Custom PasswordPolicy defined (only AWS Default). This is intended behaviour.
+        # client returns None when there is no Custom PasswordPolicy defined (only AWS Default).
         app = self.client.get("iam", "get-account-password-policy", "PasswordPolicy", expected_errors=["NoSuchEntity"])
         if app:
             self.account.minimum_password_length = int(app.get("MinimumPasswordLength", 0))


### PR DESCRIPTION
# Description

Ignore NoSuchEntity in get-account-password-policy


# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
