### PR TITLE
[resotolib][feat] Allow authorization header as cookie

### DIFF
--- a/resotolib/resotolib/asynchronous/web/auth.py
+++ b/resotolib/resotolib/asynchronous/web/auth.py
@@ -38,7 +38,7 @@ def check_jwt(psk: str, always_allowed_paths: Set[str]) -> Middleware:
 
     @middleware
     async def valid_jwt_handler(request: Request, handler: RequestHandler) -> StreamResponse:
-        auth_header = request.headers.get("authorization")
+        auth_header = request.headers.get("authorization") or request.cookies.get("resoto_authorization")
         if always_allowed(request):
             return await handler(request)
         elif auth_header:

--- a/resotolib/test/asynchronous/web/test_auth.py
+++ b/resotolib/test/asynchronous/web/test_auth.py
@@ -41,6 +41,14 @@ async def test_correct_psk(aiohttp_client: Any, app_with_auth: Application) -> N
 
 
 @mark.asyncio
+async def test_correct_psk_as_cookie(aiohttp_client: Any, app_with_auth: Application) -> None:
+    client: TestClient = await aiohttp_client(app_with_auth)
+    jwt = encode_jwt({"foo": "bla"}, "test")
+    resp = await client.get("/", cookies=CIMultiDict({"resoto_authorization": f"Bearer {jwt}"}))
+    assert resp.status == 200
+
+
+@mark.asyncio
 async def test_wrong_psk(aiohttp_client: Any, app_with_auth: Application) -> None:
     client: TestClient = await aiohttp_client(app_with_auth)
     jwt = encode_jwt({"foo": "bla"}, "wrong!")


### PR DESCRIPTION
# Description

Allow sending the jwt as cookie `resoto_authorization`.

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
