### PR TITLE
[aws][feat] Make the list of called mutator APIs available

### DIFF
--- a/plugins/aws/resoto_plugin_aws/collector.py
+++ b/plugins/aws/resoto_plugin_aws/collector.py
@@ -83,9 +83,16 @@ def called_collect_apis() -> List[AwsApiSpec]:
     """
     # list all calls here, that are not defined in any resource.
     additional_calls = [AwsApiSpec("pricing", "get-products")]
-    specs = [spec for r in all_resources for spec in r.called_apis()] + additional_calls
-    unique_specs = {f"{spec.service}::{spec.api_action}": spec for spec in specs}
-    return sorted(unique_specs.values(), key=lambda s: s.service + "::" + s.api_action)
+    specs = [spec for r in all_resources for spec in r.called_collect_apis()] + additional_calls
+    return sorted(specs, key=lambda s: s.service + "::" + s.api_action)
+
+
+def called_mutator_apis() -> List[AwsApiSpec]:
+    """
+    Return a list of all the APIs that are called to mutate resources.
+    """
+    specs = [spec for r in all_resources for spec in r.called_mutator_apis()]
+    return sorted(specs, key=lambda s: s.service + "::" + s.api_action)
 
 
 class AwsAccountCollector:

--- a/plugins/aws/resoto_plugin_aws/collector.py
+++ b/plugins/aws/resoto_plugin_aws/collector.py
@@ -91,7 +91,9 @@ def called_mutator_apis() -> List[AwsApiSpec]:
     """
     Return a list of all the APIs that are called to mutate resources.
     """
-    specs = [spec for r in all_resources for spec in r.called_mutator_apis()]
+    # explicitly list all calls here, that should be allowed to mutate resources.
+    additional_calls = [AwsApiSpec("ec2", "start-instances"), AwsApiSpec("ec2", "stop-instances")]
+    specs = [spec for r in all_resources for spec in r.called_mutator_apis()] + additional_calls
     return sorted(specs, key=lambda s: s.service + "::" + s.api_action)
 
 

--- a/plugins/aws/resoto_plugin_aws/resource/athena.py
+++ b/plugins/aws/resoto_plugin_aws/resource/athena.py
@@ -85,8 +85,16 @@ class AwsAthenaWorkGroup(AwsResource):
     }
 
     @classmethod
-    def called_apis(cls) -> List[AwsApiSpec]:
+    def called_collect_apis(cls) -> List[AwsApiSpec]:
         return [cls.api_spec, AwsApiSpec("athena", "get-work-group"), AwsApiSpec("athena", "list-tags-for-resource")]
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return [
+            AwsApiSpec("athena", "tag-resource"),
+            AwsApiSpec("athena", "untag-resource"),
+            AwsApiSpec("athena", "delete-work-group"),
+        ]
 
     @classmethod
     def collect(cls: Type[AwsResource], json: List[Json], builder: GraphBuilder) -> None:
@@ -135,7 +143,7 @@ class AwsAthenaWorkGroup(AwsResource):
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
         client.call(
             aws_service=self.api_spec.service,
-            action="tag_resource",
+            action="tag-resource",
             result_name=None,
             ResourceARN=self.arn,
             Tags=[{"Key": key, "Value": value}],
@@ -145,7 +153,7 @@ class AwsAthenaWorkGroup(AwsResource):
     def delete_resource_tag(self, client: AwsClient, key: str) -> bool:
         client.call(
             aws_service=self.api_spec.service,
-            action="untag_resource",
+            action="untag-resource",
             result_name=None,
             ResourceARN=self.arn,
             TagKeys=[key],
@@ -179,8 +187,16 @@ class AwsAthenaDataCatalog(AwsResource):
     datacatalog_parameters: Optional[Dict[str, str]] = None
 
     @classmethod
-    def called_apis(cls) -> List[AwsApiSpec]:
+    def called_collect_apis(cls) -> List[AwsApiSpec]:
         return [cls.api_spec, AwsApiSpec("athena", "get-data-catalog"), AwsApiSpec("athena", "list-tags-for-resource")]
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return [
+            AwsApiSpec("athena", "tag-resource"),
+            AwsApiSpec("athena", "untag-resource"),
+            AwsApiSpec("athena", "delete-data-catalog"),
+        ]
 
     @classmethod
     def collect(cls: Type[AwsResource], json: List[Json], builder: GraphBuilder) -> None:
@@ -218,7 +234,7 @@ class AwsAthenaDataCatalog(AwsResource):
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
         client.call(
             aws_service=self.api_spec.service,
-            action="tag_resource",
+            action="tag-resource",
             result_name=None,
             ResourceARN=self.arn,
             Tags=[{"Key": key, "Value": value}],
@@ -228,7 +244,7 @@ class AwsAthenaDataCatalog(AwsResource):
     def delete_resource_tag(self, client: AwsClient, key: str) -> bool:
         client.call(
             aws_service=self.api_spec.service,
-            action="untag_resource",
+            action="untag-resource",
             result_name=None,
             ResourceARN=self.arn,
             TagKeys=[key],

--- a/plugins/aws/resoto_plugin_aws/resource/autoscaling.py
+++ b/plugins/aws/resoto_plugin_aws/resource/autoscaling.py
@@ -282,7 +282,7 @@ class AwsAutoScalingGroup(AwsResource, BaseAutoScalingGroup):
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
         client.call(
             aws_service="autoscaling",
-            action="create_or_update_tags",
+            action="create-or-update-tags",
             result_name=None,
             Tags=[
                 {
@@ -299,7 +299,7 @@ class AwsAutoScalingGroup(AwsResource, BaseAutoScalingGroup):
     def delete_resource_tag(self, client: AwsClient, key: str) -> bool:
         client.call(
             aws_service="autoscaling",
-            action="delete_tags",
+            action="delete-tags",
             result_name=None,
             Tags=[
                 {
@@ -314,12 +314,20 @@ class AwsAutoScalingGroup(AwsResource, BaseAutoScalingGroup):
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
             aws_service=self.api_spec.service,
-            action="delete_auto_scaling_group",
+            action="delete-auto-scaling-group",
             result_name=None,
             AutoScalingGroupName=self.name,
             ForceDelete=True,
         )
         return True
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return [
+            AwsApiSpec("autoscaling", "create-or-update-tags"),
+            AwsApiSpec("autoscaling", "delete-tags"),
+            AwsApiSpec("autoscaling", "delete-auto-scaling-group"),
+        ]
 
 
 resources: List[Type[AwsResource]] = [AwsAutoScalingGroup]

--- a/plugins/aws/resoto_plugin_aws/resource/cloudformation.py
+++ b/plugins/aws/resoto_plugin_aws/resource/cloudformation.py
@@ -123,7 +123,7 @@ class AwsCloudFormationStack(AwsResource, BaseStack):
         try:
             client.call(
                 aws_service="cloudformation",
-                action="update_stack",
+                action="update-stack",
                 result_name=None,
                 StackName=self.name,
                 Capabilities=["CAPABILITY_NAMED_IAM"],
@@ -161,8 +161,12 @@ class AwsCloudFormationStack(AwsResource, BaseStack):
         return self._modify_tag(client, key, None, "delete")
 
     def delete_resource(self, client: AwsClient) -> bool:
-        client.call(aws_service=self.api_spec.service, action="delete_stack", result_name=None, StackName=self.name)
+        client.call(aws_service=self.api_spec.service, action="delete-stack", result_name=None, StackName=self.name)
         return True
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return [AwsApiSpec("cloudformation", "update-stack"), AwsApiSpec("cloudformation", "delete-stack")]
 
 
 @define(eq=False, slots=False)
@@ -218,7 +222,7 @@ class AwsCloudFormationStackSet(AwsResource):
         try:
             client.call(
                 aws_service="cloudformation",
-                action="update_stack_set",
+                action="update-stack-set",
                 result_name=None,
                 StackSetName=self.name,
                 Capabilities=["CAPABILITY_NAMED_IAM"],
@@ -245,11 +249,15 @@ class AwsCloudFormationStackSet(AwsResource):
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
             aws_service=self.api_spec.service,
-            action="delete_stack_set",
+            action="delete-stack-set",
             result_name=None,
             StackSetName=self.name,
         )
         return True
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return [AwsApiSpec("cloudformation", "update-stack-set"), AwsApiSpec("cloudformation", "delete-stack-set")]
 
 
 resources: List[Type[AwsResource]] = [AwsCloudFormationStack, AwsCloudFormationStackSet]

--- a/plugins/aws/resoto_plugin_aws/resource/cloudwatch.py
+++ b/plugins/aws/resoto_plugin_aws/resource/cloudwatch.py
@@ -21,7 +21,7 @@ class CloudwatchTaggable:
             if spec := self.api_spec:
                 client.call(
                     aws_service=spec.service,
-                    action="tag_resource",
+                    action="tag-resource",
                     result_name=None,
                     ResourceARN=self.arn,
                     Tags=[{"Key": key, "Value": value}],
@@ -35,7 +35,7 @@ class CloudwatchTaggable:
             if spec := self.api_spec:
                 client.call(
                     aws_service=spec.service,
-                    action="untag_resource",
+                    action="untag-resource",
                     result_name=None,
                     ResourceARN=self.arn,
                     TagKeys=[key],
@@ -43,6 +43,10 @@ class CloudwatchTaggable:
                 return True
             return False
         return False
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return [AwsApiSpec("cloudwatch", "tag-resource"), AwsApiSpec("cloudwatch", "untag-resource")]
 
 
 @define(eq=False, slots=False)
@@ -185,8 +189,12 @@ class AwsCloudwatchAlarm(CloudwatchTaggable, AwsResource):
             )
 
     def delete_resource(self, client: AwsClient) -> bool:
-        client.call(aws_service=self.api_spec.service, action="delete_alarms", result_name=None, AlarmNames=[self.name])
+        client.call(aws_service=self.api_spec.service, action="delete-alarms", result_name=None, AlarmNames=[self.name])
         return True
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return super().called_mutator_apis() + [AwsApiSpec("cloudwatch", "delete-alarms")]
 
 
 @define(hash=True, frozen=True)

--- a/plugins/aws/resoto_plugin_aws/resource/dynamodb.py
+++ b/plugins/aws/resoto_plugin_aws/resource/dynamodb.py
@@ -37,6 +37,10 @@ class DynamoDbTaggable:
             return True
         return False
 
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return [AwsApiSpec("dynamodb", "tag-resource"), AwsApiSpec("dynamodb", "untag-resource")]
+
 
 @define(eq=False, slots=False)
 class AwsDynamoDbAttributeDefinition:
@@ -297,7 +301,7 @@ class AwsDynamoDbTable(DynamoDbTaggable, AwsResource):
     dynamodb_table_class_summary: Optional[AwsDynamoDbTableClassSummary] = field(default=None)
 
     @classmethod
-    def called_apis(cls) -> List[AwsApiSpec]:
+    def called_collect_apis(cls) -> List[AwsApiSpec]:
         return [cls.api_spec, AwsApiSpec("dynamodb", "describe-table"), AwsApiSpec("dynamodb", "list-tags-of-resource")]
 
     @classmethod
@@ -343,6 +347,10 @@ class AwsDynamoDbTable(DynamoDbTaggable, AwsResource):
         client.call(aws_service=self.api_spec.service, action="delete-table", result_name=None, TableName=self.name)
         return True
 
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return super().called_mutator_apis() + [AwsApiSpec("dynamodb", "delete-table")]
+
 
 @define(eq=False, slots=False)
 class AwsDynamoDbGlobalTable(DynamoDbTaggable, AwsResource):
@@ -366,7 +374,7 @@ class AwsDynamoDbGlobalTable(DynamoDbTaggable, AwsResource):
     dynamodb_global_table_status: Optional[str] = field(default=None)
 
     @classmethod
-    def called_apis(cls) -> List[AwsApiSpec]:
+    def called_collect_apis(cls) -> List[AwsApiSpec]:
         return [
             cls.api_spec,
             AwsApiSpec("dynamodb", "describe-global-table"),
@@ -405,6 +413,10 @@ class AwsDynamoDbGlobalTable(DynamoDbTaggable, AwsResource):
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(aws_service=self.api_spec.service, action="delete-table", result_name=None, TableName=self.name)
         return True
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return super().called_mutator_apis() + [AwsApiSpec("dynamodb", "delete-table")]
 
 
 global_resources: List[Type[AwsResource]] = [AwsDynamoDbGlobalTable]

--- a/plugins/aws/resoto_plugin_aws/resource/ecs.py
+++ b/plugins/aws/resoto_plugin_aws/resource/ecs.py
@@ -49,6 +49,10 @@ class EcsTaggable:
             return False
         return False
 
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return [AwsApiSpec("ecs", "tag-resource"), AwsApiSpec("ecs", "untag-resource")]
+
 
 @define(eq=False, slots=False)
 class AwsEcsManagedScaling:
@@ -123,6 +127,16 @@ class AwsEcsCapacityProvider(EcsTaggable, AwsResource):
     def delete_resource(self, client: AwsClient) -> bool:
         client.call("ecs", "delete-capacity-provider", None, capacityProvider=self.safe_name)
         return True
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+
+        return super().called_mutator_apis() + [
+            AwsApiSpec("ecs", "update-service"),
+            AwsApiSpec("ecs", "put-cluster-capacity-providers"),
+            AwsApiSpec("ecs", "delete-capacity-provider"),
+            AwsApiSpec("ecs", "put-cluster-capacity-providers"),
+        ]
 
 
 @define(eq=False, slots=False)
@@ -430,6 +444,10 @@ class AwsEcsTask(EcsTaggable, AwsResource):
             aws_service="ecs", action="stop-task", result_name=None, cluster=self.task_cluster_arn, task=self.arn
         )
         return True
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return super().called_mutator_apis() + [AwsApiSpec("ecs", "stop-task")]
 
 
 @define(eq=False, slots=False)
@@ -865,7 +883,7 @@ class AwsEcsTaskDefinition(EcsTaggable, AwsResource):
     ephemeral_storage: Optional[int] = field(default=None)
 
     @classmethod
-    def called_apis(cls) -> List[AwsApiSpec]:
+    def called_collect_apis(cls) -> List[AwsApiSpec]:
         return [
             cls.api_spec,
             AwsApiSpec("ecs", "describe-task-definition"),
@@ -905,6 +923,10 @@ class AwsEcsTaskDefinition(EcsTaggable, AwsResource):
             taskDefinition=f"{self.family}:{self.revision}",
         )
         return True
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return super().called_mutator_apis() + [AwsApiSpec("ecs", "deregister-task-definition")]
 
 
 @define(eq=False, slots=False)
@@ -1309,6 +1331,13 @@ class AwsEcsService(EcsTaggable, AwsResource):
         except ValueError:
             return False
 
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return super().called_mutator_apis() + [
+            AwsApiSpec("ecs", "update-service"),
+            AwsApiSpec("ecs", "delete-service"),
+        ]
+
 
 @define(eq=False, slots=False)
 class AwsEcsVersionInfo:
@@ -1427,6 +1456,10 @@ class AwsEcsContainerInstance(EcsTaggable, AwsResource):
         client.call("ecs", "deregister-container-instance", None, cluster=self.cluster_link, containerInstance=self.arn)
         return True
 
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return super().called_mutator_apis() + [AwsApiSpec("ecs", "deregister-container-instance")]
+
 
 @define(eq=False, slots=False)
 class AwsEcsExecuteCommandLogConfiguration:
@@ -1526,7 +1559,7 @@ class AwsEcsCluster(EcsTaggable, AwsResource):
     cluster_attachments_status: Optional[str] = field(default=None)
 
     @classmethod
-    def called_apis(cls) -> List[AwsApiSpec]:
+    def called_collect_apis(cls) -> List[AwsApiSpec]:
         return [
             cls.api_spec,
             AwsApiSpec("ecs", "describe-clusters"),
@@ -1649,6 +1682,10 @@ class AwsEcsCluster(EcsTaggable, AwsResource):
             return True
         except ValueError:
             return False
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return super().called_mutator_apis() + [AwsApiSpec("ecs", "delete-cluster")]
 
 
 resources: List[Type[AwsResource]] = [

--- a/plugins/aws/resoto_plugin_aws/resource/elasticache.py
+++ b/plugins/aws/resoto_plugin_aws/resource/elasticache.py
@@ -20,7 +20,7 @@ class ElastiCacheTaggable:
         if isinstance(self, AwsResource):
             client.call(
                 aws_service="elasticache",
-                action="add_tags_to_resource",
+                action="add-tags-to-resource",
                 result_name=None,
                 ResourceName=self.arn,
                 Tags=[{"Key": key, "Value": value}],
@@ -32,13 +32,20 @@ class ElastiCacheTaggable:
         if isinstance(self, AwsResource):
             client.call(
                 aws_service="elasticache",
-                action="remove_tags_from_resource",
+                action="remove-tags-from-resource",
                 result_name=None,
                 ResourceName=self.arn,
                 TagKeys=[key],
             )
             return True
         return False
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return [
+            AwsApiSpec("elasticache", "add-tags-to-resource"),
+            AwsApiSpec("elasticache", "remove-tags-from-resource"),
+        ]
 
 
 @define(eq=False, slots=False)
@@ -254,12 +261,16 @@ class AwsElastiCacheCacheCluster(ElastiCacheTaggable, AwsResource):
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
-            aws_service=self.api_spec.service, action="delete_cache_cluster", result_name=None, CacheClusterId=self.id
+            aws_service=self.api_spec.service, action="delete-cache-cluster", result_name=None, CacheClusterId=self.id
         )
         return True
 
     @classmethod
-    def called_apis(cls) -> List[AwsApiSpec]:
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return super().called_mutator_apis() + [AwsApiSpec("elasticache", "delete-cache-cluster")]
+
+    @classmethod
+    def called_collect_apis(cls) -> List[AwsApiSpec]:
         return [cls.api_spec, AwsApiSpec(cls.api_spec.service, "list-tags-for-resource")]
 
     @classmethod
@@ -444,7 +455,7 @@ class AwsElastiCacheReplicationGroup(ElastiCacheTaggable, AwsResource):
     replication_group_data_tiering: Optional[str] = field(default=None)
 
     @classmethod
-    def called_apis(cls) -> List[AwsApiSpec]:
+    def called_collect_apis(cls) -> List[AwsApiSpec]:
         return [cls.api_spec, AwsApiSpec(cls.api_spec.service, "list-tags-for-resource")]
 
     @classmethod
@@ -474,12 +485,16 @@ class AwsElastiCacheReplicationGroup(ElastiCacheTaggable, AwsResource):
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
             aws_service=self.api_spec.service,
-            action="delete_replication_group",
+            action="delete-replication-group",
             result_name=None,
             ReplicationGroupId=self.id,
             RetainPrimaryCluster=False,
         )
         return True
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return super().called_mutator_apis() + [AwsApiSpec("elasticache", "delete-replication-group")]
 
 
 resources: List[Type[AwsResource]] = [AwsElastiCacheReplicationGroup, AwsElastiCacheCacheCluster]

--- a/plugins/aws/resoto_plugin_aws/resource/elasticbeanstalk.py
+++ b/plugins/aws/resoto_plugin_aws/resource/elasticbeanstalk.py
@@ -84,7 +84,7 @@ class AwsBeanstalkApplication(AwsResource):
     beanstalk_resource_lifecycle_config: Optional[AwsBeanstalkApplicationResourceLifecycleConfig] = field(default=None)
 
     @classmethod
-    def called_apis(cls) -> List[AwsApiSpec]:
+    def called_collect_apis(cls) -> List[AwsApiSpec]:
         return [cls.api_spec, AwsApiSpec(cls.api_spec.service, "list-tags-for-resource")]
 
     @classmethod
@@ -126,6 +126,13 @@ class AwsBeanstalkApplication(AwsResource):
             aws_service=self.api_spec.service, action="delete-application", result_name=None, ApplicationName=self.name
         )
         return True
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return [
+            AwsApiSpec("elasticbeanstalk", "update-tags-for-resource"),
+            AwsApiSpec("elasticbeanstalk", "delete-application"),
+        ]
 
 
 @define(eq=False, slots=False)
@@ -253,7 +260,7 @@ class AwsBeanstalkEnvironment(AwsResource):
     beanstalk_operations_role: Optional[str] = field(default=None)
 
     @classmethod
-    def called_apis(cls) -> List[AwsApiSpec]:
+    def called_collect_apis(cls) -> List[AwsApiSpec]:
         return [
             cls.api_spec,
             AwsApiSpec(cls.api_spec.service, "describe-environment-resources"),
@@ -356,6 +363,13 @@ class AwsBeanstalkEnvironment(AwsResource):
             EnvironmentName=self.name,
         )
         return True
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return [
+            AwsApiSpec("elasticbeanstalk", "update-tags-for-resource"),
+            AwsApiSpec("elasticbeanstalk", "terminate-environment"),
+        ]
 
 
 resources: List[Type[AwsResource]] = [AwsBeanstalkApplication, AwsBeanstalkEnvironment]

--- a/plugins/aws/resoto_plugin_aws/resource/glacier.py
+++ b/plugins/aws/resoto_plugin_aws/resource/glacier.py
@@ -183,7 +183,7 @@ class AwsGlacierVault(AwsResource):
     glacier_size_in_bytes: Optional[int] = field(default=None)
 
     @classmethod
-    def called_apis(cls) -> List[AwsApiSpec]:
+    def called_collect_apis(cls) -> List[AwsApiSpec]:
         return [
             cls.api_spec,
             AwsApiSpec(cls.api_spec.service, "list-tags-for-vault"),
@@ -221,6 +221,14 @@ class AwsGlacierVault(AwsResource):
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(aws_service="glacier", action="delete-vault", result_name=None, vaultName=self.name)
         return True
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return [
+            AwsApiSpec("glacier", "add-tags-to-vault"),
+            AwsApiSpec("glacier", "remove-tags-from-vault"),
+            AwsApiSpec("glacier", "delete-vault"),
+        ]
 
 
 resources: List[Type[AwsResource]] = [AwsGlacierVault, AwsGlacierJob]

--- a/plugins/aws/resoto_plugin_aws/resource/iam.py
+++ b/plugins/aws/resoto_plugin_aws/resource/iam.py
@@ -124,7 +124,7 @@ class AwsIamRole(AwsResource):
         return iam_update_tag(
             resource=self,
             client=client,
-            action="tag_role",
+            action="tag-role",
             key=key,
             value=value,
             RoleName=self.name,
@@ -134,7 +134,7 @@ class AwsIamRole(AwsResource):
         return iam_delete_tag(
             resource=self,
             client=client,
-            action="untag_role",
+            action="untag-role",
             key=key,
             RoleName=self.name,
         )
@@ -147,7 +147,7 @@ class AwsIamRole(AwsResource):
                 self.log(log_msg)
                 client.call(
                     aws_service="iam",
-                    action="detach_role_policy",
+                    action="detach-role-policy",
                     result_name=None,
                     PolicyArn=successor.arn,
                     RoleName=self.name,
@@ -158,7 +158,7 @@ class AwsIamRole(AwsResource):
             self.log(log_msg)
             client.call(
                 aws_service="iam",
-                action="delete_role_policy",
+                action="delete-role-policy",
                 result_name=None,
                 PolicyName=role_policy.policy_name,
                 RoleName=self.name,
@@ -167,8 +167,18 @@ class AwsIamRole(AwsResource):
         return True
 
     def delete_resource(self, client: AwsClient) -> bool:
-        client.call(aws_service="iam", action="delete_role", result_name=None, RoleName=self.name)
+        client.call(aws_service="iam", action="delete-role", result_name=None, RoleName=self.name)
         return True
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return [
+            AwsApiSpec("iam", "tag-role"),
+            AwsApiSpec("iam", "untag-role"),
+            AwsApiSpec("iam", "detach-role-policy"),
+            AwsApiSpec("iam", "delete-role-policy"),
+            AwsApiSpec("iam", "delete-role"),
+        ]
 
 
 @define(eq=False, slots=False)
@@ -190,7 +200,7 @@ class AwsIamServerCertificate(AwsResource, BaseCertificate):
         return iam_update_tag(
             resource=self,
             client=client,
-            action="tag_server_certificate",
+            action="tag-server-certificate",
             key=key,
             value=value,
             ServerCertificateName=self.name,
@@ -200,7 +210,7 @@ class AwsIamServerCertificate(AwsResource, BaseCertificate):
         return iam_delete_tag(
             resource=self,
             client=client,
-            action="untag_server_certificate",
+            action="untag-server-certificate",
             key=key,
             ServerCertificateName=self.name,
         )
@@ -208,11 +218,19 @@ class AwsIamServerCertificate(AwsResource, BaseCertificate):
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
             aws_service=self.api_spec.service,
-            action="delete_server_certificate",
+            action="delete-server-certificate",
             result_name=None,
             ServerCertificateName=self.name,
         )
         return True
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return [
+            AwsApiSpec("iam", "tag-server-certificate"),
+            AwsApiSpec("iam", "untag-server-certificate"),
+            AwsApiSpec("iam", "delete-server-certificate"),
+        ]
 
 
 @define(eq=False, slots=False)
@@ -244,7 +262,7 @@ class AwsIamPolicy(AwsResource, BasePolicy):
         return iam_update_tag(
             resource=self,
             client=client,
-            action="tag_policy",
+            action="tag-policy",
             key=key,
             value=value,
             PolicyArn=self.arn,
@@ -254,7 +272,7 @@ class AwsIamPolicy(AwsResource, BasePolicy):
         return iam_delete_tag(
             resource=self,
             client=client,
-            action="untag_policy",
+            action="untag-policy",
             key=key,
             PolicyArn=self.arn,
         )
@@ -262,11 +280,19 @@ class AwsIamPolicy(AwsResource, BasePolicy):
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
             aws_service="iam",
-            action="delete_policy",
+            action="delete-policy",
             result_name=None,
             PolicyArn=self.arn,
         )
         return True
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return [
+            AwsApiSpec("iam", "tag-policy"),
+            AwsApiSpec("iam", "untag-policy"),
+            AwsApiSpec("iam", "delete-policy"),
+        ]
 
 
 @define(eq=False, slots=False)
@@ -300,7 +326,7 @@ class AwsIamGroup(AwsResource, BaseGroup):
                 self.log(log_msg)
                 client.call(
                     aws_service="iam",
-                    action="detach_group_policy",
+                    action="detach-group-policy",
                     result_name=None,
                     GroupName=self.name,
                     PolicyArn=successor.arn,
@@ -311,7 +337,7 @@ class AwsIamGroup(AwsResource, BaseGroup):
             self.log(log_msg)
             client.call(
                 aws_service="iam",
-                action="delete_group_policy",
+                action="delete-group-policy",
                 result_name=None,
                 GroupName=self.name,
                 PolicyName=group_policy,
@@ -322,11 +348,19 @@ class AwsIamGroup(AwsResource, BaseGroup):
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
             aws_service="iam",
-            action="delete_group",
+            action="delete-group",
             result_name=None,
             GroupName=self.name,
         )
         return True
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return [
+            AwsApiSpec("iam", "detach-group-policy"),
+            AwsApiSpec("iam", "delete-group-policy"),
+            AwsApiSpec("iam", "delete-group"),
+        ]
 
 
 @define(eq=False, slots=False)
@@ -385,7 +419,7 @@ class AwsIamUser(AwsResource, BaseUser):
     user_permissions_boundary: Optional[AwsIamAttachedPermissionsBoundary] = field(default=None)
 
     @classmethod
-    def called_apis(cls) -> List[AwsApiSpec]:
+    def called_collect_apis(cls) -> List[AwsApiSpec]:
         return [
             cls.api_spec,
             AwsApiSpec("iam", "list-access-keys"),
@@ -433,10 +467,10 @@ class AwsIamUser(AwsResource, BaseUser):
             builder.add_edge(self, reverse=True, clazz=AwsIamGroup, arn=arn)
 
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
-        return iam_update_tag(resource=self, client=client, action="tag_user", key=key, value=value, UserName=self.name)
+        return iam_update_tag(resource=self, client=client, action="tag-user", key=key, value=value, UserName=self.name)
 
     def delete_resource_tag(self, client: AwsClient, key: str) -> bool:
-        return iam_delete_tag(resource=self, client=client, action="untag_user", key=key, UserName=self.name)
+        return iam_delete_tag(resource=self, client=client, action="untag-user", key=key, UserName=self.name)
 
     def pre_delete_resource(self, client: AwsClient, graph: Graph) -> bool:
         for successor in self.successors(graph, edge_type=EdgeType.delete):
@@ -445,7 +479,7 @@ class AwsIamUser(AwsResource, BaseUser):
                 self.log(log_msg)
                 client.call(
                     aws_service="iam",
-                    action="detach_user_policy",
+                    action="detach-user-policy",
                     result_name=None,
                     UserName=self.name,
                     PolicyArn=successor.arn,
@@ -456,7 +490,7 @@ class AwsIamUser(AwsResource, BaseUser):
             self.log(log_msg)
             client.call(
                 aws_service="iam",
-                action="delete_user_policy",
+                action="delete-user-policy",
                 result_name=None,
                 UserName=self.name,
                 PolicyName=user_policy.policy_name,
@@ -465,8 +499,18 @@ class AwsIamUser(AwsResource, BaseUser):
         return True
 
     def delete_resource(self, client: AwsClient) -> bool:
-        client.call(aws_service="iam", action="delete_user", result_name=None, UserName=self.name)
+        client.call(aws_service="iam", action="delete-user", result_name=None, UserName=self.name)
         return True
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return [
+            AwsApiSpec("iam", "tag-user"),
+            AwsApiSpec("iam", "untag-user"),
+            AwsApiSpec("iam", "detach-user-policy"),
+            AwsApiSpec("iam", "delete-user-policy"),
+            AwsApiSpec("iam", "delete-user"),
+        ]
 
 
 @define(eq=False, slots=False)
@@ -486,7 +530,7 @@ class AwsIamInstanceProfile(AwsResource, BaseInstanceProfile):
         return iam_update_tag(
             resource=self,
             client=client,
-            action="tag_instance_profile",
+            action="tag-instance-profile",
             key=key,
             value=value,
             InstanceProfileName=self.name,
@@ -494,7 +538,7 @@ class AwsIamInstanceProfile(AwsResource, BaseInstanceProfile):
 
     def delete_resource_tag(self, client: AwsClient, key: str) -> bool:
         return iam_delete_tag(
-            resource=self, client=client, action="untag_instance_profile", key=key, InstanceProfileName=self.name
+            resource=self, client=client, action="untag-instance-profile", key=key, InstanceProfileName=self.name
         )
 
     def pre_delete_resource(self, client: AwsClient, graph: Graph) -> bool:
@@ -504,7 +548,7 @@ class AwsIamInstanceProfile(AwsResource, BaseInstanceProfile):
                 self.log(log_msg)
                 client.call(
                     aws_service="iam",
-                    action="remove_role_from_instance_profile",
+                    action="remove-role-from-instance-profile",
                     result_name=None,
                     RoleName=predecessor.name,
                     InstanceProfileName=self.name,
@@ -513,9 +557,18 @@ class AwsIamInstanceProfile(AwsResource, BaseInstanceProfile):
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
-            aws_service="iam", action="delete_instance_profile", result_name=None, InstanceProfileName=self.name
+            aws_service="iam", action="delete-instance-profile", result_name=None, InstanceProfileName=self.name
         )
         return True
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return [
+            AwsApiSpec("iam", "tag-instance-profile"),
+            AwsApiSpec("iam", "untag-instance-profile"),
+            AwsApiSpec("iam", "remove-role-from-instance-profile"),
+            AwsApiSpec("iam", "delete-instance-profile"),
+        ]
 
 
 resources: List[Type[AwsResource]] = [

--- a/plugins/aws/resoto_plugin_aws/resource/kinesis.py
+++ b/plugins/aws/resoto_plugin_aws/resource/kinesis.py
@@ -89,8 +89,8 @@ class AwsKinesisStream(AwsResource):
     kinesis_key_id: Optional[str] = field(default=None)
 
     @classmethod
-    def called_apis(cls) -> List[AwsApiSpec]:
-        return [cls.api_spec, AwsApiSpec("kinesis", "describe-stream"), AwsApiSpec("kinesis", "list_tags_for_stream")]
+    def called_collect_apis(cls) -> List[AwsApiSpec]:
+        return [cls.api_spec, AwsApiSpec("kinesis", "describe-stream"), AwsApiSpec("kinesis", "list-tags-for-stream")]
 
     @classmethod
     def collect(cls: Type[AwsResource], json: List[Json], builder: GraphBuilder) -> None:
@@ -114,7 +114,7 @@ class AwsKinesisStream(AwsResource):
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
         client.call(
             aws_service=self.api_spec.service,
-            action="add_tags_to_stream",
+            action="add-tags-to-stream",
             result_name=None,
             StreamName=self.name,
             Tags={key: value},
@@ -124,7 +124,7 @@ class AwsKinesisStream(AwsResource):
     def delete_resource_tag(self, client: AwsClient, key: str) -> bool:
         client.call(
             aws_service=self.api_spec.service,
-            action="remove_tags_from_stream",
+            action="remove-tags-from-stream",
             result_name=None,
             StreamName=self.name,
             TagKeys=[key],
@@ -134,11 +134,19 @@ class AwsKinesisStream(AwsResource):
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
             aws_service=self.api_spec.service,
-            action="delete_stream",
+            action="delete-stream",
             result_name=None,
             StreamName=self.name,
         )
         return True
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return [
+            AwsApiSpec("kinesis", "add-tags-to-stream"),
+            AwsApiSpec("kinesis", "remove-tags-from-stream"),
+            AwsApiSpec("kinesis", "delete-stream"),
+        ]
 
 
 resources: List[Type[AwsResource]] = [AwsKinesisStream]

--- a/plugins/aws/resoto_plugin_aws/resource/kms.py
+++ b/plugins/aws/resoto_plugin_aws/resource/kms.py
@@ -89,7 +89,7 @@ class AwsKmsKey(AwsResource, BaseAccessKey):
     kms_mac_algorithms: List[str] = field(factory=list)
 
     @classmethod
-    def called_apis(cls) -> List[AwsApiSpec]:
+    def called_collect_apis(cls) -> List[AwsApiSpec]:
         return [cls.api_spec, AwsApiSpec("kms", "describe-key"), AwsApiSpec("kms", "list-resource-tags")]
 
     @classmethod
@@ -140,6 +140,15 @@ class AwsKmsKey(AwsResource, BaseAccessKey):
 
         client.call(aws_service="kms", action="disable-key", result_name=None, KeyId=self.id)
         return True
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return [
+            AwsApiSpec("kms", "tag-resource"),
+            AwsApiSpec("kms", "untag-resource"),
+            AwsApiSpec("kms", "schedule-key-deletion"),
+            AwsApiSpec("kms", "disable-key"),
+        ]
 
     @staticmethod
     def normalise_id(identifier: str) -> str:

--- a/plugins/aws/resoto_plugin_aws/resource/lambda_.py
+++ b/plugins/aws/resoto_plugin_aws/resource/lambda_.py
@@ -228,7 +228,7 @@ class AwsLambdaFunction(AwsResource, BaseServerlessFunction):
     function_ephemeral_storage: Optional[int] = field(default=None)
 
     @classmethod
-    def called_apis(cls) -> List[AwsApiSpec]:
+    def called_collect_apis(cls) -> List[AwsApiSpec]:
         return [cls.api_spec, AwsApiSpec("lambda", "list-tags")]
 
     @classmethod
@@ -294,7 +294,7 @@ class AwsLambdaFunction(AwsResource, BaseServerlessFunction):
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
         client.call(
             aws_service=self.api_spec.service,
-            action="tag_resource",
+            action="tag-resource",
             result_name=None,
             Resource=self.arn,
             Tags={key: value},
@@ -304,7 +304,7 @@ class AwsLambdaFunction(AwsResource, BaseServerlessFunction):
     def delete_resource_tag(self, client: AwsClient, key: str) -> bool:
         client.call(
             aws_service=self.api_spec.service,
-            action="untag_resource",
+            action="untag-resource",
             result_name=None,
             Resource=self.arn,
             TagKeys=[key],
@@ -313,9 +313,17 @@ class AwsLambdaFunction(AwsResource, BaseServerlessFunction):
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
-            aws_service=self.api_spec.service, action="delete_function", result_name=None, FunctionName=self.arn
+            aws_service=self.api_spec.service, action="delete-function", result_name=None, FunctionName=self.arn
         )
         return True
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return [
+            AwsApiSpec("lambda", "tag-resource"),
+            AwsApiSpec("lambda", "untag-resource"),
+            AwsApiSpec("lambda", "delete-function"),
+        ]
 
 
 resources: List[Type[AwsResource]] = [AwsLambdaFunction]

--- a/plugins/aws/resoto_plugin_aws/resource/rds.py
+++ b/plugins/aws/resoto_plugin_aws/resource/rds.py
@@ -20,7 +20,7 @@ class RdsTaggable:
             if spec := self.api_spec:
                 client.call(
                     aws_service=spec.service,
-                    action="add_tags_to_resource",
+                    action="add-tags-to-resource",
                     result_name=None,
                     ResourceName=self.arn,
                     Tags=[{"Key": key, "Value": value}],
@@ -34,7 +34,7 @@ class RdsTaggable:
             if spec := self.api_spec:
                 client.call(
                     aws_service=spec.service,
-                    action="remove_tags_from_resource",
+                    action="remove-tags-from-resource",
                     result_name=None,
                     ResourceName=self.arn,
                     TagKeys=[key],
@@ -42,6 +42,10 @@ class RdsTaggable:
                 return True
             return False
         return False
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return [AwsApiSpec("rds", "add-tags-to-resource"), AwsApiSpec("rds", "remove-tags-from-resource")]
 
 
 @define(eq=False, slots=False)
@@ -408,7 +412,7 @@ class AwsRdsInstance(RdsTaggable, AwsResource, BaseDatabase):
     rds_network_type: Optional[str] = field(default=None)
 
     @classmethod
-    def called_apis(cls) -> List[AwsApiSpec]:
+    def called_collect_apis(cls) -> List[AwsApiSpec]:
         return [cls.api_spec, AwsApiSpec(cls.api_spec.service, "list-tags-for-resource")]
 
     @classmethod
@@ -486,12 +490,16 @@ class AwsRdsInstance(RdsTaggable, AwsResource, BaseDatabase):
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
             aws_service=self.api_spec.service,
-            action="delete_db_instance",
+            action="delete-db-instance",
             result_name=None,
             DBInstanceIdentifier=self.id,
             SkipFinalSnapshot=True,
         )
         return True
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return super().called_mutator_apis() + [AwsApiSpec("rds", "delete-db-instance")]
 
 
 resources: List[Type[AwsResource]] = [AwsRdsInstance]

--- a/plugins/aws/resoto_plugin_aws/resource/redshift.py
+++ b/plugins/aws/resoto_plugin_aws/resource/redshift.py
@@ -444,7 +444,7 @@ class AwsRedshiftCluster(AwsResource):
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
         client.call(
             aws_service=self.api_spec.service,
-            action="create_tags",
+            action="create-tags",
             result_name=None,
             ResourceName=self.arn,
             Tags=[{"Key": key, "Value": value}],
@@ -454,7 +454,7 @@ class AwsRedshiftCluster(AwsResource):
     def delete_resource_tag(self, client: AwsClient, key: str) -> bool:
         client.call(
             aws_service=self.api_spec.service,
-            action="delete_tags",
+            action="delete-tags",
             result_name=None,
             ResourceName=self.arn,
             TagKeys=[key],
@@ -464,12 +464,20 @@ class AwsRedshiftCluster(AwsResource):
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(
             aws_service=self.api_spec.service,
-            action="delete_cluster",
+            action="delete-cluster",
             result_name=None,
             ClusterIdentifier=self.id,
             SkipFinalClusterSnapshot=True,
         )
         return True
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return [
+            AwsApiSpec("redshift", "create-tags"),
+            AwsApiSpec("redshift", "delete-tags"),
+            AwsApiSpec("redshift", "delete-cluster"),
+        ]
 
 
 resources: List[Type[AwsResource]] = [AwsRedshiftCluster]

--- a/plugins/aws/resoto_plugin_aws/resource/route53.py
+++ b/plugins/aws/resoto_plugin_aws/resource/route53.py
@@ -58,7 +58,7 @@ class AwsRoute53Zone(AwsResource, BaseDNSZone):
     zone_linked_service: Optional[AwsRoute53LinkedService] = field(default=None)
 
     @classmethod
-    def called_apis(cls) -> List[AwsApiSpec]:
+    def called_collect_apis(cls) -> List[AwsApiSpec]:
         return [
             cls.api_spec,
             AwsApiSpec("route53", "list-resource-record-sets"),
@@ -126,6 +126,13 @@ class AwsRoute53Zone(AwsResource, BaseDNSZone):
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(aws_service="route53", action="delete-hosted-zone", result_name=None, Id=self.id.rsplit("/", 1)[-1])
         return True
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return [
+            AwsApiSpec("route53", "change-tags-for-resource"),
+            AwsApiSpec("route53", "delete-hosted-zone"),
+        ]
 
 
 @define(eq=False, slots=False)

--- a/plugins/aws/resoto_plugin_aws/resource/service_quotas.py
+++ b/plugins/aws/resoto_plugin_aws/resource/service_quotas.py
@@ -82,8 +82,12 @@ class AwsServiceQuota(AwsResource, BaseQuota):
     quota_error_reason: Optional[AwsQuotaErrorReason] = field(default=None)
 
     @classmethod
-    def called_apis(cls) -> List[AwsApiSpec]:
-        return [AwsApiSpec("service-quotas", "list_service_quotas")]
+    def called_collect_apis(cls) -> List[AwsApiSpec]:
+        return [
+            AwsApiSpec(
+                "service-quotas", "list-service-quotas", override_iam_permission="servicequotas:ListServiceQuotas"
+            )
+        ]
 
     @classmethod
     def collect_service(cls, service_code: str, matchers: List["QuotaMatcher"], builder: GraphBuilder) -> None:
@@ -124,7 +128,7 @@ class AwsServiceQuota(AwsResource, BaseQuota):
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
         client.call(
             aws_service="service-quotas",
-            action="tag_resource",
+            action="tag-resource",
             result_name=None,
             ResourceARN=self.arn,
             Tags=[{"Key": key, "Value": value}],
@@ -134,12 +138,19 @@ class AwsServiceQuota(AwsResource, BaseQuota):
     def delete_resource_tag(self, client: AwsClient, key: str) -> bool:
         client.call(
             aws_service="service-quotas",
-            action="untag_resource",
+            action="untag-resource",
             result_name=None,
             ResourceARN=self.arn,
             TagKeys=[key],
         )
         return True
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return [
+            AwsApiSpec("service-quotas", "tag-resource", override_iam_permission="servicequotas:TagResource"),
+            AwsApiSpec("service-quotas", "untag-resource", override_iam_permission="servicequotas:UntagResource"),
+        ]
 
 
 @define

--- a/plugins/aws/resoto_plugin_aws/resource/sns.py
+++ b/plugins/aws/resoto_plugin_aws/resource/sns.py
@@ -47,7 +47,7 @@ class AwsSnsTopic(AwsResource):
     topic_content_based_deduplication: Optional[bool] = field(default=None)
 
     @classmethod
-    def called_apis(cls) -> List[AwsApiSpec]:
+    def called_collect_apis(cls) -> List[AwsApiSpec]:
         return [
             cls.api_spec,
             AwsApiSpec("sns", "get-topic-attributes"),
@@ -96,6 +96,14 @@ class AwsSnsTopic(AwsResource):
         client.call(aws_service="sns", action="delete-topic", result_name=None, TopicArn=self.arn)
         return True
 
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return [
+            AwsApiSpec("sns", "tag-resource"),
+            AwsApiSpec("sns", "untag-resource"),
+            AwsApiSpec("sns", "delete-topic"),
+        ]
+
 
 @define(eq=False, slots=False)
 class AwsSnsSubscription(AwsResource):
@@ -131,7 +139,7 @@ class AwsSnsSubscription(AwsResource):
     subscription_role_arn: Optional[str] = field(default=None)
 
     @classmethod
-    def called_apis(cls) -> List[AwsApiSpec]:
+    def called_collect_apis(cls) -> List[AwsApiSpec]:
         return [
             cls.api_spec,
             AwsApiSpec("sns", "get-subscription-attributes"),
@@ -164,6 +172,10 @@ class AwsSnsSubscription(AwsResource):
         client.call(aws_service="sns", action="unsubscribe", result_name=None, SubscriptionArn=self.arn)
         return True
 
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return [AwsApiSpec("sns", "unsubscribe")]
+
 
 @define(eq=False, slots=False)
 class AwsSnsEndpoint(AwsResource):
@@ -181,6 +193,10 @@ class AwsSnsEndpoint(AwsResource):
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(aws_service="sns", action="delete-endpoint", result_name=None, EndpointArn=self.arn)
         return True
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return [AwsApiSpec("sns", "delete-endpoint")]
 
 
 @define(eq=False, slots=False)
@@ -214,7 +230,7 @@ class AwsSnsPlatformApplication(AwsResource):
     application_event_endpoint_failure: Optional[str] = field(default=None)
 
     @classmethod
-    def called_apis(cls) -> List[AwsApiSpec]:
+    def called_collect_apis(cls) -> List[AwsApiSpec]:
         return [
             cls.api_spec,
             AwsApiSpec("sns", "get-platform-application-attributes"),
@@ -263,6 +279,10 @@ class AwsSnsPlatformApplication(AwsResource):
             aws_service="sns", action="delete-platform-application", result_name=None, PlatformApplicationArn=self.arn
         )
         return True
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return [AwsApiSpec("sns", "delete-platform-application")]
 
 
 resources: List[Type[AwsResource]] = [AwsSnsTopic, AwsSnsSubscription, AwsSnsPlatformApplication, AwsSnsEndpoint]

--- a/plugins/aws/resoto_plugin_aws/resource/sqs.py
+++ b/plugins/aws/resoto_plugin_aws/resource/sqs.py
@@ -65,7 +65,7 @@ class AwsSqsQueue(AwsResource):
     sqs_managed_sse_enabled: Optional[bool] = field(default=None)
 
     @classmethod
-    def called_apis(cls) -> List[AwsApiSpec]:
+    def called_collect_apis(cls) -> List[AwsApiSpec]:
         return [cls.api_spec, AwsApiSpec("sqs", "get-queue-attributes"), AwsApiSpec("sqs", "list-queue-tags")]
 
     @classmethod
@@ -113,6 +113,14 @@ class AwsSqsQueue(AwsResource):
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(aws_service="sqs", action="delete-queue", result_name=None, QueueUrl=self.sqs_queue_url)
         return True
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[AwsApiSpec]:
+        return [
+            AwsApiSpec("sqs", "tag-queue"),
+            AwsApiSpec("sqs", "untag-queue"),
+            AwsApiSpec("sqs", "delete-queue"),
+        ]
 
 
 resources: List[Type[AwsResource]] = [AwsSqsQueue]

--- a/plugins/aws/test/resources/athena_test.py
+++ b/plugins/aws/test/resources/athena_test.py
@@ -23,12 +23,12 @@ def test_data_catalogs_tagging() -> None:
     res, builder = round_trip_for(AwsAthenaDataCatalog)
 
     def validate_update_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "tag_resource"
+        assert kwargs["action"] == "tag-resource"
         assert kwargs["ResourceARN"] == res.arn
         assert kwargs["Tags"] == [{"Key": "foo", "Value": "bar"}]
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "untag_resource"
+        assert kwargs["action"] == "untag-resource"
         assert kwargs["ResourceARN"] == res.arn
         assert kwargs["TagKeys"] == ["foo"]
 
@@ -43,12 +43,12 @@ def test_workgroup_tagging() -> None:
     res, builder = round_trip_for(AwsAthenaWorkGroup)
 
     def validate_update_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "tag_resource"
+        assert kwargs["action"] == "tag-resource"
         assert kwargs["ResourceARN"] == res.arn
         assert kwargs["Tags"] == [{"Key": "foo", "Value": "bar"}]
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "untag_resource"
+        assert kwargs["action"] == "untag-resource"
         assert kwargs["ResourceARN"] == res.arn
         assert kwargs["TagKeys"] == ["foo"]
 

--- a/plugins/aws/test/resources/autoscaling_test.py
+++ b/plugins/aws/test/resources/autoscaling_test.py
@@ -13,7 +13,7 @@ def test_tagging() -> None:
     asg, _ = round_trip_for(AwsAutoScalingGroup)
 
     def validate_update_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "create_or_update_tags"
+        assert kwargs["action"] == "create-or-update-tags"
         assert kwargs["Tags"] == [
             {
                 "ResourceId": asg.name,
@@ -25,7 +25,7 @@ def test_tagging() -> None:
         ]
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_tags"
+        assert kwargs["action"] == "delete-tags"
         assert kwargs["Tags"] == [
             {
                 "ResourceId": asg.name,
@@ -45,7 +45,7 @@ def test_deletion() -> None:
     asg, _ = round_trip_for(AwsAutoScalingGroup)
 
     def validate_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_auto_scaling_group"
+        assert kwargs["action"] == "delete-auto-scaling-group"
         assert kwargs["AutoScalingGroupName"] == asg.name
         assert kwargs["ForceDelete"] is True
 

--- a/plugins/aws/test/resources/cloudformation_test.py
+++ b/plugins/aws/test/resources/cloudformation_test.py
@@ -21,11 +21,11 @@ def test_cloud_formation_stack_tagging() -> None:
 
     def validate_args(delete: bool, **kwargs: Any) -> Any:
 
-        assert kwargs["action"] in {"describe_stacks", "update_stack"}
+        assert kwargs["action"] in {"describe_stacks", "update-stack"}
         if kwargs["action"] == "describe_stacks":
             assert kwargs["StackName"] == cf.name
             return [{"StackStatus": "complete"}]
-        if kwargs["action"] == "update_stack":
+        if kwargs["action"] == "update-stack":
             tags = cf.tags
             if delete:
                 del tags[tag]
@@ -50,7 +50,7 @@ def test_cloud_formation_stack_delete() -> None:
     cf, _ = round_trip_for(AwsCloudFormationStack)
 
     def validate_args(**kwargs: Any) -> Any:
-        assert kwargs["action"] == "delete_stack"
+        assert kwargs["action"] == "delete-stack"
         assert kwargs["StackName"] == cf.name
 
     client = cast(AwsClient, SimpleNamespace(call=partial(validate_args)))
@@ -63,7 +63,7 @@ def test_cloud_formation_stack_set_tagging() -> None:
 
     def validate_args(delete: bool, **kwargs: Any) -> None:
 
-        assert kwargs["action"] == "update_stack_set"
+        assert kwargs["action"] == "update-stack-set"
         tags = cf.tags
         if delete:
             del tags["bar"]
@@ -89,7 +89,7 @@ def test_cloud_formation_stack_set_delete() -> None:
     cf, _ = round_trip_for(AwsCloudFormationStackSet)
 
     def validate_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_stack_set"
+        assert kwargs["action"] == "delete-stack-set"
         assert kwargs["StackSetName"] == cf.name
 
     client = cast(AwsClient, SimpleNamespace(call=partial(validate_args)))

--- a/plugins/aws/test/resources/cloudwatch_test.py
+++ b/plugins/aws/test/resources/cloudwatch_test.py
@@ -28,12 +28,12 @@ def test_tagging() -> None:
     alarm, _ = round_trip_for(AwsCloudwatchAlarm)
 
     def validate_update_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "tag_resource"
+        assert kwargs["action"] == "tag-resource"
         assert kwargs["ResourceARN"] == alarm.arn
         assert kwargs["Tags"] == [{"Key": "foo", "Value": "bar"}]
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "untag_resource"
+        assert kwargs["action"] == "untag-resource"
         assert kwargs["ResourceARN"] == alarm.arn
         assert kwargs["TagKeys"] == ["foo"]
 
@@ -48,7 +48,7 @@ def test_deletion() -> None:
     alarm, _ = round_trip_for(AwsCloudwatchAlarm)
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_alarms"
+        assert kwargs["action"] == "delete-alarms"
         assert kwargs["AlarmNames"] == [alarm.name]
 
     client = cast(AwsClient, SimpleNamespace(call=validate_delete_args))

--- a/plugins/aws/test/resources/ec2_test.py
+++ b/plugins/aws/test/resources/ec2_test.py
@@ -58,7 +58,7 @@ def test_delete_shapshot() -> None:
     snapshot, _ = round_trip_for(AwsEc2Snapshot)
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_snapshot"
+        assert kwargs["action"] == "delete-snapshot"
         assert kwargs["SnapshotId"] == snapshot.id
 
     client = cast(AwsClient, SimpleNamespace(call=validate_delete_args))
@@ -73,7 +73,7 @@ def test_delete_keypair() -> None:
     keypair, _ = round_trip_for(AwsEc2KeyPair)
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_key_pair"
+        assert kwargs["action"] == "delete-key-pair"
         assert kwargs["KeyPairId"] == keypair.id
 
     client = cast(AwsClient, SimpleNamespace(call=validate_delete_args))
@@ -88,7 +88,7 @@ def test_delete_instances() -> None:
     instance, _ = round_trip_for(AwsEc2Instance)
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "terminate_instances"
+        assert kwargs["action"] == "terminate-instances"
         assert kwargs["InstanceIds"] == [instance.id]
         assert kwargs["DryRun"] is False
 
@@ -104,7 +104,7 @@ def test_delete_network_acl() -> None:
     network_acl, _ = round_trip_for(AwsEc2NetworkAcl)
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_network_acl"
+        assert kwargs["action"] == "delete-network-acl"
         assert kwargs["NetworkAclId"] == network_acl.id
 
     client = cast(AwsClient, SimpleNamespace(call=validate_delete_args))
@@ -120,10 +120,10 @@ def test_delete_elastic_ips() -> None:
 
     def validate_delete_args(**kwargs: Any) -> None:
 
-        assert kwargs["action"] in {"release_address", "disassociate_address"}
-        if kwargs["action"] == "disassociate_address":
+        assert kwargs["action"] in {"release-address", "disassociate-address"}
+        if kwargs["action"] == "disassociate-address":
             assert kwargs["AssociationId"] == elastic_ip.ip_association_id
-        if kwargs["action"] == "release_address":
+        if kwargs["action"] == "release-address":
             assert kwargs["AllocationId"] == elastic_ip.ip_allocation_id
 
     client = cast(AwsClient, SimpleNamespace(call=validate_delete_args))
@@ -143,7 +143,7 @@ def test_delete_network_interfaces() -> None:
     network_interface, _ = round_trip_for(AwsEc2NetworkInterface)
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_network_interface"
+        assert kwargs["action"] == "delete-network-interface"
         assert kwargs["NetworkInterfaceId"] == network_interface.id
 
     client = cast(AwsClient, SimpleNamespace(call=validate_delete_args))
@@ -158,7 +158,7 @@ def test_delete_vpcs() -> None:
     vpc, _ = round_trip_for(AwsEc2Vpc)
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_vpc"
+        assert kwargs["action"] == "delete-vpc"
         assert kwargs["VpcId"] == vpc.id
 
     client = cast(AwsClient, SimpleNamespace(call=validate_delete_args))
@@ -173,7 +173,7 @@ def test_delete_vpc_peering_connections() -> None:
     vpc_peering_connection, _ = round_trip_for(AwsEc2VpcPeeringConnection)
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_vpc_peering_connection"
+        assert kwargs["action"] == "delete-vpc-peering-connection"
         assert kwargs["VpcPeeringConnectionId"] == vpc_peering_connection.id
 
     client = cast(AwsClient, SimpleNamespace(call=validate_delete_args))
@@ -188,7 +188,7 @@ def test_delete_vpc_endpoints() -> None:
     vpc_endpoint, _ = round_trip_for(AwsEc2VpcEndpoint)
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_vpc_endpoints"
+        assert kwargs["action"] == "delete-vpc-endpoints"
         assert kwargs["VpcEndpointIds"] == [vpc_endpoint.id]
 
     client = cast(AwsClient, SimpleNamespace(call=validate_delete_args))
@@ -203,7 +203,7 @@ def test_delete_subnets() -> None:
     subnet, _ = round_trip_for(AwsEc2Subnet)
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_subnet"
+        assert kwargs["action"] == "delete-subnet"
         assert kwargs["SubnetId"] == subnet.id
 
     client = cast(AwsClient, SimpleNamespace(call=validate_delete_args))
@@ -218,7 +218,7 @@ def test_delete_route_table() -> None:
     route_table, _ = round_trip_for(AwsEc2RouteTable)
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_route_table"
+        assert kwargs["action"] == "delete-route-table"
         assert kwargs["RouteTableId"] == route_table.id
 
     client = cast(AwsClient, SimpleNamespace(call=validate_delete_args))
@@ -233,10 +233,10 @@ def test_delete_security_groups() -> None:
     security_group, _ = round_trip_for(AwsEc2SecurityGroup)
 
     def validate_delete_args(**kwargs: Any) -> Any:
-        if kwargs["action"] == "describe_security_groups":
+        if kwargs["action"] == "describe-security-groups":
             return [dict()]
 
-        if kwargs["action"] == "delete_security_group":
+        if kwargs["action"] == "delete-security-group":
             assert kwargs["GroupId"] == security_group.id
 
     client = cast(AwsClient, SimpleNamespace(call=validate_delete_args))
@@ -251,7 +251,7 @@ def test_delete_nat_gateways() -> None:
     nat_gateway, _ = round_trip_for(AwsEc2NatGateway)
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_nat_gateway"
+        assert kwargs["action"] == "delete-nat-gateway"
         assert kwargs["NatGatewayId"] == nat_gateway.id
 
     client = cast(AwsClient, SimpleNamespace(call=validate_delete_args))
@@ -266,7 +266,7 @@ def test_delete_internet_gateways() -> None:
     internet_gateway, _ = round_trip_for(AwsEc2InternetGateway)
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_internet_gateway"
+        assert kwargs["action"] == "delete-internet-gateway"
         assert kwargs["InternetGatewayId"] == internet_gateway.id
 
     client = cast(AwsClient, SimpleNamespace(call=validate_delete_args))
@@ -292,12 +292,12 @@ def test_tagging() -> None:
     instance, _ = round_trip_for(AwsEc2Instance)
 
     def validate_update_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "create_tags"
+        assert kwargs["action"] == "create-tags"
         assert kwargs["Resources"] == [instance.id]
         assert kwargs["Tags"] == [{"Key": "foo", "Value": "bar"}]
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_tags"
+        assert kwargs["action"] == "delete-tags"
         assert kwargs["Resources"] == [instance.id]
         assert kwargs["Tags"] == [{"Key": "foo"}]
 

--- a/plugins/aws/test/resources/eks_test.py
+++ b/plugins/aws/test/resources/eks_test.py
@@ -15,7 +15,7 @@ def test_cluster_deletion() -> None:
     cluster, _ = round_trip_for(AwsEksCluster)
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_cluster"
+        assert kwargs["action"] == "delete-cluster"
         assert kwargs["name"] == cluster.name
 
     client = cast(AwsClient, SimpleNamespace(call=validate_delete_args))
@@ -27,7 +27,7 @@ def test_nodegroup_deletion() -> None:
     nodegroup = builder.resources_of(AwsEksNodegroup)[0]
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_nodegroup"
+        assert kwargs["action"] == "delete-nodegroup"
         assert kwargs["nodegroupName"] == nodegroup.name
         assert kwargs["clusterName"] == nodegroup.cluster_name
 
@@ -39,12 +39,12 @@ def test_tagging() -> None:
     cluster, _ = round_trip_for(AwsEksCluster)
 
     def validate_update_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "tag_resource"
+        assert kwargs["action"] == "tag-resource"
         assert kwargs["resourceArn"] == cluster.arn
         assert kwargs["tags"] == {"foo": "bar"}
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "untag_resource"
+        assert kwargs["action"] == "untag-resource"
         assert kwargs["resourceArn"] == cluster.arn
         assert kwargs["tagKeys"] == ["foo"]
 

--- a/plugins/aws/test/resources/elasticache_test.py
+++ b/plugins/aws/test/resources/elasticache_test.py
@@ -24,12 +24,12 @@ def test_tagging() -> None:
     resource, _ = round_trip_for(AwsElastiCacheReplicationGroup)
 
     def validate_update_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "add_tags_to_resource"
+        assert kwargs["action"] == "add-tags-to-resource"
         assert kwargs["ResourceName"] == resource.arn
         assert kwargs["Tags"] == [{"Key": "foo", "Value": "bar"}]
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "remove_tags_from_resource"
+        assert kwargs["action"] == "remove-tags-from-resource"
         assert kwargs["ResourceName"] == resource.arn
         assert kwargs["TagKeys"] == ["foo"]
 
@@ -44,7 +44,7 @@ def test_replication_group_deletion() -> None:
     group, _ = round_trip_for(AwsElastiCacheReplicationGroup)
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_replication_group"
+        assert kwargs["action"] == "delete-replication-group"
         assert kwargs["ReplicationGroupId"] == group.id
         assert kwargs["RetainPrimaryCluster"] is False
 
@@ -56,7 +56,7 @@ def test_cluster_deletion() -> None:
     cluster, _ = round_trip_for(AwsElastiCacheCacheCluster)
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_cache_cluster"
+        assert kwargs["action"] == "delete-cache-cluster"
         assert kwargs["CacheClusterId"] == cluster.id
 
     client = cast(AwsClient, SimpleNamespace(call=validate_delete_args))

--- a/plugins/aws/test/resources/elb_test.py
+++ b/plugins/aws/test/resources/elb_test.py
@@ -14,7 +14,7 @@ def test_elb_deletion() -> None:
     elb, _ = round_trip_for(AwsElb, "public_ip_address")
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_load_balancer"
+        assert kwargs["action"] == "delete-load-balancer"
         assert kwargs["LoadBalancerName"] == elb.name
 
     client = cast(AwsClient, SimpleNamespace(call=validate_delete_args))
@@ -25,12 +25,12 @@ def test_tagging() -> None:
     elb, _ = round_trip_for(AwsElb, "public_ip_address")
 
     def validate_update_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "add_tags"
+        assert kwargs["action"] == "add-tags"
         assert kwargs["LoadBalancerNames"] == [elb.name]
         assert kwargs["Tags"] == [{"Key": "foo", "Value": "bar"}]
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "remove_tags"
+        assert kwargs["action"] == "remove-tags"
         assert kwargs["LoadBalancerNames"] == [elb.name]
         assert kwargs["Tags"] == [{"Key": "foo"}]
 

--- a/plugins/aws/test/resources/elbv2_test.py
+++ b/plugins/aws/test/resources/elbv2_test.py
@@ -15,7 +15,7 @@ def test_alb_deletion() -> None:
     alb, _ = round_trip_for(AwsAlb)
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_load_balancer"
+        assert kwargs["action"] == "delete-load-balancer"
         assert kwargs["LoadBalancerArn"] == alb.arn
 
     client = cast(AwsClient, SimpleNamespace(call=validate_delete_args))
@@ -26,7 +26,7 @@ def test_alb_target_group_deletion() -> None:
     alb, _ = round_trip_for(AwsAlbTargetGroup)
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_target_group"
+        assert kwargs["action"] == "delete-target-group"
         assert kwargs["TargetGroupArn"] == alb.arn
 
     client = cast(AwsClient, SimpleNamespace(call=validate_delete_args))
@@ -42,12 +42,12 @@ def test_tagging() -> None:
     elb, _ = round_trip_for(AwsAlb)
 
     def validate_update_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "add_tags"
+        assert kwargs["action"] == "add-tags"
         assert kwargs["ResourceArns"] == [elb.arn]
         assert kwargs["Tags"] == [{"Key": "foo", "Value": "bar"}]
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "remove_tags"
+        assert kwargs["action"] == "remove-tags"
         assert kwargs["ResourceArns"] == [elb.arn]
         assert kwargs["TagKeys"] == ["foo"]
 

--- a/plugins/aws/test/resources/iam_test.py
+++ b/plugins/aws/test/resources/iam_test.py
@@ -57,7 +57,7 @@ def test_server_certificate_deletion() -> None:
     res, _ = round_trip_for(AwsIamServerCertificate, "dns_names", "sha1_fingerprint")
 
     def validate_update_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_server_certificate"
+        assert kwargs["action"] == "delete-server-certificate"
         assert kwargs["ServerCertificateName"] == res.name
 
     client = cast(AwsClient, SimpleNamespace(call=validate_update_args))
@@ -69,7 +69,7 @@ def test_aws_iam_policy_deletion() -> None:
     res = builder.resources_of(AwsIamPolicy)[0]
 
     def validate_update_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_policy"
+        assert kwargs["action"] == "delete-policy"
         assert kwargs["PolicyArn"] == res.arn
 
     client = cast(AwsClient, SimpleNamespace(call=validate_update_args))
@@ -81,7 +81,7 @@ def test_aws_iam_group_deletion() -> None:
     res = builder.resources_of(AwsIamGroup)[0]
 
     def validate_update_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_group"
+        assert kwargs["action"] == "delete-group"
         assert kwargs["GroupName"] == res.name
 
     client = cast(AwsClient, SimpleNamespace(call=validate_update_args))
@@ -93,7 +93,7 @@ def test_aws_iam_role_deletion() -> None:
     res = builder.resources_of(AwsIamRole)[0]
 
     def validate_update_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_role"
+        assert kwargs["action"] == "delete-role"
         assert kwargs["RoleName"] == res.name
 
     client = cast(AwsClient, SimpleNamespace(call=validate_update_args))
@@ -105,7 +105,7 @@ def test_aws_iam_user_deletion() -> None:
     res = builder.resources_of(AwsIamUser)[0]
 
     def validate_update_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_user"
+        assert kwargs["action"] == "delete-user"
         assert kwargs["UserName"] == res.name
 
     client = cast(AwsClient, SimpleNamespace(call=validate_update_args))
@@ -116,7 +116,7 @@ def test_aws_iam_instance_profile_deletion() -> None:
     res, _ = round_trip_for(AwsIamInstanceProfile)
 
     def validate_update_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_instance_profile"
+        assert kwargs["action"] == "delete-instance-profile"
         assert kwargs["InstanceProfileName"] == res.name
 
     client = cast(AwsClient, SimpleNamespace(call=validate_update_args))
@@ -128,12 +128,12 @@ def test_tagging() -> None:
     res, _ = round_trip_for(AwsIamServerCertificate, "dns_names", "sha1_fingerprint")
 
     def validate_update_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "tag_server_certificate"
+        assert kwargs["action"] == "tag-server-certificate"
         assert kwargs["Tags"] == [{"Key": "foo", "Value": "bar"}]
         assert kwargs["ServerCertificateName"] == res.name
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "untag_server_certificate"
+        assert kwargs["action"] == "untag-server-certificate"
         assert kwargs["TagKeys"] == ["foo"]
         assert kwargs["ServerCertificateName"] == res.name
 

--- a/plugins/aws/test/resources/kinesis_test.py
+++ b/plugins/aws/test/resources/kinesis_test.py
@@ -15,12 +15,12 @@ def test_tagging() -> None:
     stream, _ = round_trip_for(AwsKinesisStream)
 
     def validate_update_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "add_tags_to_stream"
+        assert kwargs["action"] == "add-tags-to-stream"
         assert kwargs["StreamName"] == stream.name
         assert kwargs["Tags"] == {"foo": "bar"}
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "remove_tags_from_stream"
+        assert kwargs["action"] == "remove-tags-from-stream"
         assert kwargs["StreamName"] == stream.name
         assert kwargs["TagKeys"] == ["foo"]
 
@@ -35,7 +35,7 @@ def test_deletion() -> None:
     stream, _ = round_trip_for(AwsKinesisStream)
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_stream"
+        assert kwargs["action"] == "delete-stream"
         assert kwargs["StreamName"] == stream.name
 
     client = cast(AwsClient, SimpleNamespace(call=validate_delete_args))

--- a/plugins/aws/test/resources/lambda_test.py
+++ b/plugins/aws/test/resources/lambda_test.py
@@ -15,12 +15,12 @@ def test_tagging() -> None:
     res, _ = round_trip_for(AwsLambdaFunction)
 
     def validate_update_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "tag_resource"
+        assert kwargs["action"] == "tag-resource"
         assert kwargs["Tags"] == {"foo": "bar"}
         assert kwargs["Resource"] == res.arn
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "untag_resource"
+        assert kwargs["action"] == "untag-resource"
         assert kwargs["TagKeys"] == ["foo"]
         assert kwargs["Resource"] == res.arn
 
@@ -35,7 +35,7 @@ def test_deletion() -> None:
     res, _ = round_trip_for(AwsLambdaFunction)
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_function"
+        assert kwargs["action"] == "delete-function"
         assert kwargs["FunctionName"] == res.arn
 
     client = cast(AwsClient, SimpleNamespace(call=validate_delete_args))

--- a/plugins/aws/test/resources/rds_test.py
+++ b/plugins/aws/test/resources/rds_test.py
@@ -15,12 +15,12 @@ def test_tagging() -> None:
     instance, _ = round_trip_for(AwsRdsInstance)
 
     def validate_update_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "add_tags_to_resource"
+        assert kwargs["action"] == "add-tags-to-resource"
         assert kwargs["ResourceName"] == instance.arn
         assert kwargs["Tags"] == [{"Key": "foo", "Value": "bar"}]
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "remove_tags_from_resource"
+        assert kwargs["action"] == "remove-tags-from-resource"
         assert kwargs["ResourceName"] == instance.arn
         assert kwargs["TagKeys"] == ["foo"]
 
@@ -35,7 +35,7 @@ def test_deletion() -> None:
     instance, _ = round_trip_for(AwsRdsInstance)
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_db_instance"
+        assert kwargs["action"] == "delete-db-instance"
         assert kwargs["DBInstanceIdentifier"] == instance.name
         assert kwargs["SkipFinalSnapshot"] is True
 

--- a/plugins/aws/test/resources/redshift_test.py
+++ b/plugins/aws/test/resources/redshift_test.py
@@ -16,12 +16,12 @@ def test_tagging() -> None:
     cluster, _ = round_trip_for(AwsRedshiftCluster)
 
     def validate_update_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "create_tags"
+        assert kwargs["action"] == "create-tags"
         assert kwargs["ResourceName"] == cluster.arn
         assert kwargs["Tags"] == [{"Key": "foo", "Value": "bar"}]
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_tags"
+        assert kwargs["action"] == "delete-tags"
         assert kwargs["ResourceName"] == cluster.arn
         assert kwargs["TagKeys"] == ["foo"]
 
@@ -36,7 +36,7 @@ def test_deletion() -> None:
     cluster, _ = round_trip_for(AwsRedshiftCluster)
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "delete_cluster"
+        assert kwargs["action"] == "delete-cluster"
         assert kwargs["ClusterIdentifier"] == cluster.id
         assert kwargs["SkipFinalClusterSnapshot"] is True
 

--- a/plugins/aws/test/resources/service_quotas_test.py
+++ b/plugins/aws/test/resources/service_quotas_test.py
@@ -93,12 +93,12 @@ def test_tagging() -> None:
     quota, _ = round_trip_for(AwsServiceQuota, "usage", "quota_type")
 
     def validate_update_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "tag_resource"
+        assert kwargs["action"] == "tag-resource"
         assert kwargs["ResourceARN"] == quota.arn
         assert kwargs["Tags"] == [{"Key": "foo", "Value": "bar"}]
 
     def validate_delete_args(**kwargs: Any) -> None:
-        assert kwargs["action"] == "untag_resource"
+        assert kwargs["action"] == "untag-resource"
         assert kwargs["ResourceARN"] == quota.arn
         assert kwargs["TagKeys"] == ["foo"]
 


### PR DESCRIPTION
# Description
We can already retrieve the list of called APIs during collect.
This PR provides the same functionality for mutating API calls.
<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
