### PR TITLE
[resoto][chore] Add files required to run setup

### DIFF
--- a/plugins/aws/MANIFEST.in
+++ b/plugins/aws/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/plugins/aws/MANIFEST.in
+++ b/plugins/aws/MANIFEST.in
@@ -1,1 +1,2 @@
+include README.md
 include requirements.txt

--- a/plugins/aws/setup.py
+++ b/plugins/aws/setup.py
@@ -1,12 +1,12 @@
 import os
+
+import pkg_resources
 from setuptools import setup, find_packages
 
-with open("requirements.txt") as f:
-    requirements = f.read().splitlines()
 
-
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+def read(file_name: str) -> str:
+    with open(os.path.join(os.path.dirname(__file__), file_name)) as of:
+        return of.read()
 
 
 setup(
@@ -22,7 +22,7 @@ setup(
     },
     include_package_data=True,
     zip_safe=False,
-    install_requires=requirements,
+    install_requires=[str(requirement) for requirement in pkg_resources.parse_requirements(read("requirements.txt"))],
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     classifiers=[

--- a/plugins/aws_k8s/MANIFEST.in
+++ b/plugins/aws_k8s/MANIFEST.in
@@ -1,4 +1,2 @@
-include README.md
 include requirements.txt
 include requirements-test.txt
-include resotolib/web/static/*

--- a/plugins/aws_k8s/MANIFEST.in
+++ b/plugins/aws_k8s/MANIFEST.in
@@ -1,2 +1,3 @@
+include README.md
 include requirements.txt
 include requirements-test.txt

--- a/plugins/aws_k8s/setup.py
+++ b/plugins/aws_k8s/setup.py
@@ -1,12 +1,11 @@
 import os
+import pkg_resources
 from setuptools import setup, find_packages
 
-with open("requirements.txt") as f:
-    requirements = f.read().splitlines()
 
-
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+def read(file_name: str) -> str:
+    with open(os.path.join(os.path.dirname(__file__), file_name)) as of:
+        return of.read()
 
 
 setup(
@@ -20,7 +19,7 @@ setup(
     entry_points={"resoto.plugins": ["aws_k8s_collector = resoto_plugin_aws_k8s:AWSK8sCollectorPlugin"]},
     include_package_data=True,
     zip_safe=False,
-    install_requires=requirements,
+    install_requires=[str(requirement) for requirement in pkg_resources.parse_requirements(read("requirements.txt"))],
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     classifiers=[

--- a/plugins/cleanup_aws_alarms/MANIFEST.in
+++ b/plugins/cleanup_aws_alarms/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/plugins/cleanup_aws_alarms/MANIFEST.in
+++ b/plugins/cleanup_aws_alarms/MANIFEST.in
@@ -1,1 +1,2 @@
+include README.md
 include requirements.txt

--- a/plugins/cleanup_aws_alarms/setup.py
+++ b/plugins/cleanup_aws_alarms/setup.py
@@ -1,12 +1,11 @@
 import os
+import pkg_resources
 from setuptools import setup, find_packages
 
-with open("requirements.txt") as f:
-    requirements = f.read().splitlines()
 
-
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+def read(file_name: str) -> str:
+    with open(os.path.join(os.path.dirname(__file__), file_name)) as of:
+        return of.read()
 
 
 setup(
@@ -20,7 +19,7 @@ setup(
     entry_points={"resoto.plugins": ["cleanup_aws_alarms = resoto_plugin_cleanup_aws_alarms:CleanupAWSAlarmsPlugin"]},
     include_package_data=True,
     zip_safe=False,
-    install_requires=requirements,
+    install_requires=[str(requirement) for requirement in pkg_resources.parse_requirements(read("requirements.txt"))],
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     classifiers=[

--- a/plugins/cleanup_aws_loadbalancers/MANIFEST.in
+++ b/plugins/cleanup_aws_loadbalancers/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/plugins/cleanup_aws_loadbalancers/MANIFEST.in
+++ b/plugins/cleanup_aws_loadbalancers/MANIFEST.in
@@ -1,1 +1,2 @@
+include README.md
 include requirements.txt

--- a/plugins/cleanup_aws_loadbalancers/setup.py
+++ b/plugins/cleanup_aws_loadbalancers/setup.py
@@ -1,12 +1,11 @@
 import os
+import pkg_resources
 from setuptools import setup, find_packages
 
-with open("requirements.txt") as f:
-    requirements = f.read().splitlines()
 
-
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+def read(file_name: str) -> str:
+    with open(os.path.join(os.path.dirname(__file__), file_name)) as of:
+        return of.read()
 
 
 setup(
@@ -24,7 +23,7 @@ setup(
     },
     include_package_data=True,
     zip_safe=False,
-    install_requires=requirements,
+    install_requires=[str(requirement) for requirement in pkg_resources.parse_requirements(read("requirements.txt"))],
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     classifiers=[

--- a/plugins/cleanup_aws_vpcs/MANIFEST.in
+++ b/plugins/cleanup_aws_vpcs/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/plugins/cleanup_aws_vpcs/MANIFEST.in
+++ b/plugins/cleanup_aws_vpcs/MANIFEST.in
@@ -1,1 +1,2 @@
+include README.md
 include requirements.txt

--- a/plugins/cleanup_aws_vpcs/setup.py
+++ b/plugins/cleanup_aws_vpcs/setup.py
@@ -1,12 +1,11 @@
 import os
+import pkg_resources
 from setuptools import setup, find_packages
 
-with open("requirements.txt") as f:
-    requirements = f.read().splitlines()
 
-
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+def read(file_name: str) -> str:
+    with open(os.path.join(os.path.dirname(__file__), file_name)) as of:
+        return of.read()
 
 
 setup(
@@ -20,7 +19,7 @@ setup(
     entry_points={"resoto.plugins": ["cleanup_aws_vpcs = resoto_plugin_cleanup_aws_vpcs:CleanupAWSVPCsPlugin"]},
     include_package_data=True,
     zip_safe=False,
-    install_requires=requirements,
+    install_requires=[str(requirement) for requirement in pkg_resources.parse_requirements(read("requirements.txt"))],
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     classifiers=[

--- a/plugins/cleanup_expired/MANIFEST.in
+++ b/plugins/cleanup_expired/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/plugins/cleanup_expired/MANIFEST.in
+++ b/plugins/cleanup_expired/MANIFEST.in
@@ -1,1 +1,2 @@
+include README.md
 include requirements.txt

--- a/plugins/cleanup_expired/setup.py
+++ b/plugins/cleanup_expired/setup.py
@@ -1,12 +1,10 @@
 import os
+import pkg_resources
 from setuptools import setup, find_packages
 
-with open("requirements.txt") as f:
-    requirements = f.read().splitlines()
-
-
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+def read(file_name: str) -> str:
+    with open(os.path.join(os.path.dirname(__file__), file_name)) as of:
+        return of.read()
 
 
 setup(
@@ -20,7 +18,7 @@ setup(
     entry_points={"resoto.plugins": ["cleanup_expired = resoto_plugin_cleanup_expired:CleanupExpiredPlugin"]},
     include_package_data=True,
     zip_safe=False,
-    install_requires=requirements,
+    install_requires=[str(requirement) for requirement in pkg_resources.parse_requirements(read("requirements.txt"))],
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     classifiers=[

--- a/plugins/cleanup_untagged/MANIFEST.in
+++ b/plugins/cleanup_untagged/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/plugins/cleanup_untagged/MANIFEST.in
+++ b/plugins/cleanup_untagged/MANIFEST.in
@@ -1,1 +1,2 @@
+include README.md
 include requirements.txt

--- a/plugins/cleanup_untagged/setup.py
+++ b/plugins/cleanup_untagged/setup.py
@@ -1,12 +1,11 @@
 import os
+import pkg_resources
 from setuptools import setup, find_packages
 
-with open("requirements.txt") as f:
-    requirements = f.read().splitlines()
 
-
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+def read(file_name: str) -> str:
+    with open(os.path.join(os.path.dirname(__file__), file_name)) as of:
+        return of.read()
 
 
 setup(
@@ -20,7 +19,7 @@ setup(
     entry_points={"resoto.plugins": ["cleanup_untagged = resoto_plugin_cleanup_untagged:CleanupUntaggedPlugin"]},
     include_package_data=True,
     zip_safe=False,
-    install_requires=requirements,
+    install_requires=[str(requirement) for requirement in pkg_resources.parse_requirements(read("requirements.txt"))],
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     classifiers=[

--- a/plugins/cleanup_volumes/MANIFEST.in
+++ b/plugins/cleanup_volumes/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/plugins/cleanup_volumes/MANIFEST.in
+++ b/plugins/cleanup_volumes/MANIFEST.in
@@ -1,1 +1,2 @@
+include README.md
 include requirements.txt

--- a/plugins/cleanup_volumes/setup.py
+++ b/plugins/cleanup_volumes/setup.py
@@ -1,12 +1,11 @@
 import os
+import pkg_resources
 from setuptools import setup, find_packages
 
-with open("requirements.txt") as f:
-    requirements = f.read().splitlines()
 
-
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+def read(file_name: str) -> str:
+    with open(os.path.join(os.path.dirname(__file__), file_name)) as of:
+        return of.read()
 
 
 setup(
@@ -20,7 +19,7 @@ setup(
     entry_points={"resoto.plugins": ["cleanup_volumes = resoto_plugin_cleanup_volumes:CleanupVolumesPlugin"]},
     include_package_data=True,
     zip_safe=False,
-    install_requires=requirements,
+    install_requires=[str(requirement) for requirement in pkg_resources.parse_requirements(read("requirements.txt"))],
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     classifiers=[

--- a/plugins/digitalocean/MANIFEST.in
+++ b/plugins/digitalocean/MANIFEST.in
@@ -1,4 +1,2 @@
-include README.md
 include requirements.txt
 include requirements-test.txt
-include resotolib/web/static/*

--- a/plugins/digitalocean/MANIFEST.in
+++ b/plugins/digitalocean/MANIFEST.in
@@ -1,2 +1,3 @@
+include README.md
 include requirements.txt
 include requirements-test.txt

--- a/plugins/digitalocean/setup.py
+++ b/plugins/digitalocean/setup.py
@@ -1,12 +1,11 @@
 import os
+import pkg_resources
 from setuptools import setup, find_packages
 
-with open("requirements.txt") as f:
-    requirements = f.read().splitlines()
 
-
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+def read(file_name: str) -> str:
+    with open(os.path.join(os.path.dirname(__file__), file_name)) as of:
+        return of.read()
 
 
 setup(
@@ -22,7 +21,7 @@ setup(
     },
     include_package_data=True,
     zip_safe=False,
-    install_requires=requirements,
+    install_requires=[str(requirement) for requirement in pkg_resources.parse_requirements(read("requirements.txt"))],
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     classifiers=[

--- a/plugins/digitalocean_k8s/MANIFEST.in
+++ b/plugins/digitalocean_k8s/MANIFEST.in
@@ -1,4 +1,2 @@
-include README.md
 include requirements.txt
 include requirements-test.txt
-include resotolib/web/static/*

--- a/plugins/digitalocean_k8s/MANIFEST.in
+++ b/plugins/digitalocean_k8s/MANIFEST.in
@@ -1,2 +1,3 @@
+include README.md
 include requirements.txt
 include requirements-test.txt

--- a/plugins/digitalocean_k8s/setup.py
+++ b/plugins/digitalocean_k8s/setup.py
@@ -1,12 +1,11 @@
 import os
+import pkg_resources
 from setuptools import setup, find_packages
 
-with open("requirements.txt") as f:
-    requirements = f.read().splitlines()
 
-
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+def read(file_name: str) -> str:
+    with open(os.path.join(os.path.dirname(__file__), file_name)) as of:
+        return of.read()
 
 
 setup(
@@ -22,7 +21,7 @@ setup(
     },
     include_package_data=True,
     zip_safe=False,
-    install_requires=requirements,
+    install_requires=[str(requirement) for requirement in pkg_resources.parse_requirements(read("requirements.txt"))],
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     classifiers=[

--- a/plugins/dockerhub/MANIFEST.in
+++ b/plugins/dockerhub/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/plugins/dockerhub/MANIFEST.in
+++ b/plugins/dockerhub/MANIFEST.in
@@ -1,1 +1,2 @@
+include README.md
 include requirements.txt

--- a/plugins/dockerhub/setup.py
+++ b/plugins/dockerhub/setup.py
@@ -1,12 +1,11 @@
 import os
+import pkg_resources
 from setuptools import setup, find_packages
 
-with open("requirements.txt") as f:
-    requirements = f.read().splitlines()
 
-
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+def read(file_name: str) -> str:
+    with open(os.path.join(os.path.dirname(__file__), file_name)) as of:
+        return of.read()
 
 
 setup(
@@ -20,7 +19,7 @@ setup(
     entry_points={"resoto.plugins": ["dockerhub = resoto_plugin_dockerhub:DockerHubCollectorPlugin"]},
     include_package_data=True,
     zip_safe=False,
-    install_requires=requirements,
+    install_requires=[str(requirement) for requirement in pkg_resources.parse_requirements(read("requirements.txt"))],
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     classifiers=[

--- a/plugins/example_collector/MANIFEST.in
+++ b/plugins/example_collector/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/plugins/example_collector/MANIFEST.in
+++ b/plugins/example_collector/MANIFEST.in
@@ -1,1 +1,2 @@
+include README.md
 include requirements.txt

--- a/plugins/example_collector/setup.py
+++ b/plugins/example_collector/setup.py
@@ -1,12 +1,11 @@
 import os
+import pkg_resources
 from setuptools import setup, find_packages
 
-with open("requirements.txt") as f:
-    requirements = f.read().splitlines()
 
-
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+def read(file_name: str) -> str:
+    with open(os.path.join(os.path.dirname(__file__), file_name)) as of:
+        return of.read()
 
 
 setup(
@@ -20,7 +19,7 @@ setup(
     entry_points={"resoto.plugins": ["example_collector = resoto_plugin_example_collector:ExampleCollectorPlugin"]},
     include_package_data=True,
     zip_safe=False,
-    install_requires=requirements,
+    install_requires=[str(requirement) for requirement in pkg_resources.parse_requirements(read("requirements.txt"))],
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     classifiers=[

--- a/plugins/gcp/MANIFEST.in
+++ b/plugins/gcp/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/plugins/gcp/MANIFEST.in
+++ b/plugins/gcp/MANIFEST.in
@@ -1,1 +1,2 @@
+include README.md
 include requirements.txt

--- a/plugins/gcp/setup.py
+++ b/plugins/gcp/setup.py
@@ -1,12 +1,11 @@
 import os
+import pkg_resources
 from setuptools import setup, find_packages
 
-with open("requirements.txt") as f:
-    requirements = f.read().splitlines()
 
-
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+def read(file_name: str) -> str:
+    with open(os.path.join(os.path.dirname(__file__), file_name)) as of:
+        return of.read()
 
 
 setup(
@@ -20,7 +19,7 @@ setup(
     entry_points={"resoto.plugins": ["gcp = resoto_plugin_gcp:GCPCollectorPlugin"]},
     include_package_data=True,
     zip_safe=False,
-    install_requires=requirements,
+    install_requires=[str(requirement) for requirement in pkg_resources.parse_requirements(read("requirements.txt"))],
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     classifiers=[

--- a/plugins/github/MANIFEST.in
+++ b/plugins/github/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/plugins/github/MANIFEST.in
+++ b/plugins/github/MANIFEST.in
@@ -1,1 +1,2 @@
+include README.md
 include requirements.txt

--- a/plugins/github/setup.py
+++ b/plugins/github/setup.py
@@ -1,12 +1,11 @@
 import os
+import pkg_resources
 from setuptools import setup, find_packages
 
-with open("requirements.txt") as f:
-    requirements = f.read().splitlines()
 
-
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+def read(file_name: str) -> str:
+    with open(os.path.join(os.path.dirname(__file__), file_name)) as of:
+        return of.read()
 
 
 setup(
@@ -20,7 +19,7 @@ setup(
     entry_points={"resoto.plugins": ["github = resoto_plugin_github:GithubCollectorPlugin"]},
     include_package_data=True,
     zip_safe=False,
-    install_requires=requirements,
+    install_requires=[str(requirement) for requirement in pkg_resources.parse_requirements(read("requirements.txt"))],
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     classifiers=[

--- a/plugins/k8s/MANIFEST.in
+++ b/plugins/k8s/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/plugins/k8s/MANIFEST.in
+++ b/plugins/k8s/MANIFEST.in
@@ -1,1 +1,2 @@
+include README.md
 include requirements.txt

--- a/plugins/k8s/setup.py
+++ b/plugins/k8s/setup.py
@@ -1,12 +1,11 @@
 import os
+import pkg_resources
 from setuptools import setup, find_packages
 
-with open("requirements.txt") as f:
-    requirements = f.read().splitlines()
 
-
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+def read(file_name: str) -> str:
+    with open(os.path.join(os.path.dirname(__file__), file_name)) as of:
+        return of.read()
 
 
 setup(
@@ -20,7 +19,7 @@ setup(
     entry_points={"resoto.plugins": ["k8s_collector = resoto_plugin_k8s:KubernetesCollectorPlugin"]},
     include_package_data=True,
     zip_safe=False,
-    install_requires=requirements,
+    install_requires=[str(requirement) for requirement in pkg_resources.parse_requirements(read("requirements.txt"))],
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     classifiers=[

--- a/plugins/onelogin/MANIFEST.in
+++ b/plugins/onelogin/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/plugins/onelogin/MANIFEST.in
+++ b/plugins/onelogin/MANIFEST.in
@@ -1,1 +1,2 @@
+include README.md
 include requirements.txt

--- a/plugins/onelogin/setup.py
+++ b/plugins/onelogin/setup.py
@@ -1,12 +1,11 @@
 import os
+import pkg_resources
 from setuptools import setup, find_packages
 
-with open("requirements.txt") as f:
-    requirements = f.read().splitlines()
 
-
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+def read(file_name: str) -> str:
+    with open(os.path.join(os.path.dirname(__file__), file_name)) as of:
+        return of.read()
 
 
 setup(
@@ -20,7 +19,7 @@ setup(
     entry_points={"resoto.plugins": ["onelogin = resoto_plugin_onelogin:OneLoginPlugin"]},
     include_package_data=True,
     zip_safe=False,
-    install_requires=requirements,
+    install_requires=[str(requirement) for requirement in pkg_resources.parse_requirements(read("requirements.txt"))],
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     classifiers=[

--- a/plugins/onprem/MANIFEST.in
+++ b/plugins/onprem/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/plugins/onprem/MANIFEST.in
+++ b/plugins/onprem/MANIFEST.in
@@ -1,1 +1,2 @@
+include README.md
 include requirements.txt

--- a/plugins/onprem/setup.py
+++ b/plugins/onprem/setup.py
@@ -1,12 +1,11 @@
 import os
+import pkg_resources
 from setuptools import setup, find_packages
 
-with open("requirements.txt") as f:
-    requirements = f.read().splitlines()
 
-
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+def read(file_name: str) -> str:
+    with open(os.path.join(os.path.dirname(__file__), file_name)) as of:
+        return of.read()
 
 
 setup(
@@ -20,7 +19,7 @@ setup(
     entry_points={"resoto.plugins": ["onprem = resoto_plugin_onprem:OnpremCollectorPlugin"]},
     include_package_data=True,
     zip_safe=False,
-    install_requires=requirements,
+    install_requires=[str(requirement) for requirement in pkg_resources.parse_requirements(read("requirements.txt"))],
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     classifiers=[

--- a/plugins/posthog/MANIFEST.in
+++ b/plugins/posthog/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/plugins/posthog/MANIFEST.in
+++ b/plugins/posthog/MANIFEST.in
@@ -1,1 +1,2 @@
+include README.md
 include requirements.txt

--- a/plugins/posthog/setup.py
+++ b/plugins/posthog/setup.py
@@ -1,12 +1,11 @@
 import os
+import pkg_resources
 from setuptools import setup, find_packages
 
-with open("requirements.txt") as f:
-    requirements = f.read().splitlines()
 
-
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+def read(file_name: str) -> str:
+    with open(os.path.join(os.path.dirname(__file__), file_name)) as of:
+        return of.read()
 
 
 setup(
@@ -20,7 +19,7 @@ setup(
     entry_points={"resoto.plugins": ["posthog = resoto_plugin_posthog:PosthogCollectorPlugin"]},
     include_package_data=True,
     zip_safe=False,
-    install_requires=requirements,
+    install_requires=[str(requirement) for requirement in pkg_resources.parse_requirements(read("requirements.txt"))],
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     classifiers=[

--- a/plugins/protector/MANIFEST.in
+++ b/plugins/protector/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/plugins/protector/MANIFEST.in
+++ b/plugins/protector/MANIFEST.in
@@ -1,1 +1,2 @@
+include README.md
 include requirements.txt

--- a/plugins/protector/setup.py
+++ b/plugins/protector/setup.py
@@ -1,12 +1,11 @@
 import os
+import pkg_resources
 from setuptools import setup, find_packages
 
-with open("requirements.txt") as f:
-    requirements = f.read().splitlines()
 
-
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+def read(file_name: str) -> str:
+    with open(os.path.join(os.path.dirname(__file__), file_name)) as of:
+        return of.read()
 
 
 setup(
@@ -20,7 +19,7 @@ setup(
     entry_points={"resoto.plugins": ["protector = resoto_plugin_protector:ProtectorPlugin"]},
     include_package_data=True,
     zip_safe=False,
-    install_requires=requirements,
+    install_requires=[str(requirement) for requirement in pkg_resources.parse_requirements(read("requirements.txt"))],
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     classifiers=[

--- a/plugins/random/MANIFEST.in
+++ b/plugins/random/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/plugins/random/MANIFEST.in
+++ b/plugins/random/MANIFEST.in
@@ -1,1 +1,2 @@
+include README.md
 include requirements.txt

--- a/plugins/random/setup.py
+++ b/plugins/random/setup.py
@@ -1,12 +1,11 @@
 import os
+import pkg_resources
 from setuptools import setup, find_packages
 
-with open("requirements.txt") as f:
-    requirements = f.read().splitlines()
 
-
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+def read(file_name: str) -> str:
+    with open(os.path.join(os.path.dirname(__file__), file_name)) as of:
+        return of.read()
 
 
 setup(
@@ -20,7 +19,7 @@ setup(
     entry_points={"resoto.plugins": ["random = resoto_plugin_random:RandomCollectorPlugin"]},
     include_package_data=True,
     zip_safe=False,
-    install_requires=requirements,
+    install_requires=[str(requirement) for requirement in pkg_resources.parse_requirements(read("requirements.txt"))],
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     classifiers=[

--- a/plugins/scarf/MANIFEST.in
+++ b/plugins/scarf/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/plugins/scarf/MANIFEST.in
+++ b/plugins/scarf/MANIFEST.in
@@ -1,1 +1,2 @@
+include README.md
 include requirements.txt

--- a/plugins/scarf/setup.py
+++ b/plugins/scarf/setup.py
@@ -1,12 +1,11 @@
 import os
+import pkg_resources
 from setuptools import setup, find_packages
 
-with open("requirements.txt") as f:
-    requirements = f.read().splitlines()
 
-
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+def read(file_name: str) -> str:
+    with open(os.path.join(os.path.dirname(__file__), file_name)) as of:
+        return of.read()
 
 
 setup(
@@ -20,7 +19,7 @@ setup(
     entry_points={"resoto.plugins": ["scarf = resoto_plugin_scarf:ScarfCollectorPlugin"]},
     include_package_data=True,
     zip_safe=False,
-    install_requires=requirements,
+    install_requires=[str(requirement) for requirement in pkg_resources.parse_requirements(read("requirements.txt"))],
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     classifiers=[

--- a/plugins/slack/MANIFEST.in
+++ b/plugins/slack/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/plugins/slack/MANIFEST.in
+++ b/plugins/slack/MANIFEST.in
@@ -1,1 +1,2 @@
+include README.md
 include requirements.txt

--- a/plugins/slack/setup.py
+++ b/plugins/slack/setup.py
@@ -1,12 +1,11 @@
 import os
+import pkg_resources
 from setuptools import setup, find_packages
 
-with open("requirements.txt") as f:
-    requirements = f.read().splitlines()
 
-
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+def read(file_name: str) -> str:
+    with open(os.path.join(os.path.dirname(__file__), file_name)) as of:
+        return of.read()
 
 
 setup(
@@ -23,7 +22,7 @@ setup(
             "slack_collector = resoto_plugin_slack:SlackCollectorPlugin",
         ]
     },
-    install_requires=requirements,
+    install_requires=[str(requirement) for requirement in pkg_resources.parse_requirements(read("requirements.txt"))],
     include_package_data=True,
     zip_safe=False,
     setup_requires=["pytest-runner"],

--- a/plugins/tagvalidator/MANIFEST.in
+++ b/plugins/tagvalidator/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/plugins/tagvalidator/MANIFEST.in
+++ b/plugins/tagvalidator/MANIFEST.in
@@ -1,1 +1,2 @@
+include README.md
 include requirements.txt

--- a/plugins/tagvalidator/setup.py
+++ b/plugins/tagvalidator/setup.py
@@ -1,12 +1,11 @@
 import os
+import pkg_resources
 from setuptools import setup, find_packages
 
-with open("requirements.txt") as f:
-    requirements = f.read().splitlines()
 
-
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+def read(file_name: str) -> str:
+    with open(os.path.join(os.path.dirname(__file__), file_name)) as of:
+        return of.read()
 
 
 setup(
@@ -20,7 +19,7 @@ setup(
     entry_points={"resoto.plugins": ["tagvalidator = resoto_plugin_tagvalidator:TagValidatorPlugin"]},
     include_package_data=True,
     zip_safe=False,
-    install_requires=requirements,
+    install_requires=[str(requirement) for requirement in pkg_resources.parse_requirements(read("requirements.txt"))],
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     classifiers=[

--- a/plugins/vsphere/MANIFEST.in
+++ b/plugins/vsphere/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/plugins/vsphere/MANIFEST.in
+++ b/plugins/vsphere/MANIFEST.in
@@ -1,1 +1,2 @@
+include README.md
 include requirements.txt

--- a/plugins/vsphere/setup.py
+++ b/plugins/vsphere/setup.py
@@ -1,12 +1,11 @@
 import os
+import pkg_resources
 from setuptools import setup, find_packages
 
-with open("requirements.txt") as f:
-    requirements = f.read().splitlines()
 
-
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+def read(file_name: str) -> str:
+    with open(os.path.join(os.path.dirname(__file__), file_name)) as of:
+        return of.read()
 
 
 setup(
@@ -20,7 +19,7 @@ setup(
     entry_points={"resoto.plugins": ["vsphere = resoto_plugin_vsphere:VSphereCollectorPlugin"]},
     include_package_data=True,
     zip_safe=False,
-    install_requires=requirements,
+    install_requires=[str(requirement) for requirement in pkg_resources.parse_requirements(read("requirements.txt"))],
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     classifiers=[

--- a/resotocore/MANIFEST.in
+++ b/resotocore/MANIFEST.in
@@ -1,3 +1,4 @@
+include README.md
 include requirements-dev.txt
 include requirements-test.txt
 include requirements.txt

--- a/resotocore/setup.py
+++ b/resotocore/setup.py
@@ -5,22 +5,20 @@
 from setuptools import setup, find_packages
 from setuptools.command.develop import develop
 from subprocess import check_call
+import os
+import pkg_resources
 
-with open("requirements.txt") as f:
-    required = f.read().splitlines()
 
-with open("requirements-dev.txt") as f:
-    dev_required = f.read().splitlines()
+def read(file_name: str) -> str:
+    with open(os.path.join(os.path.dirname(__file__), file_name)) as of:
+        return of.read()
 
-with open("requirements-test.txt") as f:
-    test_required = f.read().splitlines()
 
-with open("README.md") as f:
-    readme = f.read()
+def read_requirements(fname):
+    return [str(requirement) for requirement in pkg_resources.parse_requirements(read(fname))]
 
-setup_requirements = [
-    "pytest-runner",
-]
+
+setup_requirements = ["pytest-runner"]
 
 
 class PostDevelopCommand(develop):
@@ -46,15 +44,15 @@ setup(
     python_requires=">=3.5",
     classifiers=["Programming Language :: Python :: 3"],
     entry_points={"console_scripts": ["resotocore=resotocore.__main__:main"]},
-    install_requires=required,
+    install_requires=read_requirements("requirements.txt"),
     license="Apache Software License 2.0",
-    long_description=readme,
+    long_description=read("README.md"),
     long_description_content_type="text/markdown",
     include_package_data=True,
     packages=find_packages(include=["resotocore", "resotocore.*"]),
     setup_requires=setup_requirements,
     test_suite="tests",
-    tests_require=dev_required + test_required,
+    tests_require=read_requirements("requirements-dev.txt") + read_requirements("requirements-test.txt"),
     url="https://github.com/someengineering/resoto/resotocore",
     cmdclass={
         "develop": PostDevelopCommand,

--- a/resotoeventlog/MANIFEST.in
+++ b/resotoeventlog/MANIFEST.in
@@ -1,3 +1,4 @@
+include README.md
 include requirements-dev.txt
 include requirements-test.txt
 include requirements.txt

--- a/resotoeventlog/setup.py
+++ b/resotoeventlog/setup.py
@@ -3,22 +3,20 @@
 """The setup script."""
 
 from setuptools import setup, find_packages
+import pkg_resources
+import os
 
-with open("requirements.txt") as f:
-    required = f.read().splitlines()
 
-with open("requirements-dev.txt") as f:
-    dev_required = f.read().splitlines()
+def read(file_name: str) -> str:
+    with open(os.path.join(os.path.dirname(__file__), file_name)) as of:
+        return of.read()
 
-with open("requirements-test.txt") as f:
-    test_required = f.read().splitlines()
 
-with open("README.md") as f:
-    readme = f.read()
+def read_requirements(fname):
+    return [str(requirement) for requirement in pkg_resources.parse_requirements(read(fname))]
 
-setup_requirements = [
-    "pytest-runner",
-]
+
+setup_requirements = ["pytest-runner"]
 
 setup(
     name="resotoeventlog",
@@ -27,14 +25,14 @@ setup(
     python_requires=">=3.5",
     classifiers=["Programming Language :: Python :: 3"],
     entry_points={"console_scripts": ["resotoeventlog=resotoeventlog.__main__:main"]},
-    install_requires=required,
+    install_requires=read_requirements("requirements.txt"),
     license="Apache Software License 2.0",
-    long_description=readme,
+    long_description=read("README.md"),
     long_description_content_type="text/markdown",
     include_package_data=True,
     packages=find_packages(include=["resotoeventlog", "resotoeventlog.*"]),
     setup_requires=setup_requirements,
     test_suite="tests",
-    tests_require=dev_required + test_required,
+    tests_require=read_requirements("requirements-dev.txt") + read_requirements("requirements-test.txt"),
     url="https://github.com/someengineering/resoto/resotoeventlog",
 )

--- a/resotolib/setup.py
+++ b/resotolib/setup.py
@@ -1,12 +1,12 @@
+import os
 import resotolib
+import pkg_resources
 from setuptools import setup, find_packages
 
 
-with open("requirements.txt") as f:
-    requirements = f.read().splitlines()
-
-with open("README.md") as f:
-    readme = f.read()
+def read(file_name: str) -> str:
+    with open(os.path.join(os.path.dirname(__file__), file_name)) as of:
+        return of.read()
 
 
 setup(
@@ -16,11 +16,11 @@ setup(
     license=resotolib.__license__,
     packages=find_packages(),
     package_data={"resotolib": ["py.typed"]},
-    long_description=readme,
+    long_description=read("README.md"),
     long_description_content_type="text/markdown",
     include_package_data=True,
     zip_safe=False,
-    install_requires=requirements,
+    install_requires=[str(requirement) for requirement in pkg_resources.parse_requirements(read("requirements.txt"))],
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     classifiers=[

--- a/resotometrics/setup.py
+++ b/resotometrics/setup.py
@@ -1,12 +1,12 @@
+import os
+import pkg_resources
 import resotometrics
 from setuptools import setup, find_packages
 
 
-with open("requirements.txt") as f:
-    requirements = f.read().splitlines()
-
-with open("README.md") as f:
-    readme = f.read()
+def read(file_name: str) -> str:
+    with open(os.path.join(os.path.dirname(__file__), file_name)) as of:
+        return of.read()
 
 
 setup(
@@ -15,7 +15,7 @@ setup(
     description=resotometrics.__description__,
     license=resotometrics.__license__,
     packages=find_packages(),
-    long_description=readme,
+    long_description=read("README.md"),
     long_description_content_type="text/markdown",
     entry_points={
         "console_scripts": [
@@ -24,7 +24,7 @@ setup(
     },
     include_package_data=True,
     zip_safe=False,
-    install_requires=requirements,
+    install_requires=[str(requirement) for requirement in pkg_resources.parse_requirements(read("requirements.txt"))],
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     classifiers=[

--- a/resotoshell/MANIFEST.in
+++ b/resotoshell/MANIFEST.in
@@ -1,3 +1,2 @@
 include README.md
 include requirements.txt
-include resotometrics/default_metrics.yaml

--- a/resotoshell/setup.py
+++ b/resotoshell/setup.py
@@ -1,13 +1,12 @@
+import os
+import pkg_resources
 import resotoshell
 from setuptools import setup, find_packages
 
 
-with open("requirements.txt") as f:
-    requirements = f.read().splitlines()
-
-with open("README.md") as f:
-    readme = f.read()
-
+def read(file_name: str) -> str:
+    with open(os.path.join(os.path.dirname(__file__), file_name)) as of:
+        return of.read()
 
 setup(
     name=resotoshell.__title__,
@@ -15,7 +14,7 @@ setup(
     description=resotoshell.__description__,
     license=resotoshell.__license__,
     packages=find_packages(),
-    long_description=readme,
+    long_description=read("README.md"),
     long_description_content_type="text/markdown",
     entry_points={
         "console_scripts": [
@@ -24,7 +23,7 @@ setup(
     },
     include_package_data=True,
     zip_safe=False,
-    install_requires=requirements,
+    install_requires=[str(requirement) for requirement in pkg_resources.parse_requirements(read("requirements.txt"))],
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     classifiers=[

--- a/resotoworker/MANIFEST.in
+++ b/resotoworker/MANIFEST.in
@@ -1,3 +1,2 @@
 include README.md
 include requirements.txt
-include resotometrics/default_metrics.yaml

--- a/resotoworker/setup.py
+++ b/resotoworker/setup.py
@@ -1,12 +1,12 @@
 import resotoworker
+import os
+import pkg_resources
 from setuptools import setup, find_packages
 
 
-with open("requirements.txt") as f:
-    requirements = f.read().splitlines()
-
-with open("README.md") as f:
-    readme = f.read()
+def read(file_name: str) -> str:
+    with open(os.path.join(os.path.dirname(__file__), file_name)) as of:
+        return of.read()
 
 
 setup(
@@ -15,7 +15,7 @@ setup(
     description=resotoworker.__description__,
     license=resotoworker.__license__,
     packages=find_packages(),
-    long_description=readme,
+    long_description=read("README.md"),
     long_description_content_type="text/markdown",
     entry_points={
         "console_scripts": [
@@ -24,7 +24,7 @@ setup(
     },
     include_package_data=True,
     zip_safe=False,
-    install_requires=requirements,
+    install_requires=[str(requirement) for requirement in pkg_resources.parse_requirements(read("requirements.txt"))],
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     classifiers=[


### PR DESCRIPTION
# Description

Tried to install the `aws plugin` via brew and got this error:

```
Using pip 22.3.1 from /opt/homebrew/Cellar/cloud2sql/0.6.2/libexec/lib/python3.10/site-packages/pip (python 3.10)
Processing /private/tmp/cloud2sql--resoto-plugin-aws-20221227-72147-1ww1s8t/resoto-plugin-aws-3.0.2
  Preparing metadata (setup.py): started
  Running command python setup.py egg_info
  Traceback (most recent call last):
    File "<string>", line 2, in <module>
    File "<pip-setuptools-caller>", line 34, in <module>
    File "/private/tmp/cloud2sql--resoto-plugin-aws-20221227-72147-1ww1s8t/resoto-plugin-aws-3.0.2/setup.py", line 4, in <module>
      with open("requirements.txt") as f:
  FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'
  error: subprocess-exited-with-error  
```

The files referenced in setup.py are not part of the package.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
