### PR TITLE
[resotocore][feat] Allow to search nested complex objects inside arrays

### DIFF
--- a/resotocore/resotocore/cli/command.py
+++ b/resotocore/resotocore/cli/command.py
@@ -2346,7 +2346,7 @@ class ListCommand(CLICommand, OutputTransformer):
             # add all predicates the user has queried
             if ctx.query:
                 # add all predicates the user has queried
-                predicate_names = (p.name for p in ctx.query.predicates)
+                predicate_names = (p.name for p in ctx.query.visible_predicates)
                 # add sort keys of the last part the user has defined
                 sort_names = (s.name for s in ctx.query.current_part.sort)
                 for name in chain(predicate_names, sort_names):

--- a/resotocore/resotocore/query/model.py
+++ b/resotocore/resotocore/query/model.py
@@ -660,7 +660,7 @@ class Part:
             return self
 
     @property
-    def predicates(self) -> List[Predicate]:
+    def visible_predicates(self) -> List[Predicate]:
         result: List[Predicate] = self.term.find_terms(lambda x: isinstance(x, Predicate))  # type: ignore
         for ctx in self.term.find_terms(lambda x: isinstance(x, ContextTerm)):
             result.extend(ctx.visible_predicates())  # type: ignore
@@ -980,11 +980,11 @@ class Query:
         return Query(parts, preamble, aggregate)
 
     @property
-    def predicates(self) -> List[Predicate]:
+    def visible_predicates(self) -> List[Predicate]:
         """
         Returns a list of all predicates in this query.
         """
-        return [pred for part in self.parts for pred in part.predicates]
+        return [pred for part in self.parts for pred in part.visible_predicates]
 
     def find_terms(self, fn: Callable[[Term], bool]) -> List[Term]:
         return [t for p in self.parts for t in p.term.find_terms(fn)]

--- a/resotocore/setup.cfg
+++ b/resotocore/setup.cfg
@@ -18,7 +18,7 @@ universal = 1
 max-line-length = 120
 exclude = .git,.tox,__pycache__,.idea,.pytest_cache,docs
 application-import-names = resotocore tests
-ignore = E1131, N818, W503
+ignore = E1131, N818, W503, E203
 
 
 [aliases]

--- a/resotocore/tests/resotocore/cli/command_test.py
+++ b/resotocore/tests/resotocore/cli/command_test.py
@@ -569,7 +569,18 @@ async def test_kinds_command(cli: CLI, foo_model: Model) -> None:
     assert result[0][0] == {
         "name": "datetime",
         "runtime_kind": "datetime",
-        "appears_in": ["base", "foo", "bla", "cloud", "account", "region", "parent", "child", "predefined_properties"],
+        "appears_in": [
+            "base",
+            "foo",
+            "bla",
+            "cloud",
+            "account",
+            "region",
+            "parent",
+            "child",
+            "some_complex",
+            "predefined_properties",
+        ],
     }
     with pytest.raises(Exception):
         await cli.execute_cli_command("kind foo bla bar", stream.list)

--- a/resotocore/tests/resotocore/db/graphdb_test.py
+++ b/resotocore/tests/resotocore/db/graphdb_test.py
@@ -217,7 +217,20 @@ def foo_kinds() -> List[Kind]:
     region = ComplexKind("region", ["foo"], [])
     parent = ComplexKind("parent", ["foo"], [])
     child = ComplexKind("child", ["foo"], [])
-    return [base, foo, bla, cloud, account, region, parent, child, inner]
+    some_complex = ComplexKind(
+        "some_complex",
+        ["base"],
+        [
+            Property("cloud", "cloud"),
+            Property("account", "account"),
+            Property("parents", "parent[]"),
+            Property("children", "child[]"),
+            Property("nested", "inner[]"),
+        ],
+        successor_kinds={EdgeTypes.default: ["bla"]},
+    )
+
+    return [base, foo, bla, cloud, account, region, parent, child, inner, some_complex]
 
 
 @pytest.fixture

--- a/resotocore/tests/resotocore/model/model_test.py
+++ b/resotocore/tests/resotocore/model/model_test.py
@@ -301,7 +301,7 @@ def test_property_path_on_model(person_model: Model) -> None:
     # complex based property path
     person: ComplexKind = cast(ComplexKind, person_model["Person"])
     person_path = {p.path: p for p in person.resolved_properties()}
-    assert len(person_path) == 20
+    assert len(person_path) == 35
     assert person_path[PropertyPath(["name"])].kind == person_model["string"]
     assert person_path[PropertyPath(["name"])].prop.name == "name"
     assert person_path[PropertyPath(["list[]"])].kind == person_model["string"]
@@ -326,6 +326,9 @@ def test_property_path_on_model(person_model: Model) -> None:
     assert person_model.kind_by_path("addresses[23].zip") == person_model["zip"]
     assert person_model.kind_by_path("other_addresses") == DictionaryKind(string_kind, person_model["Address"])
     assert person_model.kind_by_path("other_addresses.test") == person_model["Address"]
+
+    # properties in hierarchy (tags is defined in base) works as well
+    assert person_model.kind_by_path("tags.owner") == person_model["string"]
 
 
 def test_update(person_model: Model) -> None:

--- a/resotocore/tests/resotocore/query/model_test.py
+++ b/resotocore/tests/resotocore/query/model_test.py
@@ -18,6 +18,7 @@ from resotocore.query.model import (
     NotTerm,
     FunctionTerm,
     Limit,
+    ContextTerm,
 )
 from resotocore.query.query_parser import parse_query
 
@@ -258,3 +259,9 @@ def test_term_contains() -> None:
     assert term.contains_term_type(Predicate) is True
     assert term.contains_term_type(NotTerm) is True
     assert term.contains_term_type(FunctionTerm) is False
+
+
+def test_context_predicates() -> None:
+    term: ContextTerm = parse_query("a.b[*].{ a=2 and b[1].bla=3 and c.d[*].{ e=4 and f=5 } }").parts[0].term  # type: ignore
+    expected = ["a.b[*].a", "a.b[*].b[1].bla", "a.b[*].e", "a.b[*].f", "a.b[*].c.d[*].e", "a.b[*].c.d[*].f"]
+    assert [str(a.name) for a in term.visible_predicates()] == expected

--- a/resotolib/resotolib/parse_util.py
+++ b/resotolib/resotolib/parse_util.py
@@ -62,10 +62,10 @@ variable_dp_backtick_allowed = regex(r"[^`]+")
 variable_dp_backtick = backtick_dp + variable_dp_backtick_allowed + backtick_dp
 variable_dp_part_string = regex("[A-Za-z_][A-Za-z0-9_\\-]*")
 variable_dp_part_plain = regex("[.]*")
-variable_dp_part_extra = regex("[0-9.*\\[\\]]*")
 variable_dp_part = variable_dp_part_string | variable_dp_backtick
+variable_dp_array_part = variable_dp_part + regex("(\\[[0-9\\*]*\\])*")
 optional_slash = slash.at_most(1).concat()
-variable_dp = optional_slash + (variable_dp_part + variable_dp_part_extra).at_least(1).map("".join)
+variable_dp = optional_slash + variable_dp_array_part + (dot_dp + variable_dp_array_part).many().map("".join)
 variable_no_array_dp = optional_slash + (variable_dp_part + variable_dp_part_plain).at_least(1).map("".join)
 
 
@@ -164,6 +164,7 @@ colon_p = lexeme(colon_dp)
 semicolon_p = lexeme(semicolon_dp)
 comma_p = lexeme(comma_dp)
 pipe_p = lexeme(pipe_dp)
+dot_p = lexeme(dot_dp)
 dot_dot_p = lexeme(dot_dot_dp)
 equals_p = lexeme(equals_dp)
 true_p = lexeme(true_dp)


### PR DESCRIPTION
# Description

This PR improves the capability of the Search DSL in Resoto. It allows to express patterns in objects inside arrays.
A simple predicate can look into arrays. Using the `[*]` it is possible to match any object inside an array.
If we have more than one predicate that we want to match inside an object inside an array, we can not simply use the `[*]` operator twice for each predicate, since each predicate matches on its own - there is no way to "bundle" 2 or more predicates. This PR introduces a context term, that allows exactly this.

Example using  an AWS security gateway (excerpt):
```json
{
  "id": "sg-123",
  "tags": {},
  "name": "redirus-master",
  "description": "redirus Master Security Group",
  "group_ip_permissions": [
    {
      "from_port": 80,
      "to_port": 80,
      "ip_protocol": "tcp",
      "ip_ranges": [
        { "cidr_ip": "0.0.0.0/0" }
      ]
    },
    {
      "from_port": 22,
      "to_port": 22,
      "ip_protocol": "tcp",
      "ip_ranges": [
        { "cidr_ip": "3.3.175.2/32" },
        { "cidr_ip": "4.4.119.97/32", "description": "Office access" }
      ]
    }
  ]
}
```

If we want to select gateways that allow ssh access (port 22) from everywhere, we need to select:
- filter for kind aws_security_gateway
- check for all group permissions that match: from_port >= 22, to_port <= 22 and at least one cidr that contains 0.0.0.0.

We could write a search that filters each single criteria:

```python
search is(aws_ec2_security_group) and group_ip_permissions[*].from_port>=22 and group_ip_permissions[*].to_port<=22 and group_ip_permissions[*].ip_ranges[*].cidr_ip~"0.0.0.0"
```

This query would eventually match more items than expected, since every filter criteria has to be fulfilled in at least one of the group permissions (e.g. there is one permission with from_port==to_port==22 but no cidr~"0.0.0.0" and another permission with cidr~"0.0.0.0" but with a different port).
What we actually wanted to express: all of the criteria should match in any of the nested complex objects.

The change made in this PR allows defining the context of the filter criteria, so it becomes clear, which filter criteria belong together and looks like this:

```python
search is(aws_ec2_security_group) and group_ip_permissions[*].{from_port>=22, to_port<=22, ip_ranges[*].cidr_ip~"0.0.0.0"} 
```

The term `group_ip_permission[*].{ xxxx }` says : look into the property group_ip_permission which is an array. Any element that matches the filters in { xxxx } will do. Instead of the [*] we could also define a number, which then would be interpreted as index of the array.

Every single group_ip_permission will be matched with the filters: `from_port>=22`, `to_port<=22`, `ip_ranges[*].cidr_ip~"0.0.0.0"`.

It would even be possible to nest context criterions. Example

```python
search is(aws_ec2_security_group) and group_ip_permissions[*].{from_port>=22, to_port<=22, ip_ranges[*].{ cidr_ip~"0.0.0.0", description!="Office access" }} 
```

<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`
- [ ] Document new or updated functionality (someengineering/resoto.com#XXXX)


# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
