### PR TITLE
[aws][fix] AWS operation and parameter names

### DIFF
--- a/resotolib/resotolib/core/tasks.py
+++ b/resotolib/resotolib/core/tasks.py
@@ -52,7 +52,7 @@ class CoreTaskHandler:
             result = self.handler(task_data)
             return CoreTaskResult(task_id=task_id, data=result)
         except Exception as e:
-            log.debug(f"Error while executing task {self.name}: {e}")
+            log.debug(f"Error while executing task {self.name}: {e}", e)
             return CoreTaskResult(task_id=task_id, error=str(e))
 
     def matches(self, js: Json) -> bool:


### PR DESCRIPTION
# Description

It is not always possible to translate the operation or parameter name directly by performing a pascalcase operation
Example: 
```
modify-db-cluster --> ModifyDBCluster
--db-cluster-identifier --> --DBClusterIdentifier
```
  
<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [ ] Add test coverage for new or updated functionality
- [ ] Lint and test with `tox`
- [ ] Document new or updated functionality (someengineering/resoto.com#XXXX)

# Issues Fixed

<!-- If this PR will fix/resolve an open issue on the repository, please reference it below. -->
<!-- (Otherwise, feel free to delete this section.) -->

- Fixes #XXXX

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
