### PR TITLE
[aws][feat] Do not unregister during shutdown

### DIFF
--- a/resotolib/resotolib/core/actions.py
+++ b/resotolib/resotolib/core/actions.py
@@ -164,11 +164,6 @@ class CoreActions(threading.Thread):
         remove_event_listener(EventType.SHUTDOWN, self.shutdown)
         log.debug("Received shutdown event - shutting down resotocore message bus listener")
         self.shutdown_event.set()
-        for core_action in self.actions.keys():
-            try:
-                self.unregister(core_action)
-            except Exception as e:
-                log.error(e)
         self.executor.shutdown(wait=False, cancel_futures=True)
         if self.ws:
             self.ws.close()


### PR DESCRIPTION
# Description

If the worker is not online for a couple of seconds, no user should care.
All jobs/tasks and workflows would need to wait for a certain amount of time for the worker to reappear.

<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`
- [x] Document new or updated functionality (someengineering/resoto.com#XXXX)


# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
