### PR TITLE
[ci][chore] Add docker-compose.yaml artifact to releases

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -361,7 +361,6 @@ jobs:
           fi
 
       - name: Check out repository
-        if: steps.release.outputs.prerelease == 'false'
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -386,6 +385,11 @@ jobs:
         working-directory: ./resoto.com
         run: |
           yarn run docusaurus docs:version "${{steps.release.outputs.docsVersion}}"
+
+      - name: Generate versioned Docker Compose YAML
+        shell: bash
+        run: |
+          sed -i 's/edge/${{steps.release.outputs.tag}}/g' docker-compose.yaml
 
       - name: Generate release notes
         if: steps.release.outputs.prerelease == 'false'
@@ -476,6 +480,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: ${{steps.release.outputs.prerelease}}
           bodyFile: release_body.txt
+          artifacts: docker-compose.yaml
 
       - name: Check out someengineering/helm-charts
         uses: actions/checkout@v3


### PR DESCRIPTION
# Description

Generate `docker-compose.yaml` referencing the appropriate tag upon the creation of each release, and add it as a release artifact.

This change will also need to be  cherrypicked back to the 2.4 branch, in case we tag a bugfix release in the future.

# To-Dos

- [x] Verify changes in someengineering/playground
- [x] Document new or updated functionality (someengineering/resoto.com#544)

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
