### PR TITLE
[aws][fix] fix deletion dependencies with EC2 Subnets and EC2 Security Groups

### DIFF
--- a/plugins/aws/resoto_plugin_aws/resource/ecs.py
+++ b/plugins/aws/resoto_plugin_aws/resource/ecs.py
@@ -1285,6 +1285,8 @@ class AwsEcsService(EcsTaggable, AwsResource):
         for subnet in sum(all_subnets, []):
             builder.dependant_node(
                 self,
+                reverse=True,
+                delete_same_as_default=True,
                 clazz=AwsEc2Subnet,
                 id=subnet,
             )

--- a/plugins/aws/resoto_plugin_aws/resource/ecs.py
+++ b/plugins/aws/resoto_plugin_aws/resource/ecs.py
@@ -1279,6 +1279,8 @@ class AwsEcsService(EcsTaggable, AwsResource):
         for group in sum(all_sec_groups, []):
             builder.dependant_node(
                 self,
+                reverse=True,
+                delete_same_as_default=True,
                 clazz=AwsEc2SecurityGroup,
                 id=group,
             )

--- a/plugins/aws/resoto_plugin_aws/resource/elasticache.py
+++ b/plugins/aws/resoto_plugin_aws/resource/elasticache.py
@@ -289,7 +289,9 @@ class AwsElastiCacheCacheCluster(ElastiCacheTaggable, AwsResource):
 
     def connect_in_graph(self, builder: GraphBuilder, source: Json) -> None:
         for sg in self.cluster_security_groups:
-            builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=sg.security_group_id)
+            builder.dependant_node(
+                self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=sg.security_group_id
+            )
 
 
 @define(eq=False, slots=False)

--- a/plugins/aws/resoto_plugin_aws/resource/elasticache.py
+++ b/plugins/aws/resoto_plugin_aws/resource/elasticache.py
@@ -289,7 +289,7 @@ class AwsElastiCacheCacheCluster(ElastiCacheTaggable, AwsResource):
 
     def connect_in_graph(self, builder: GraphBuilder, source: Json) -> None:
         for sg in self.cluster_security_groups:
-            builder.dependant_node(self, reverse=True, clazz=AwsEc2SecurityGroup, id=sg.security_group_id)
+            builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=sg.security_group_id)
 
 
 @define(eq=False, slots=False)

--- a/plugins/aws/resoto_plugin_aws/resource/elb.py
+++ b/plugins/aws/resoto_plugin_aws/resource/elb.py
@@ -5,7 +5,7 @@ from attrs import define, field
 from resoto_plugin_aws.resource.base import AwsResource, GraphBuilder, AwsApiSpec
 from resoto_plugin_aws.resource.ec2 import AwsEc2Subnet, AwsEc2SecurityGroup, AwsEc2Vpc, AwsEc2Instance
 from resoto_plugin_aws.utils import ToDict
-from resotolib.baseresources import BaseLoadBalancer, EdgeType, ModelReference
+from resotolib.baseresources import BaseLoadBalancer, ModelReference
 from resotolib.json_bender import Bender, S, Bend, bend, ForallBend, K
 from resotolib.types import Json
 from resoto_plugin_aws.aws_client import AwsClient
@@ -223,7 +223,7 @@ class AwsElb(ElbTaggable, AwsResource, BaseLoadBalancer):
         for subnet_id in source.get("Subnets", []):
             builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet_id)
         for sg_id in source.get("SecurityGroups", []):
-            builder.dependant_node(self, EdgeType.default, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=sg_id)
+            builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=sg_id)
         for instance in self.backends:
             builder.dependant_node(self, clazz=AwsEc2Instance, id=instance)
 

--- a/plugins/aws/resoto_plugin_aws/resource/elb.py
+++ b/plugins/aws/resoto_plugin_aws/resource/elb.py
@@ -223,7 +223,7 @@ class AwsElb(ElbTaggable, AwsResource, BaseLoadBalancer):
         for subnet_id in source.get("Subnets", []):
             builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet_id)
         for sg_id in source.get("SecurityGroups", []):
-            builder.add_edge(self, EdgeType.default, reverse=True, clazz=AwsEc2SecurityGroup, id=sg_id)
+            builder.dependant_node(self, EdgeType.default, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=sg_id)
         for instance in self.backends:
             builder.dependant_node(self, clazz=AwsEc2Instance, id=instance)
 

--- a/plugins/aws/resoto_plugin_aws/resource/elbv2.py
+++ b/plugins/aws/resoto_plugin_aws/resource/elbv2.py
@@ -5,7 +5,7 @@ from attrs import define, field
 from resoto_plugin_aws.resource.base import AwsResource, GraphBuilder, AwsApiSpec
 from resoto_plugin_aws.resource.ec2 import AwsEc2Vpc, AwsEc2Subnet, AwsEc2Instance, AwsEc2SecurityGroup
 from resoto_plugin_aws.utils import ToDict
-from resotolib.baseresources import BaseLoadBalancer, EdgeType, ModelReference
+from resotolib.baseresources import BaseLoadBalancer, ModelReference
 from resotolib.json import from_json
 from resotolib.json_bender import Bender, S, Bend, bend, ForallBend, K
 from resotolib.types import Json
@@ -325,7 +325,7 @@ class AwsAlb(ElbV2Taggable, AwsResource, BaseLoadBalancer):
         if vpc_id := source.get("VpcId"):
             builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Vpc, id=vpc_id)
         for sg in self.alb_security_groups:
-            builder.dependant_node(self, EdgeType.default, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=sg)
+            builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=sg)
         for sn in self.alb_availability_zones:
             builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=sn.subnet_id)
 

--- a/plugins/aws/resoto_plugin_aws/resource/elbv2.py
+++ b/plugins/aws/resoto_plugin_aws/resource/elbv2.py
@@ -325,7 +325,7 @@ class AwsAlb(ElbV2Taggable, AwsResource, BaseLoadBalancer):
         if vpc_id := source.get("VpcId"):
             builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Vpc, id=vpc_id)
         for sg in self.alb_security_groups:
-            builder.add_edge(self, EdgeType.default, reverse=True, clazz=AwsEc2SecurityGroup, id=sg)
+            builder.dependant_node(self, EdgeType.default, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=sg)
         for sn in self.alb_availability_zones:
             builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=sn.subnet_id)
 

--- a/plugins/aws/resoto_plugin_aws/resource/lambda_.py
+++ b/plugins/aws/resoto_plugin_aws/resource/lambda_.py
@@ -327,7 +327,7 @@ class AwsLambdaFunction(AwsResource, BaseServerlessFunction):
                     self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet_id
                 )
             for security_group_id in vpc_config.get("SecurityGroupIds", []):
-                builder.add_edge(self, reverse=True, clazz=AwsEc2SecurityGroup, id=security_group_id)
+                builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group_id)
         if self.function_kms_key_arn:
             builder.dependant_node(
                 self,

--- a/plugins/aws/resoto_plugin_aws/resource/lambda_.py
+++ b/plugins/aws/resoto_plugin_aws/resource/lambda_.py
@@ -327,7 +327,9 @@ class AwsLambdaFunction(AwsResource, BaseServerlessFunction):
                     self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet_id
                 )
             for security_group_id in vpc_config.get("SecurityGroupIds", []):
-                builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group_id)
+                builder.dependant_node(
+                    self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group_id
+                )
         if self.function_kms_key_arn:
             builder.dependant_node(
                 self,

--- a/plugins/aws/resoto_plugin_aws/resource/redshift.py
+++ b/plugins/aws/resoto_plugin_aws/resource/redshift.py
@@ -427,7 +427,7 @@ class AwsRedshiftCluster(AwsResource):
 
         for vsg in self.redshift_vpc_security_groups:
             if vsg.vpc_security_group_id:
-                builder.dependant_node(self, reverse=True, clazz=AwsEc2SecurityGroup, id=vsg.vpc_security_group_id)
+                builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=vsg.vpc_security_group_id)
 
         for role in self.redshift_iam_roles:
             if role.iam_role_arn:

--- a/plugins/aws/resoto_plugin_aws/resource/redshift.py
+++ b/plugins/aws/resoto_plugin_aws/resource/redshift.py
@@ -436,7 +436,7 @@ class AwsRedshiftCluster(AwsResource):
                 )
 
         if self.redshift_cluster_subnet_group_name:
-            builder.dependant_node(self, reverse=True, clazz=AwsEc2Subnet, name=self.redshift_cluster_subnet_group_name)
+            builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, name=self.redshift_cluster_subnet_group_name)
 
         if self.redshift_kms_key_id:
             builder.dependant_node(self, clazz=AwsKmsKey, id=self.redshift_kms_key_id)

--- a/plugins/aws/resoto_plugin_aws/resource/redshift.py
+++ b/plugins/aws/resoto_plugin_aws/resource/redshift.py
@@ -427,7 +427,13 @@ class AwsRedshiftCluster(AwsResource):
 
         for vsg in self.redshift_vpc_security_groups:
             if vsg.vpc_security_group_id:
-                builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=vsg.vpc_security_group_id)
+                builder.dependant_node(
+                    self,
+                    reverse=True,
+                    delete_same_as_default=True,
+                    clazz=AwsEc2SecurityGroup,
+                    id=vsg.vpc_security_group_id,
+                )
 
         for role in self.redshift_iam_roles:
             if role.iam_role_arn:
@@ -436,7 +442,13 @@ class AwsRedshiftCluster(AwsResource):
                 )
 
         if self.redshift_cluster_subnet_group_name:
-            builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, name=self.redshift_cluster_subnet_group_name)
+            builder.dependant_node(
+                self,
+                reverse=True,
+                delete_same_as_default=True,
+                clazz=AwsEc2Subnet,
+                name=self.redshift_cluster_subnet_group_name,
+            )
 
         if self.redshift_kms_key_id:
             builder.dependant_node(self, clazz=AwsKmsKey, id=self.redshift_kms_key_id)

--- a/plugins/aws/resoto_plugin_aws/resource/sagemaker.py
+++ b/plugins/aws/resoto_plugin_aws/resource/sagemaker.py
@@ -139,7 +139,9 @@ class AwsSagemakerNotebook(SagemakerTaggable, AwsResource):
             builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet)
         if security_groups := value_in_path(source, "SecurityGroups"):
             for security_group in security_groups:
-                builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group)
+                builder.dependant_node(
+                    self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group
+                )
         if role_arn := value_in_path(source, "RoleArn"):
             builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsIamRole, arn=role_arn)
         if key := value_in_path(source, "KmsKeyId"):
@@ -734,7 +736,9 @@ class AwsSagemakerModel(SagemakerTaggable, AwsResource):
             builder.dependant_node(self, delete_same_as_default=True, clazz=AwsIamRole, arn=role_arn)
         if self.model_vpc_config:
             for security_group in self.model_vpc_config.security_group_ids:
-                builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group)
+                builder.dependant_node(
+                    self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group
+                )
             for subnet in self.model_vpc_config.subnets:
                 builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet)
 
@@ -1131,7 +1135,9 @@ class AwsSagemakerDomain(AwsResource):
                 )
             if security_groups := value_in_path(source, ["DefaultUserSettings", "SecurityGroups"]):
                 for security_group in security_groups:
-                    builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group)
+                    builder.dependant_node(
+                        self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group
+                    )
             if shs := dus.sharing_settings:
                 if shs.s3_output_path:
                     builder.add_edge(self, clazz=AwsS3Bucket, name=AwsS3Bucket.name_from_path(shs.s3_output_path))
@@ -1179,7 +1185,9 @@ class AwsSagemakerDomain(AwsResource):
 
         if ds := self.domain_settings:
             for security_group in ds.security_group_ids:
-                builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group)
+                builder.dependant_node(
+                    self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group
+                )
             if rss := ds.r_studio_server_pro_domain_settings:
                 if rss.domain_execution_role_arn:
                     builder.dependant_node(
@@ -1199,7 +1207,9 @@ class AwsSagemakerDomain(AwsResource):
                     self, reverse=True, delete_same_as_default=True, clazz=AwsIamRole, arn=dss.execution_role
                 )
             for security_group in dss.security_groups:
-                builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group)
+                builder.dependant_node(
+                    self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group
+                )
             if jup := dss.jupyter_server_app_settings:
                 if drs := jup.default_resource_spec:
                     if drs.sage_maker_image_arn:
@@ -2497,9 +2507,17 @@ class AwsSagemakerAutoMLJob(AwsSagemakerJob):
                     builder.dependant_node(self, clazz=AwsKmsKey, id=AwsKmsKey.normalise_id(sc.volume_kms_key_id))
                 if vpc := sc.vpc_config:
                     for security_group in vpc.security_group_ids:
-                        builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group)
+                        builder.dependant_node(
+                            self,
+                            reverse=True,
+                            delete_same_as_default=True,
+                            clazz=AwsEc2SecurityGroup,
+                            id=security_group,
+                        )
                     for subnet in vpc.subnets:
-                        builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet)
+                        builder.dependant_node(
+                            self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet
+                        )
             if jc.candidate_generation_config:
                 builder.add_edge(
                     self, clazz=AwsS3Bucket, name=AwsS3Bucket.name_from_path(jc.candidate_generation_config)
@@ -2647,7 +2665,9 @@ class AwsSagemakerCompilationJob(AwsSagemakerJob):
                 builder.dependant_node(self, clazz=AwsKmsKey, id=AwsKmsKey.normalise_id(oc.kms_key_id))
         if vpc := self.compilation_job_vpc_config:
             for security_group in vpc.security_group_ids:
-                builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group)
+                builder.dependant_node(
+                    self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group
+                )
             for subnet in vpc.subnets:
                 builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet)
 
@@ -3145,9 +3165,13 @@ class AwsSagemakerHyperParameterTuningJob(SagemakerTaggable, AwsSagemakerJob):
                             )
             if vpc := jobdef.vpc_config:
                 for security_group in vpc.security_group_ids:
-                    builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group)
+                    builder.dependant_node(
+                        self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group
+                    )
                 for subnet in vpc.subnets:
-                    builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet)
+                    builder.dependant_node(
+                        self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet
+                    )
             if odc := jobdef.output_data_config:
                 if odc.kms_key_id:
                     builder.dependant_node(self, clazz=AwsKmsKey, id=AwsKmsKey.normalise_id(odc.kms_key_id))
@@ -3481,9 +3505,13 @@ class AwsSagemakerInferenceRecommendationsJob(AwsSagemakerJob):
                         )
             if vpc := ic.vpc_config:
                 for security_group in vpc.security_group_ids:
-                    builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group)
+                    builder.dependant_node(
+                        self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group
+                    )
                 for subnet in vpc.subnets:
-                    builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet)
+                    builder.dependant_node(
+                        self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet
+                    )
         for rec in self.inference_recommendations_job_inference_recommendations:
             if ec := rec.endpoint_configuration:
                 if ec.endpoint_name:
@@ -3763,9 +3791,17 @@ class AwsSagemakerLabelingJob(SagemakerTaggable, AwsSagemakerJob):
                     builder.dependant_node(self, clazz=AwsKmsKey, id=AwsKmsKey.normalise_id(jrc.volume_kms_key_id))
                 if vpc := jrc.vpc_config:
                     for security_group in vpc.security_group_ids:
-                        builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group)
+                        builder.dependant_node(
+                            self,
+                            reverse=True,
+                            delete_same_as_default=True,
+                            clazz=AwsEc2SecurityGroup,
+                            id=security_group,
+                        )
                     for subnet in vpc.subnets:
-                        builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet)
+                        builder.dependant_node(
+                            self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet
+                        )
         if htc := self.labeling_job_human_task_config:
             if htc.workteam_arn:
                 builder.add_edge(self, reverse=True, clazz=AwsSagemakerWorkteam, arn=htc.workteam_arn)
@@ -4092,9 +4128,13 @@ class AwsSagemakerProcessingJob(AwsSagemakerJob):
         if nc := self.processing_job_network_config:
             if vpc := nc.vpc_config:
                 for security_group in vpc.security_group_ids:
-                    builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group)
+                    builder.dependant_node(
+                        self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group
+                    )
                 for subnet in vpc.subnets:
-                    builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet)
+                    builder.dependant_node(
+                        self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet
+                    )
         if self.processing_job_role_arn:
             builder.dependant_node(
                 self, reverse=True, delete_same_as_default=True, clazz=AwsIamRole, arn=self.processing_job_role_arn
@@ -4452,7 +4492,9 @@ class AwsSagemakerTrainingJob(SagemakerTaggable, AwsSagemakerJob):
                 builder.dependant_node(self, clazz=AwsKmsKey, id=AwsKmsKey.normalise_id(rc.volume_kms_key_id))
         if vpc := self.training_job_vpc_config:
             for security_group in vpc.security_group_ids:
-                builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group)
+                builder.dependant_node(
+                    self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group
+                )
             for subnet in vpc.subnets:
                 builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet)
         if cc := self.training_job_checkpoint_config:

--- a/plugins/aws/resoto_plugin_aws/resource/sagemaker.py
+++ b/plugins/aws/resoto_plugin_aws/resource/sagemaker.py
@@ -139,7 +139,7 @@ class AwsSagemakerNotebook(SagemakerTaggable, AwsResource):
             builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet)
         if security_groups := value_in_path(source, "SecurityGroups"):
             for security_group in security_groups:
-                builder.dependant_node(self, reverse=True, clazz=AwsEc2SecurityGroup, id=security_group)
+                builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group)
         if role_arn := value_in_path(source, "RoleArn"):
             builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsIamRole, arn=role_arn)
         if key := value_in_path(source, "KmsKeyId"):
@@ -734,7 +734,7 @@ class AwsSagemakerModel(SagemakerTaggable, AwsResource):
             builder.dependant_node(self, delete_same_as_default=True, clazz=AwsIamRole, arn=role_arn)
         if self.model_vpc_config:
             for security_group in self.model_vpc_config.security_group_ids:
-                builder.dependant_node(self, reverse=True, clazz=AwsEc2SecurityGroup, id=security_group)
+                builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group)
             for subnet in self.model_vpc_config.subnets:
                 builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet)
 
@@ -1131,7 +1131,7 @@ class AwsSagemakerDomain(AwsResource):
                 )
             if security_groups := value_in_path(source, ["DefaultUserSettings", "SecurityGroups"]):
                 for security_group in security_groups:
-                    builder.dependant_node(self, reverse=True, clazz=AwsEc2SecurityGroup, id=security_group)
+                    builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group)
             if shs := dus.sharing_settings:
                 if shs.s3_output_path:
                     builder.add_edge(self, clazz=AwsS3Bucket, name=AwsS3Bucket.name_from_path(shs.s3_output_path))
@@ -1179,7 +1179,7 @@ class AwsSagemakerDomain(AwsResource):
 
         if ds := self.domain_settings:
             for security_group in ds.security_group_ids:
-                builder.dependant_node(self, reverse=True, clazz=AwsEc2SecurityGroup, id=security_group)
+                builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group)
             if rss := ds.r_studio_server_pro_domain_settings:
                 if rss.domain_execution_role_arn:
                     builder.dependant_node(
@@ -1199,7 +1199,7 @@ class AwsSagemakerDomain(AwsResource):
                     self, reverse=True, delete_same_as_default=True, clazz=AwsIamRole, arn=dss.execution_role
                 )
             for security_group in dss.security_groups:
-                builder.dependant_node(self, reverse=True, clazz=AwsEc2SecurityGroup, id=security_group)
+                builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group)
             if jup := dss.jupyter_server_app_settings:
                 if drs := jup.default_resource_spec:
                     if drs.sage_maker_image_arn:
@@ -2497,7 +2497,7 @@ class AwsSagemakerAutoMLJob(AwsSagemakerJob):
                     builder.dependant_node(self, clazz=AwsKmsKey, id=AwsKmsKey.normalise_id(sc.volume_kms_key_id))
                 if vpc := sc.vpc_config:
                     for security_group in vpc.security_group_ids:
-                        builder.dependant_node(self, reverse=True, clazz=AwsEc2SecurityGroup, id=security_group)
+                        builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group)
                     for subnet in vpc.subnets:
                         builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet)
             if jc.candidate_generation_config:
@@ -2647,7 +2647,7 @@ class AwsSagemakerCompilationJob(AwsSagemakerJob):
                 builder.dependant_node(self, clazz=AwsKmsKey, id=AwsKmsKey.normalise_id(oc.kms_key_id))
         if vpc := self.compilation_job_vpc_config:
             for security_group in vpc.security_group_ids:
-                builder.dependant_node(self, reverse=True, clazz=AwsEc2SecurityGroup, id=security_group)
+                builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group)
             for subnet in vpc.subnets:
                 builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet)
 
@@ -3145,7 +3145,7 @@ class AwsSagemakerHyperParameterTuningJob(SagemakerTaggable, AwsSagemakerJob):
                             )
             if vpc := jobdef.vpc_config:
                 for security_group in vpc.security_group_ids:
-                    builder.dependant_node(self, reverse=True, clazz=AwsEc2SecurityGroup, id=security_group)
+                    builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group)
                 for subnet in vpc.subnets:
                     builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet)
             if odc := jobdef.output_data_config:
@@ -3481,7 +3481,7 @@ class AwsSagemakerInferenceRecommendationsJob(AwsSagemakerJob):
                         )
             if vpc := ic.vpc_config:
                 for security_group in vpc.security_group_ids:
-                    builder.dependant_node(self, reverse=True, clazz=AwsEc2SecurityGroup, id=security_group)
+                    builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group)
                 for subnet in vpc.subnets:
                     builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet)
         for rec in self.inference_recommendations_job_inference_recommendations:
@@ -3763,7 +3763,7 @@ class AwsSagemakerLabelingJob(SagemakerTaggable, AwsSagemakerJob):
                     builder.dependant_node(self, clazz=AwsKmsKey, id=AwsKmsKey.normalise_id(jrc.volume_kms_key_id))
                 if vpc := jrc.vpc_config:
                     for security_group in vpc.security_group_ids:
-                        builder.dependant_node(self, reverse=True, clazz=AwsEc2SecurityGroup, id=security_group)
+                        builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group)
                     for subnet in vpc.subnets:
                         builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet)
         if htc := self.labeling_job_human_task_config:
@@ -4092,7 +4092,7 @@ class AwsSagemakerProcessingJob(AwsSagemakerJob):
         if nc := self.processing_job_network_config:
             if vpc := nc.vpc_config:
                 for security_group in vpc.security_group_ids:
-                    builder.dependant_node(self, reverse=True, clazz=AwsEc2SecurityGroup, id=security_group)
+                    builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group)
                 for subnet in vpc.subnets:
                     builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet)
         if self.processing_job_role_arn:
@@ -4452,7 +4452,7 @@ class AwsSagemakerTrainingJob(SagemakerTaggable, AwsSagemakerJob):
                 builder.dependant_node(self, clazz=AwsKmsKey, id=AwsKmsKey.normalise_id(rc.volume_kms_key_id))
         if vpc := self.training_job_vpc_config:
             for security_group in vpc.security_group_ids:
-                builder.dependant_node(self, reverse=True, clazz=AwsEc2SecurityGroup, id=security_group)
+                builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2SecurityGroup, id=security_group)
             for subnet in vpc.subnets:
                 builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet)
         if cc := self.training_job_checkpoint_config:

--- a/plugins/aws/resoto_plugin_aws/resource/sagemaker.py
+++ b/plugins/aws/resoto_plugin_aws/resource/sagemaker.py
@@ -136,7 +136,7 @@ class AwsSagemakerNotebook(SagemakerTaggable, AwsResource):
 
     def connect_in_graph(self, builder: GraphBuilder, source: Json) -> None:
         if subnet := value_in_path(source, "SubnetId"):
-            builder.dependant_node(self, reverse=True, clazz=AwsEc2Subnet, id=subnet)
+            builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet)
         if security_groups := value_in_path(source, "SecurityGroups"):
             for security_group in security_groups:
                 builder.dependant_node(self, reverse=True, clazz=AwsEc2SecurityGroup, id=security_group)
@@ -736,7 +736,7 @@ class AwsSagemakerModel(SagemakerTaggable, AwsResource):
             for security_group in self.model_vpc_config.security_group_ids:
                 builder.dependant_node(self, reverse=True, clazz=AwsEc2SecurityGroup, id=security_group)
             for subnet in self.model_vpc_config.subnets:
-                builder.dependant_node(self, reverse=True, clazz=AwsEc2Subnet, id=subnet)
+                builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet)
 
     def delete_resource(self, client: AwsClient) -> bool:
         client.call(aws_service=self.api_spec.service, action="delete-model", result_name=None, ModelName=self.name)
@@ -1169,7 +1169,7 @@ class AwsSagemakerDomain(AwsResource):
                 self, clazz=AwsKmsKey, id=AwsKmsKey.normalise_id(self.domain_home_efs_file_system_kms_key_id)
             )
         for subnet in self.domain_subnet_ids:
-            builder.dependant_node(self, reverse=True, clazz=AwsEc2Subnet, id=subnet)
+            builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet)
         if self.domain_vpc_id:
             builder.dependant_node(
                 self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Vpc, id=self.domain_vpc_id
@@ -2499,7 +2499,7 @@ class AwsSagemakerAutoMLJob(AwsSagemakerJob):
                     for security_group in vpc.security_group_ids:
                         builder.dependant_node(self, reverse=True, clazz=AwsEc2SecurityGroup, id=security_group)
                     for subnet in vpc.subnets:
-                        builder.dependant_node(self, reverse=True, clazz=AwsEc2Subnet, id=subnet)
+                        builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet)
             if jc.candidate_generation_config:
                 builder.add_edge(
                     self, clazz=AwsS3Bucket, name=AwsS3Bucket.name_from_path(jc.candidate_generation_config)
@@ -2649,7 +2649,7 @@ class AwsSagemakerCompilationJob(AwsSagemakerJob):
             for security_group in vpc.security_group_ids:
                 builder.dependant_node(self, reverse=True, clazz=AwsEc2SecurityGroup, id=security_group)
             for subnet in vpc.subnets:
-                builder.dependant_node(self, reverse=True, clazz=AwsEc2Subnet, id=subnet)
+                builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet)
 
 
 @define(eq=False, slots=False)
@@ -3147,7 +3147,7 @@ class AwsSagemakerHyperParameterTuningJob(SagemakerTaggable, AwsSagemakerJob):
                 for security_group in vpc.security_group_ids:
                     builder.dependant_node(self, reverse=True, clazz=AwsEc2SecurityGroup, id=security_group)
                 for subnet in vpc.subnets:
-                    builder.dependant_node(self, reverse=True, clazz=AwsEc2Subnet, id=subnet)
+                    builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet)
             if odc := jobdef.output_data_config:
                 if odc.kms_key_id:
                     builder.dependant_node(self, clazz=AwsKmsKey, id=AwsKmsKey.normalise_id(odc.kms_key_id))
@@ -3483,7 +3483,7 @@ class AwsSagemakerInferenceRecommendationsJob(AwsSagemakerJob):
                 for security_group in vpc.security_group_ids:
                     builder.dependant_node(self, reverse=True, clazz=AwsEc2SecurityGroup, id=security_group)
                 for subnet in vpc.subnets:
-                    builder.dependant_node(self, reverse=True, clazz=AwsEc2Subnet, id=subnet)
+                    builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet)
         for rec in self.inference_recommendations_job_inference_recommendations:
             if ec := rec.endpoint_configuration:
                 if ec.endpoint_name:
@@ -3765,7 +3765,7 @@ class AwsSagemakerLabelingJob(SagemakerTaggable, AwsSagemakerJob):
                     for security_group in vpc.security_group_ids:
                         builder.dependant_node(self, reverse=True, clazz=AwsEc2SecurityGroup, id=security_group)
                     for subnet in vpc.subnets:
-                        builder.dependant_node(self, reverse=True, clazz=AwsEc2Subnet, id=subnet)
+                        builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet)
         if htc := self.labeling_job_human_task_config:
             if htc.workteam_arn:
                 builder.add_edge(self, reverse=True, clazz=AwsSagemakerWorkteam, arn=htc.workteam_arn)
@@ -4094,7 +4094,7 @@ class AwsSagemakerProcessingJob(AwsSagemakerJob):
                 for security_group in vpc.security_group_ids:
                     builder.dependant_node(self, reverse=True, clazz=AwsEc2SecurityGroup, id=security_group)
                 for subnet in vpc.subnets:
-                    builder.dependant_node(self, reverse=True, clazz=AwsEc2Subnet, id=subnet)
+                    builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet)
         if self.processing_job_role_arn:
             builder.dependant_node(
                 self, reverse=True, delete_same_as_default=True, clazz=AwsIamRole, arn=self.processing_job_role_arn
@@ -4454,7 +4454,7 @@ class AwsSagemakerTrainingJob(SagemakerTaggable, AwsSagemakerJob):
             for security_group in vpc.security_group_ids:
                 builder.dependant_node(self, reverse=True, clazz=AwsEc2SecurityGroup, id=security_group)
             for subnet in vpc.subnets:
-                builder.dependant_node(self, reverse=True, clazz=AwsEc2Subnet, id=subnet)
+                builder.dependant_node(self, reverse=True, delete_same_as_default=True, clazz=AwsEc2Subnet, id=subnet)
         if cc := self.training_job_checkpoint_config:
             if cc.s3_uri:
                 builder.add_edge(self, clazz=AwsS3Bucket, name=AwsS3Bucket.name_from_path(cc.s3_uri))

--- a/plugins/aws/test/collector_test.py
+++ b/plugins/aws/test/collector_test.py
@@ -31,7 +31,7 @@ def test_collect(account_collector: AwsAccountCollector) -> None:
     assert len(threading.enumerate()) == 1
     # ensure the correct number of nodes and edges
     assert count_kind(AwsResource) == 195
-    assert len(account_collector.graph.edges) == 454
+    assert len(account_collector.graph.edges) == 457
 
 
 def test_dependencies() -> None:


### PR DESCRIPTION
# Description

From [Boto3 docs](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html):
```
You must terminate all running instances in the subnet before you can delete the subnet.
```
and
```
If you attempt to delete a security group that is associated with an instance,
or is referenced by another security group, the operation fails with
InvalidGroup.InUse in EC2-Classic or DependencyViolation in EC2-VPC.
```

Therefore
- all connections from resources with subnets and/or security groups need to be `dependant_node`s. (Exceptions apply for resources within EC2 itself)
- the default edge is *usually* going from subnet/security group to the other resource
- the deletion edge **needs** to go from subnet/security group to the other resource


# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`
- [ ] Document new or updated functionality (someengineering/resoto.com#XXXX)

# Issues Fixed

<!-- If this PR will fix/resolve an open issue on the repository, please reference it below. -->
<!-- (Otherwise, feel free to delete this section.) -->

- Fixes #XXXX

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
