### PR TITLE
[resotocore][fix] Turn on WebSocket pings

### DIFF
--- a/resotolib/resotolib/asynchronous/web/ws_handler.py
+++ b/resotolib/resotolib/asynchronous/web/ws_handler.py
@@ -49,7 +49,7 @@ async def accept_websocket(
     initial_messages: Optional[Sequence[Any]] = None,
     outgoing_fn: Callable[[T], str] = js_str,
 ) -> WebSocketResponse:
-    ws = WebSocketResponse()
+    ws = WebSocketResponse(autoping=True, heartbeat=20)
     await ws.prepare(request)
     wsid = str(uuid1())
 

--- a/resotolib/resotolib/core/actions.py
+++ b/resotolib/resotolib/core/actions.py
@@ -156,7 +156,7 @@ class CoreActions(threading.Thread):
             sslopt = None
             if self.tls_data:
                 sslopt = {"ca_certs": self.tls_data.ca_cert_path}
-            self.ws.run_forever(sslopt=sslopt, ping_interval=30, ping_timeout=10, ping_payload="ping")
+            self.ws.run_forever(sslopt=sslopt, ping_interval=20, ping_timeout=10, ping_payload="ping")
         finally:
             self.ws = None
 

--- a/resotolib/resotolib/core/events.py
+++ b/resotolib/resotolib/core/events.py
@@ -61,7 +61,7 @@ class CoreEvents(threading.Thread):
         sslopt = None
         if self.tls_data:
             sslopt = {"ca_certs": self.tls_data.ca_cert_path}
-        self.ws.run_forever(sslopt=sslopt, ping_interval=30, ping_timeout=10, ping_payload="ping")
+        self.ws.run_forever(sslopt=sslopt, ping_interval=20, ping_timeout=10, ping_payload="ping")
 
     def shutdown(self, event: Event = None) -> None:
         log.debug("Received shutdown event - shutting down resotocore event bus listener")

--- a/resotolib/resotolib/core/tasks.py
+++ b/resotolib/resotolib/core/tasks.py
@@ -181,7 +181,7 @@ class CoreTasks(threading.Thread):
         sslopt = None
         if self.tls_data:
             sslopt = {"ca_certs": self.tls_data.ca_cert_path}
-        self.ws.run_forever(sslopt=sslopt, ping_interval=30, ping_timeout=10, ping_payload="ping")
+        self.ws.run_forever(sslopt=sslopt, ping_interval=20, ping_timeout=10, ping_payload="ping")
 
     def shutdown(self, event: Event = None) -> None:
         log.debug("Received shutdown event - shutting down resotocore task queue listener")


### PR DESCRIPTION
# Description

Turn on resotocore (server) based WebSocket pings
Also reduce interval for resotoworker and resotometrics initiated (client) pings from 30 to 20s

Websocket Pings can be initiated on the server as well as the client side. So far we only used client side pings. Since the UI has no explicit support for WebSocket client side pings this turns on server side pings in the core.

From [the Mozilla spec](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_servers#pings_and_pongs_the_heartbeat_of_websockets):
```
At any point after the handshake, either the client or the server
can choose to send a ping to the other party. When the ping is
received, the recipient must send back a pong as soon as possible.
You can use this to make sure that the client is still connected,
for example.

A ping or pong is just a regular frame, but it's a control frame.
Pings have an opcode of 0x9, and pongs have an opcode of 0xA.
When you get a ping, send back a pong with the exact same
Payload Data as the ping (for pings and pongs, the max payload length
is 125). You might also get a pong without ever sending a ping;
ignore this if it happens.
```

[rfc6455](https://www.rfc-editor.org/rfc/rfc6455#section-5.5.2) specifies that clients MUST implement ping/pong. I.e. it's not an optional feature and safe to assume that every WebSocket client supports it.
```
[5.5.2](https://www.rfc-editor.org/rfc/rfc6455#section-5.5.2).  Ping

   The Ping frame contains an opcode of 0x9.

   A Ping frame MAY include "Application data".

   Upon receipt of a Ping frame, an endpoint MUST send a Pong frame in
   response, unless it already received a Close frame.  It SHOULD
   respond with Pong frame as soon as is practical.  Pong frames are
   discussed in [Section 5.5.3](https://www.rfc-editor.org/rfc/rfc6455#section-5.5.3).

   An endpoint MAY send a Ping frame any time after the connection is
   established and before the connection is closed.

   NOTE: A Ping frame may serve either as a keepalive or as a means to
   verify that the remote endpoint is still responsive.
```

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
