### PR TITLE
[resotolib][fix] Use pyOpenSSL for cherryPy

### DIFF
--- a/resotolib/requirements.txt
+++ b/resotolib/requirements.txt
@@ -7,6 +7,7 @@ requests==2.28.1
 prometheus-client==0.15.0
 PyJWT==2.6.0
 CherryPy==18.8.0
+pyOpenSSL==22.1.0 # used by CherryPy SSL adapter
 cryptography==38.0.4
 aiohttp[speedups]==3.8.3
 Pint==0.20.1

--- a/resotolib/resotolib/web/__init__.py
+++ b/resotolib/resotolib/web/__init__.py
@@ -50,7 +50,7 @@ class WebServer(threading.Thread):
         ssl_args = {}
         if self.ssl_cert and self.ssl_key:
             ssl_args = {
-                "server.ssl_module": "builtin",
+                "server.ssl_module": "pyOpenSSL",
                 "server.ssl_certificate": self.ssl_cert,
                 "server.ssl_private_key": self.ssl_key,
             }


### PR DESCRIPTION
# Description

Under some circumstances the builtin module is not able to handle a valid SSL certificate.


# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
