### PR TITLE
[resotolib][fix] Initialize empty config to {}

### DIFF
--- a/resotolib/resotolib/config.py
+++ b/resotolib/resotolib/config.py
@@ -147,6 +147,8 @@ class Config(metaclass=MetaConfig):
     def read_config(config: Json) -> Dict[str, Any]:
         new_config = {}
         for config_id, config_data in config.items():
+            if config_data is None:
+                config_data = {}
             if config_id in Config.running_config.classes:
                 log.debug(f"Loading config section {config_id}")
                 clazz: Type[Any] = Config.running_config.classes.get(config_id, Any)


### PR DESCRIPTION
# Description

Initialize empty config to {} to support configs that contain no further items, like
```
aws:
```


# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
