### PR TITLE
[resotocore][feat] Allow relative time in history command

### DIFF
--- a/resotocore/resotocore/cli/__init__.py
+++ b/resotocore/resotocore/cli/__init__.py
@@ -1,11 +1,13 @@
 import re
 from argparse import ArgumentParser
+from datetime import datetime
 from functools import lru_cache
 from typing import TypeVar, Union, Any, Callable, AsyncIterator, NoReturn, Optional, Awaitable, Tuple, List
 
 from aiostream.core import Stream
 from parsy import Parser, regex
 
+from resotolib.durations import parse_duration, DurationRe
 from resotolib.parse_util import (
     make_parser,
     literal_dp,
@@ -21,7 +23,7 @@ from resotolib.parse_util import (
 )
 from resotocore.model.graph_access import Section
 from resotocore.types import JsonElement
-from resotocore.util import AnyT
+from resotocore.util import AnyT, utc, parse_utc
 
 T = TypeVar("T")
 # Allow the function to return either a coroutine or the result directly
@@ -111,6 +113,11 @@ def parse_path_index(path: str) -> Tuple[str, Union[bool, int, None]]:
             raise ValueError(f"Invalid path index: {path}")
     else:
         return path, None
+
+
+# Is able to read iso timestamps: 2020-01-01T00:00:00.000Z, as well as durations like 1d, 3h, 5m, 10s
+def parse_time_or_delta(time_or_delta: str) -> datetime:
+    return utc() - parse_duration(time_or_delta) if DurationRe.fullmatch(time_or_delta) else parse_utc(time_or_delta)
 
 
 def js_value_get(element: JsonElement, path_or_name: Union[List[str], str], if_none: AnyT) -> AnyT:

--- a/resotocore/tests/resotocore/cli/command_test.py
+++ b/resotocore/tests/resotocore/cli/command_test.py
@@ -1000,15 +1000,14 @@ async def test_history(cli: CLI, filled_graph_db: ArangoGraphDB) -> None:
     five_min_later = utc_str(now + timedelta(minutes=5))
     assert await history_count("history") == 113  # 112 inserts and 1 update for the filled graph db
     assert await history_count(f"history --after {five_min_ago}") == 113
+    assert await history_count(f"history --after 5m") == 113
     assert await history_count(f"history --after {five_min_later}") == 0
     assert await history_count(f"history --before {five_min_ago}") == 0
+    assert await history_count(f"history --before 5m") == 0
     assert await history_count(f"history --change node_created") == 112
     assert await history_count(f"history --change node_updated") == 1
     assert await history_count(f"history --change node_deleted") == 0
     assert await history_count(f"history --change node_deleted") == 0
     assert await history_count(f"history is(foo)") == 11
     # combine all selectors
-    assert (
-        await history_count(f"history --after {five_min_ago} --before {five_min_later} --change node_created is(foo)")
-        == 11
-    )
+    assert await history_count(f"history --after 5m --before {five_min_later} --change node_created is(foo)") == 11


### PR DESCRIPTION
# Description

Instead of absolute time, allow defining `2h` or `1d` as time, which is interpreted as time delta from now.
<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`


# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
