### PR TITLE
[resoto][fix] Allow worker and metrics to start webserver without TLS

### DIFF
--- a/resotolib/resotolib/proc.py
+++ b/resotolib/resotolib/proc.py
@@ -68,7 +68,11 @@ def close_fds(safety_margin: int = 1024) -> None:
     if sys.platform == "win32":
         return
 
-    num_open = max([f.fd for f in psutil.Process().open_files()])
+    open_fds = [f.fd for f in psutil.Process().open_files()]
+    if len(open_fds) == 0:
+        return
+
+    num_open = max(open_fds)
 
     try:
         sc_open_max = os.sysconf("SC_OPEN_MAX")

--- a/resotometrics/resotometrics/__main__.py
+++ b/resotometrics/resotometrics/__main__.py
@@ -104,7 +104,7 @@ def main() -> None:
         tls_data=tls_data,
     )
     web_server_args = {}
-    if tls_data:
+    if tls_data and not Config.resotometrics.no_tls:
         web_server_args = {
             "ssl_cert": tls_data.cert_path,
             "ssl_key": tls_data.key_path,

--- a/resotometrics/resotometrics/config.py
+++ b/resotometrics/resotometrics/config.py
@@ -50,6 +50,13 @@ class ResotoMetricsConfig:
             "description": ("Metrics config\n" "See https://resoto.com/docs/reference/cli/aggregate for syntax details")
         },
     )
+    no_tls: bool = field(
+        default=False,
+        metadata={
+            "description": "Disable TLS for the web server, even if Resoto Core uses TLS.",
+            "restart_required": True,
+        },
+    )
     web_host: str = field(
         default="::",
         metadata={

--- a/resotoworker/resotoworker/__main__.py
+++ b/resotoworker/resotoworker/__main__.py
@@ -119,7 +119,7 @@ def main() -> None:
     increase_limits()
 
     web_server_args = {}
-    if tls_data:
+    if tls_data and not Config.resotoworker.no_tls:
         web_server_args = {
             "ssl_cert": tls_data.cert_path,
             "ssl_key": tls_data.key_path,

--- a/resotoworker/resotoworker/config.py
+++ b/resotoworker/resotoworker/config.py
@@ -38,6 +38,13 @@ class ResotoWorkerConfig:
         default=True,
         metadata={"description": "Do not actually cleanup resources, just create log messages"},
     )
+    no_tls: bool = field(
+        default=False,
+        metadata={
+            "description": "Disable TLS for the web server, even if Resoto Core uses TLS.",
+            "restart_required": True,
+        },
+    )
     web_host: str = field(
         default="::",
         metadata={


### PR DESCRIPTION
# Description

Allow worker and metrics to start webserver without TLS
Also fixes an exception that can happen during config related reloads when there are no open files.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
