### PR TITLE
[resotocore][feat] Add pagerduty notification command

### DIFF
--- a/resotocore/tests/resotocore/cli/command_test.py
+++ b/resotocore/tests/resotocore/cli/command_test.py
@@ -888,10 +888,10 @@ async def test_pagerduty_alias(cli: CLI, echo_http_server: Tuple[int, List[Tuple
     )
     assert result == [["1 requests with status 200 sent."]]
     assert len(requests) == 1
-    result = requests[0][1]
+    response = requests[0][1]
     # override timestamp
-    assert result["payload"]["timestamp"] is not None
-    result["payload"]["timestamp"] = "2023-02-10T15:03:33Z"
+    assert response["payload"]["timestamp"] is not None
+    response["payload"]["timestamp"] = "2023-02-10T15:03:33Z"
     assert requests[0][1] == {
         "payload": {
             "summary": "test",

--- a/resotocore/tests/resotocore/cli/command_test.py
+++ b/resotocore/tests/resotocore/cli/command_test.py
@@ -880,6 +880,44 @@ async def test_jira_alias(cli: CLI, echo_http_server: Tuple[int, List[Tuple[Requ
 
 
 @pytest.mark.asyncio
+async def test_pagerduty_alias(cli: CLI, echo_http_server: Tuple[int, List[Tuple[Request, Json]]]) -> None:
+    port, requests = echo_http_server
+    result = await cli.execute_cli_command(
+        f'search is(bla) | pagerduty webhook_url="http://localhost:{port}/success" summary=test routing_key=123 dedup_key=234',
+        stream.list,
+    )
+    assert result == [["1 requests with status 200 sent."]]
+    assert len(requests) == 1
+    result = requests[0][1]
+    # override timestamp
+    assert result["payload"]["timestamp"] is not None
+    result["payload"]["timestamp"] = "2023-02-10T15:03:33Z"
+    assert requests[0][1] == {
+        "payload": {
+            "summary": "test",
+            "timestamp": "2023-02-10T15:03:33Z",
+            "source": "Resoto",
+            "severity": "warning",
+            "component": "Resoto",
+            "custom_details": {"account___region_": 100},
+            "routing_key": "123",
+            "dedup_key": "234",
+            "images": [
+                {
+                    "src": "https://cdn.some.engineering/assets/resoto-logos/resoto-logo.svg",
+                    "href": "https://resoto.com/",
+                    "alt": "Resoto Home Page",
+                }
+            ],
+            "links": [],
+            "event_action": "trigger",
+            "client": "Resoto Service",
+            "client_url": "https://resoto.com",
+        }
+    }
+
+
+@pytest.mark.asyncio
 async def test_welcome(cli: CLI) -> None:
     ctx = CLIContext(console_renderer=ConsoleRenderer.default_renderer())
     result = await cli.execute_cli_command(f"welcome", stream.list, ctx)


### PR DESCRIPTION
# Description

This adds the `pagerduty` command that creates an alert in Pagerduty.
The result of a search is piped into `pagerduty` which will aggregate the resources by account and region.
`dedup_key` and `summary` has to be defined by the user in order to make sense out of that alert.

Example payload:

```yaml
payload:
  summary: test
  timestamp: '2023-02-10T15:15:24Z'
  source: Resoto
  severity: warning
  component: Resoto
  custom_details:
    account_625596817853__region_us-east-1: 2
    account_625596817853__region_us-east-2: 2
  routing_key: kdjfhgkdfhgkdfjh
  dedup_key: '123'
  images:
  - src: https://cdn.some.engineering/assets/resoto-logos/resoto-logo.svg
    href: https://resoto.com/
    alt: Resoto Home Page
  links: []
  event_action: trigger
  client: Resoto Service
  client_url: https://resoto.com
```

See rendered help page:
<img width="934" alt="image" src="https://user-images.githubusercontent.com/330485/218127024-b9ac5252-4459-4612-a3f7-96033b0c3c3f.png">


<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
