### PR TITLE
[fix][plugins/aws] Fix inline policy length

### DIFF
--- a/plugins/aws/tools/awspolicygen/awspolicygen/gen.py
+++ b/plugins/aws/tools/awspolicygen/awspolicygen/gen.py
@@ -23,7 +23,7 @@ org_list_policy = {
 }
 
 
-def get_policies() -> list:
+def get_policies(org_list: bool = True, collect: bool = True, mutate: bool = True) -> list:
     def iam_statement(name: str, apis: list[AwsApiSpec]) -> tuple[set[str], str]:
         permissions = {api.iam_permission() for api in apis}
         statement = {
@@ -35,14 +35,19 @@ def get_policies() -> list:
         }
         return statement
 
-    collect_policy = iam_statement("ResotoCollect", called_collect_apis())
-    mutate_policy = iam_statement("ResotoMutate", called_mutator_apis())
-    policies = [org_list_policy, collect_policy, mutate_policy]
+    policies = []
+    if org_list:
+        policies.append(org_list_policy)
+    if collect:
+        collect_policy = iam_statement("ResotoCollect", called_collect_apis())
+        policies.append(collect_policy)
+    if mutate:
+        mutate_policy = iam_statement("ResotoMutate", called_mutator_apis())
+        policies.append(mutate_policy)
     return policies
 
 
 def get_cf_template() -> str:
-    policies = get_policies()
     local_path = os.path.abspath(os.path.dirname(__file__))
     template_path = os.path.join(local_path, "templates/resoto-role.template.in")
     with open(template_path, "r") as f:
@@ -53,7 +58,7 @@ def get_cf_template() -> str:
 
     indent_by = len(template[-1]) - len(template[-1].lstrip())
 
-    policies = safe_dump(get_policies(), sort_keys=False)
+    policies = safe_dump(get_policies(collect=False), sort_keys=False)
     policies = "\n".join(" " * indent_by + line for line in policies.splitlines())
 
-    return "".join(template) + policies
+    return "".join(template) + policies + "\n"

--- a/plugins/aws/tools/awspolicygen/awspolicygen/templates/resoto-role.template.in
+++ b/plugins/aws/tools/awspolicygen/awspolicygen/templates/resoto-role.template.in
@@ -122,4 +122,7 @@ Resources:
           Action:
           - 'sts:AssumeRole'
           - 'sts:TagSession'
+      MaxSessionDuration: 10800
+      ManagedPolicyArns:
+      - 'arn:aws:iam::aws:policy/ReadOnlyAccess'
       Policies:


### PR DESCRIPTION
# Description

Adding sagemaker has put the Role length over 10kb. This removes the Collect policy and replaces it with the AWS managed ReadOnlyAccess policy.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
