### PR TITLE
[fix][resotocore] Fix predefined custom commands and make them available in existing configurations

### DIFF
--- a/resotocore/resotocore/cli/command.py
+++ b/resotocore/resotocore/cli/command.py
@@ -3833,7 +3833,8 @@ class HttpCommand(CLICommand):
                     status_code = await perform_request(elem)
                     results[status_code] += 1
             summary = ", ".join(f"{count} requests with status {status}" for status, count in results.items())
-            yield f"{summary} sent."
+            if results:
+                yield f"{summary} sent."
 
         return iterate_stream
 

--- a/resotocore/resotocore/cli/model.py
+++ b/resotocore/resotocore/cli/model.py
@@ -405,7 +405,10 @@ class AliasTemplate:
         indent = "            "
         arg_info = f"\n{indent}".join(param_info(arg) for arg in sorted(self.parameters, key=attrgetter("name")))
         minimal = ", ".join(f'{p.name}="{p.example_value()}"' for p in self.parameters if p.default is None)
-        desc = f"\n{indent}{self.description}\n" if self.description else ""
+        desc = ""
+        if self.description:
+            for line in self.description.splitlines():
+                desc += f"\n{indent}{line}"
         return dedent(
             f"""
             {self.name}: {self.info}

--- a/resotocore/resotocore/core_config.py
+++ b/resotocore/resotocore/core_config.py
@@ -4,22 +4,21 @@ import re
 from argparse import Namespace
 from contextlib import suppress
 from copy import deepcopy
-from attrs import define, field
 from datetime import timedelta
 from pathlib import Path
 from typing import Optional, List, ClassVar, Dict, Union, cast
 
 from arango.database import StandardDatabase
+from attrs import define, field
 from cerberus import schema_registry
-from resotolib.core.model_export import dataclasses_to_resotocore_model
 
+from resotocore.ids import ConfigId
 from resotocore.model.model import Kind, Model, ComplexKind
 from resotocore.model.typed_model import from_js, to_js
 from resotocore.types import Json, JsonElement
 from resotocore.util import set_value_in_path, value_in_path, del_value_in_path
 from resotocore.validator import Validator, schema_name
-from resotocore.ids import ConfigId
-
+from resotolib.core.model_export import dataclasses_to_resotocore_model
 
 log = logging.getLogger(__name__)
 
@@ -194,18 +193,31 @@ class AliasTemplateConfig(ConfigObject):
 def alias_templates() -> List[AliasTemplateConfig]:
     return [
         AliasTemplateConfig(
-            "discord",
-            "Send the result of a search to Discord",
-            # define the fields to show in the message
-            "jq {name:{{key}}, value:{{value}}} | "
-            # Discord limit: https://discord.com/developers/docs/resources/channel#embed-object-embed-limits
-            "chunk 25 | "
-            # define the Discord webhook JSON
-            'jq {embeds: [{type: "rich", title: "{{title}}", {{#message}}description: "{{message}}",{{/message}} '
-            'fields:., footer:{text: "Message created by Resoto"}}]} | '
-            # call the API
-            "http POST {{webhook}}",
-            [
+            name="discord",
+            info="Send the result of a search to Discord",
+            description=(
+                "Perform a search and send the result to Discord.\n\n"
+                "Discord allows a maximum of 25 items per message. "
+                "If your search result is larger than 25 items, it will be split into multiple messages. "
+                "There are parameters to adjust the information displayed for each resource. "
+                "You can define the title and the message to be displayed.\n\n"
+                "We recommend to define the webhook URL as part of the command configuration. "
+                "This way you do not need to provide it every time you execute the command. "
+                "If you want to use a different webhook URL, you can provide it as a parameter, "
+                "or define different discord commands (e.g. discord-sre, discord-dev). "
+            ),
+            template=(
+                # define the fields to show in the message
+                "jq {name:{{key}}, value:{{value}}} | "
+                # Discord limit: https://discord.com/developers/docs/resources/channel#embed-object-embed-limits
+                "chunk 25 | "
+                # define the Discord webhook JSON
+                'jq {embeds: [{type: "rich", title: "{{title}}", {{#message}}description: "{{message}}",{{/message}} '
+                'fields:., footer:{text: "Message created by Resoto"}}]} | '
+                # call the API
+                "http POST {{webhook}}"
+            ),
+            parameters=[
                 AliasTemplateParameterConfig("key", "Resource field to show as key", ".kind"),
                 AliasTemplateParameterConfig("value", "Resource field to show as value", ".name"),
                 AliasTemplateParameterConfig("message", "Alert message", ""),
@@ -214,22 +226,35 @@ def alias_templates() -> List[AliasTemplateConfig]:
             ],
         ),
         AliasTemplateConfig(
-            "slack",
-            "Send the result of a search to Slack",
-            # define the fields to show in the message
-            'jq {type: "mrkdwn", text: ("*" + {{key}} + "*\n" + {{value}})} | '
-            # Slack limit: https://api.slack.com/reference/block-kit/blocks#actions
-            "chunk 25 | "
-            # define the Slack webhook JSON
-            "jq { blocks: ["
-            '{ type: "header", text: { type: "plain_text", text: "{{title}}" } }, '
-            '{{#message}}{ type: "section", text: { type: "mrkdwn", text: "{{message}}" } }, {{/message}}'
-            '{ type: "section", fields: . }, '
-            '{ type: "context", elements: [ { type: "mrkdwn", text: "Message created by Resoto" } ] } '
-            "] } | "
-            # call the API
-            "http POST {{webhook}}",
-            [
+            name="slack",
+            info="Send the result of a search to Slack",
+            description=(
+                "Perform a search and send the result to Slack.\n\n"
+                "Slack allows a maximum of 25 items per message. "
+                "If your search result is larger than 25 items, it will be split into multiple messages. "
+                "There are parameters to adjust the information displayed for each resource. "
+                "You can define the title and the message to be displayed.\n\n"
+                "We recommend to define the webhook URL as part of the command configuration. "
+                "This way you do not need to provide it every time you execute the command. "
+                "If you want to use a different webhook URL, you can provide it as a parameter, "
+                "or define different slack commands (e.g. slack-sre, slack-dev)."
+            ),
+            template=(
+                # define the fields to show in the message
+                'jq {type: "mrkdwn", text: ("*" + {{key}} + "*: " + {{value}})} | '
+                # Slack limit: https://api.slack.com/reference/block-kit/blocks#actions
+                "chunk 25 | "
+                # define the Slack webhook JSON
+                "jq { blocks: ["
+                '{ type: "header", text: { type: "plain_text", text: "{{title}}" } }, '
+                '{{#message}}{ type: "section", text: { type: "mrkdwn", text: "{{message}}" } }, {{/message}}'
+                '{ type: "section", fields: . }, '
+                '{ type: "context", elements: [ { type: "mrkdwn", text: "Message created by Resoto" } ] } '
+                "] } | "
+                # call the API
+                "http POST {{webhook}}"
+            ),
+            parameters=[
                 AliasTemplateParameterConfig("key", "Resource field to show as key", ".kind"),
                 AliasTemplateParameterConfig("value", "Resource field to show as value", ".name"),
                 AliasTemplateParameterConfig("message", "Alert message", ""),
@@ -238,23 +263,34 @@ def alias_templates() -> List[AliasTemplateConfig]:
             ],
         ),
         AliasTemplateConfig(
-            "jira",
-            "Send the result of a search to Jira",
-            # defines the fields to show in the message
-            'jq ({{key}} + ": " + {{value}}) | head 26 | chunk 26 | '
-            'jq "((.[:25] | join("\n")) + (if .[25] then "\n... (results truncated)" else "" end))" | '
-            # define the Jira webhook json
-            "jq {fields: { "
-            'summary: "{{title}}", '
-            'issuetype: {id: "10001"}, '
-            'description: ("{{message}}" + "\n\n" + . + "\n\n" + "Issue created by Resoto"), '
-            'project: {id: "{{project_id}}"}, '
-            'reporter: {id: "{{reporter_id}}"}, '
-            'labels: ["created-by-resoto"]'
-            "} } | "
-            # call the api
-            'http --auth "{{username}}:{{token}}" POST {{url}}/rest/api/2/issue',
-            [
+            name="jira",
+            info="Send the result of a search to Jira",
+            description=(
+                "Perform a search and send the result to Jira.\n\n"
+                "If your search result is larger than 25 items, only the first 25 items will be added to the ticket, "
+                "and the remaining items will be dropped.\n\n"
+                "Note that invoking this command will always create a new ticket since JIRA does not have any "
+                "deduplication functionality.\n\n"
+                "We recommend to define the URL, username and token as part of the command configuration. "
+                "This way you do not need to provide it every time you execute the command. "
+            ),
+            template=(
+                # defines the fields to show in the message
+                'head 26 | jq ({{key}} + ": " + {{value}}) | chunk 26 | '
+                'jq \'((.[:25] | join("\\n")) + (if .[25] then "\\n... (results truncated)" else "" end))\' | '
+                # define the Jira webhook json
+                "jq {fields: { "
+                'summary: "{{title}}", '
+                'issuetype: {id: "10001"}, '
+                'description: ("{{message}}" + "\\n\\n" + . + "\\n\\n" + "Issue created by Resoto"), '
+                'project: {id: "{{project_id}}"}, '
+                'reporter: {id: "{{reporter_id}}"}, '
+                'labels: ["created-by-resoto"]'
+                "}}"
+                # call the api
+                '| http --auth "{{username}}:{{token}}" POST {{url}}/rest/api/2/issue'
+            ),
+            parameters=[
                 AliasTemplateParameterConfig("key", "Resource field to show as key", ".kind"),
                 AliasTemplateParameterConfig("value", "Resource field to show as value", ".name"),
                 AliasTemplateParameterConfig("message", "Alert message", ""),
@@ -264,6 +300,40 @@ def alias_templates() -> List[AliasTemplateConfig]:
                 AliasTemplateParameterConfig("token", "Jira API token"),
                 AliasTemplateParameterConfig("project_id", "Jira project ID"),
                 AliasTemplateParameterConfig("reporter_id", "Jira reporter user ID"),
+            ],
+        ),
+        AliasTemplateConfig(
+            name="alertmanager",
+            info="Create an alert in alertmanager from a search.",
+            description=(
+                "Perform a search and send the result to alertmanager.\n\n"
+                "No resource specific data will be sent to alertmanager - only the count of matching resources. "
+                "The alert will be created in alertmanager and will be active for the specified duration.\n\n"
+                "The name of the alert is visible in alertmanager and used as deduplication key. "
+                "This way the same alert can be fired multiple times.\n\n"
+                "We recommend to define the URL as part of the command configuration. "
+                "This way you do not need to provide it every time you execute the command. "
+            ),
+            template=(
+                "aggregate sum(1) as count | "
+                # do not send an alert in case of 0 violations
+                'jq --no-rewrite "if (.count // 0)==0 then [] else [.count | tostring] end" | flatten | '
+                # defines the fields to show in the message
+                "jq --no-rewrite [{"
+                'status: "firing", '
+                'labels: {alertname: "{{name}}", issued_by: "Resoto"}, '
+                'annotations: {summary: ("Found "+.+ " violations!"), '
+                '"description": "{{description}}"}{{#duration}}, '
+                'startAt:"@utc@", '
+                'endsAt:"{{duration.from_now}}"{{/duration}}}] | '
+                # call the api
+                "http POST {{alertmanager_url}}/api/v1/alerts"
+            ),
+            parameters=[
+                AliasTemplateParameterConfig("name", "The globally unique name of this alert."),
+                AliasTemplateParameterConfig("description", "User defined message of the post.", "Resoto Alert"),
+                AliasTemplateParameterConfig("duration", "The duration of this alert in alertmanager.", "3h"),
+                AliasTemplateParameterConfig("alertmanager_url", "The complete url to alertmanager."),
             ],
         ),
     ]
@@ -479,7 +549,7 @@ def parse_config(args: Namespace, core_config: Json, command_templates: Optional
         set_from_cmd_line[ResotoCoreRootRE.sub("", key, 1)] = value
 
     # set the relevant value in the json config model
-    migrated = migrate_config(core_config)
+    migrated = migrate_core_config(core_config)
     adjusted = migrated.get(ResotoCoreRoot) or {}
     for path, value in set_from_cmd_line.items():
         if value is not None:
@@ -504,7 +574,9 @@ def parse_config(args: Namespace, core_config: Json, command_templates: Optional
     commands_config = CustomCommandsConfig()
     if command_templates:
         try:
-            commands_config = from_js(command_templates.get(ResotoCoreCommandsRoot), CustomCommandsConfig)
+            migrated_commands = migrate_command_config(command_templates)
+            cmd_cfg_to_parse = migrated_commands or command_templates
+            commands_config = from_js(cmd_cfg_to_parse.get(ResotoCoreCommandsRoot), CustomCommandsConfig)
         except Exception as e:
             log.error(f"Can not parse command templates. Fall back to defaults. Reason: {e}", exc_info=e)
 
@@ -521,7 +593,7 @@ def parse_config(args: Namespace, core_config: Json, command_templates: Optional
     )
 
 
-def migrate_config(config: Json) -> Json:
+def migrate_core_config(config: Json) -> Json:
     """
     :param config: The core configuration
     :return: the migrated json.
@@ -539,6 +611,17 @@ def migrate_config(config: Json) -> Json:
     # 3.0 -> 3.1: delete `api.ui_path`
     del_value_in_path(adapted, "api.ui_path")
     return {ResotoCoreRoot: adapted}
+
+
+def migrate_command_config(cmd_config: Json) -> Optional[Json]:
+    config = from_js(cmd_config.get(ResotoCoreCommandsRoot), CustomCommandsConfig)
+    existing_commands = {tpl.name: tpl for tpl in config.commands}
+    adjusted = False
+    for command in alias_templates():
+        if command.name not in existing_commands:
+            config.commands.append(command)
+            adjusted = True
+    return config.json() if adjusted else None
 
 
 def config_from_db(args: Namespace, db: StandardDatabase, collection_name: str = "configs") -> CoreConfig:

--- a/resotocore/tests/resotocore/cli/command_test.py
+++ b/resotocore/tests/resotocore/cli/command_test.py
@@ -851,7 +851,7 @@ async def test_slack_alias(cli: CLI, echo_http_server: Tuple[int, List[Tuple[Req
         "blocks": [
             {"type": "header", "text": {"type": "plain_text", "text": "test"}},
             {"type": "section", "text": {"type": "mrkdwn", "text": "test message"}},
-            {"type": "section", "fields": [{"type": "mrkdwn", "text": "*bla*\nyes or no"} for _ in range(0, 25)]},
+            {"type": "section", "fields": [{"type": "mrkdwn", "text": "*bla*: yes or no"} for _ in range(0, 25)]},
             {"type": "context", "elements": [{"type": "mrkdwn", "text": "Message created by Resoto"}]},
         ],
     }

--- a/resotocore/tests/resotocore/core_config_test.py
+++ b/resotocore/tests/resotocore/core_config_test.py
@@ -144,7 +144,7 @@ def test_migrate_commands() -> None:
     # an existing configuration is not destroyed
     example = evolve(alias_templates()[0], name="my-test-cmd")
     custom = CustomCommandsConfig(commands=[example])
-    migrated_json = migrate_command_config(custom.json())
+    migrated_json: Json = migrate_command_config(custom.json())  # type: ignore
     assert migrated_json != custom.json()
     migrated = from_js(migrated_json.get(ResotoCoreCommandsRoot), CustomCommandsConfig)
     assert any(cmd == example for cmd in migrated.commands)

--- a/resotocore/tests/resotocore/core_config_test.py
+++ b/resotocore/tests/resotocore/core_config_test.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+from attr import evolve
 from pytest import fixture
 
 from resotocore import core_config
@@ -12,10 +13,14 @@ from resotocore.core_config import (
     config_model,
     EditableConfig,
     WorkflowConfig,
-    migrate_config,
+    migrate_core_config,
+    migrate_command_config,
+    CustomCommandsConfig,
+    alias_templates,
+    ResotoCoreCommandsRoot,
 )
 from resotocore.dependencies import parse_args
-from resotocore.model.typed_model import to_js
+from resotocore.model.typed_model import to_js, from_js
 from resotocore.types import Json
 from resotocore.util import value_in_path
 
@@ -120,15 +125,30 @@ def test_in_docker() -> None:
 
 
 def test_migration() -> None:
-    cfg1 = migrate_config(dict(resotocore=dict(runtime=dict(analytics_opt_out=True))))
+    cfg1 = migrate_core_config(dict(resotocore=dict(runtime=dict(analytics_opt_out=True))))
     assert value_in_path(cfg1, "resotocore.runtime.usage_metrics") is False
     assert value_in_path(cfg1, "resotocore.runtime.analytics_opt_out") is None
-    cfg2 = migrate_config(dict(resotocore=dict(runtime=dict(usage_metrics=True))))
+    cfg2 = migrate_core_config(dict(resotocore=dict(runtime=dict(usage_metrics=True))))
     assert value_in_path(cfg2, "resotocore.runtime.usage_metrics") is True
     assert value_in_path(cfg1, "resotocore.runtime.analytics_opt_out") is None
-    cfg3 = migrate_config(dict(resotocore=dict(runtime=dict(analytics_opt_out=True, usage_metrics=True))))
+    cfg3 = migrate_core_config(dict(resotocore=dict(runtime=dict(analytics_opt_out=True, usage_metrics=True))))
     assert value_in_path(cfg3, "resotocore.runtime.usage_metrics") is True
     assert value_in_path(cfg1, "resotocore.runtime.analytics_opt_out") is None
+
+
+def test_migrate_commands() -> None:
+    # default configuration does not need migration
+    assert migrate_command_config(CustomCommandsConfig().json()) is None
+    # an empty configuration is migrated to the default configuration
+    assert migrate_command_config(CustomCommandsConfig(commands=[]).json()) == CustomCommandsConfig().json()
+    # an existing configuration is not destroyed
+    example = evolve(alias_templates()[0], name="my-test-cmd")
+    custom = CustomCommandsConfig(commands=[example])
+    migrated_json = migrate_command_config(custom.json())
+    assert migrated_json != custom.json()
+    migrated = from_js(migrated_json.get(ResotoCoreCommandsRoot), CustomCommandsConfig)
+    assert any(cmd == example for cmd in migrated.commands)
+    assert len(migrated.commands) == len(alias_templates()) + 1
 
 
 @fixture


### PR DESCRIPTION
# Description

Newly defined existing commands shipped with Resoto did not make it into user configuration.
This PR adds a migration to add non existent commands.

The commands that were defined had formatting errors and no description, which have been fixed as well.

<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
