### PR TITLE
[plugins/aws][fix] Add AwsCloudwatchMetricData API calls to collect api call list

### DIFF
--- a/plugins/aws/resoto_plugin_aws/collector.py
+++ b/plugins/aws/resoto_plugin_aws/collector.py
@@ -92,6 +92,7 @@ def called_collect_apis() -> List[AwsApiSpec]:
         AwsApiSpec("iam", "list-account-aliases"),
         AwsApiSpec("organizations", "list-accounts"),
     ]
+    additional_calls += cloudwatch.AwsCloudwatchMetricData.called_collect_apis()
     specs = [spec for r in all_resources for spec in r.called_collect_apis()] + additional_calls
     return sorted(specs, key=lambda s: s.service + "::" + s.api_action)
 


### PR DESCRIPTION
Add AwsCloudwatchMetricData API calls to collect api call list

Was currently missing, as AwsCloudwatchMetricData is not being collected directly, but as part of other resources like EBS volumes and databases.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
