### PR TITLE
[resotocore][fix] Ignore predicates in context for list rendering

### DIFF
--- a/resotocore/tests/resotocore/query/model_test.py
+++ b/resotocore/tests/resotocore/query/model_test.py
@@ -18,7 +18,6 @@ from resotocore.query.model import (
     NotTerm,
     FunctionTerm,
     Limit,
-    ContextTerm,
 )
 from resotocore.query.query_parser import parse_query
 
@@ -262,6 +261,6 @@ def test_term_contains() -> None:
 
 
 def test_context_predicates() -> None:
-    term: ContextTerm = parse_query("a.b[*].{ a=2 and b[1].bla=3 and c.d[*].{ e=4 and f=5 } }").parts[0].term  # type: ignore
-    expected = ["a.b[*].a", "a.b[*].b[1].bla", "a.b[*].e", "a.b[*].f", "a.b[*].c.d[*].e", "a.b[*].c.d[*].f"]
-    assert [str(a.name) for a in term.visible_predicates()] == expected
+    query: Query = parse_query("a.b[*].{ a=2 and b[1].bla=3 and c.d[*].{ e=4 and f=5 } }")
+    expected = ["a.b[*].a", "a.b[*].b[1].bla", "a.b[*].c.d[*].e", "a.b[*].c.d[*].f"]
+    assert [str(a.name) for a in query.visible_predicates] == expected


### PR DESCRIPTION
# Description

Before:
```
> search is(aws_ec2_security_group) and name=launch-wizard-2 and group_ip_permissions[*].{ip_protocol = tcp and from_port >= 22 and to_port <= 22 and ip_ranges[*].{cidr_ip = "0.0.0.0/0"}} limit 1
kind=aws_ec2_security_group, id=sg-02b33740af7f83e95, name=launch-wizard-2, ip_protocol=[tcp], from_port=[22], to_port=[22], cidr_ip=[None], cidr_ip=[['0.0.0.0/0']], age=19d6h, cloud=aws, account=eng-production, region=us-west-2
```
It renders this output: `cidr_ip=[None]` which is coming from a non existing predicate path.

After:
```
> search is(aws_ec2_security_group) and name=launch-wizard-2 and group_ip_permissions[*].{ip_protocol = tcp and from_port >= 22 and to_port <= 22 and ip_ranges[*].{cidr_ip = "0.0.0.0/0"}} limit 1
kind=aws_ec2_security_group, id=sg-02b33740af7f83e95, name=launch-wizard-2, ip_protocol=[tcp], from_port=[22], to_port=[22], cidr_ip=[['0.0.0.0/0']], age=19d7h, cloud=aws, account=eng-production, region=us-west-2
```

<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [ ] Add test coverage for new or updated functionality
- [ ] Lint and test with `tox`
- [ ] Document new or updated functionality (someengineering/resoto.com#XXXX)

# Issues Fixed

<!-- If this PR will fix/resolve an open issue on the repository, please reference it below. -->
<!-- (Otherwise, feel free to delete this section.) -->

- Fixes #XXXX

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
