### PR TITLE
[fix][aws] Fix duplicate instance types

### DIFF
--- a/plugins/aws/resoto_plugin_aws/resource/cloudwatch.py
+++ b/plugins/aws/resoto_plugin_aws/resource/cloudwatch.py
@@ -22,7 +22,7 @@ class CloudwatchTaggable:
             aws_service="cloudwatch",
             action="tag-resource",
             result_name=None,
-            ResourceARN=self.arn,
+            ResourceARN=self.arn,  # type: ignore
             Tags=[{"Key": key, "Value": value}],
         )
         return True
@@ -32,7 +32,7 @@ class CloudwatchTaggable:
             aws_service="cloudwatch",
             action="untag-resource",
             result_name=None,
-            ResourceARN=self.arn,
+            ResourceARN=self.arn,  # type: ignore
             TagKeys=[key],
         )
         return True
@@ -45,7 +45,7 @@ class CloudwatchTaggable:
 # noinspection PyUnresolvedReferences
 class LogsTaggable:
     def update_resource_tag(self, client: AwsClient, key: str, value: str) -> bool:
-        if arn := self.arn:
+        if arn := self.arn:  # type: ignore
             if arn.endswith(":*"):
                 arn = arn[:-2]
             client.call(
@@ -60,7 +60,7 @@ class LogsTaggable:
             return False
 
     def delete_resource_tag(self, client: AwsClient, key: str) -> bool:
-        if arn := self.arn:
+        if arn := self.arn:  # type: ignore
             if arn.endswith(":*"):
                 arn = arn[:-2]
             client.call(

--- a/plugins/aws/test/collector_test.py
+++ b/plugins/aws/test/collector_test.py
@@ -31,7 +31,7 @@ def test_collect(account_collector: AwsAccountCollector) -> None:
     assert len(threading.enumerate()) == 1
     # ensure the correct number of nodes and edges
     assert count_kind(AwsResource) == 204
-    assert len(account_collector.graph.edges) == 474
+    assert len(account_collector.graph.edges) == 476
     assert len(account_collector.graph.deferred_edges) == 2
 
 

--- a/plugins/aws/test/resources/base_test.py
+++ b/plugins/aws/test/resources/base_test.py
@@ -1,9 +1,8 @@
 from concurrent.futures import ThreadPoolExecutor
 from typing import Sequence, Tuple, List, Optional
 
-from resoto_plugin_aws.resource.base import ExecutorQueue, AwsRegion, AwsAccount, GraphBuilder
+from resoto_plugin_aws.resource.base import ExecutorQueue, AwsRegion, GraphBuilder
 from resoto_plugin_aws.resource.ec2 import AwsEc2InstanceType
-from resotolib.baseresources import Cloud
 
 
 def check_executor_queue(work: Sequence[int], fail_on_first_exception: bool) -> Tuple[List[int], Optional[Exception]]:
@@ -55,9 +54,7 @@ from test import account_collector, builder, aws_client, aws_config, no_feedback
 def test_instance_type_handling(builder: GraphBuilder) -> None:
     region1 = AwsRegion(id="us-east-1")
     region2 = AwsRegion(id="us-east-2")
-    account = AwsAccount(id="123456789012")
-    cloud = Cloud(id="test")
-    it = AwsEc2InstanceType(id="t3.micro", region=region1, account=account, cloud=cloud)
+    it = AwsEc2InstanceType(id="t3.micro")
     builder.global_instance_types[it.safe_name] = it
     it1: AwsEc2InstanceType = builder.instance_type(region1, it.safe_name)  # type: ignore
     assert it1.region() == region1


### PR DESCRIPTION
# Description

The same instance type defined in multiple regions could end up in the same global region, which is wrong.
<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`
- [x] Document new or updated functionality (someengineering/resoto.com#XXXX)


# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
