### PR TITLE
[resotolib][fix] Use latest networkx by unsetting cached properties

### DIFF
--- a/resotolib/requirements.txt
+++ b/resotolib/requirements.txt
@@ -1,4 +1,4 @@
-networkx==2.8 # 2.8.1 increase the refcounts which leads to a failing test.
+networkx==3.0
 jsons==1.6.3
 typeguard==2.13.3
 websocket-client==1.5.0

--- a/resotolib/resotolib/graph/__init__.py
+++ b/resotolib/resotolib/graph/__init__.py
@@ -31,7 +31,7 @@ from resotolib.core.model_export import (
 )
 from resotolib.logger import log
 from resotolib.types import Json
-from resotolib.utils import get_resource_attributes
+from resotolib.utils import get_resource_attributes, unset_cached_properties
 
 
 @define
@@ -596,5 +596,9 @@ class GraphExportIterator:
             elapsed = elapsed_nodes + elapsed_edges
             log.info(f"Exported {self.total_lines} nodes and edges in {elapsed:.4f}s")
             self.graph_exported = True
+            # The graph uses attributes with @cached_property.
+            # Those attributes reference the graph and increment the refcount.
+            # See: https://github.com/networkx/networkx/issues/6235
+            unset_cached_properties(self.graph)
             del self.graph
             self.tempfile.seek(0)

--- a/resotolib/resotolib/utils.py
+++ b/resotolib/resotolib/utils.py
@@ -13,10 +13,10 @@ try:
 except ImportError:
     from backports.zoneinfo import ZoneInfo
 from tzlocal import get_localzone_name
-from functools import wraps
+from functools import wraps, cached_property
 from pprint import pformat
 from tarfile import TarFile, TarInfo
-from typing import Dict, List, Tuple, Optional, NoReturn
+from typing import Dict, List, Tuple, Optional, NoReturn, Any
 from resotolib.types import DecoratedFn
 
 import pkg_resources
@@ -102,6 +102,19 @@ def chunks(items: List, n: int) -> List:
     for s in range(0, len(items), n):
         e = s + n
         yield items[s:e]
+
+
+def unset_cached_properties(obj: Any) -> None:
+    """
+    Reset all cached properties of an object.
+    Successive calls to the property will recompute the value.
+    :param obj: the object with cached properties.
+    """
+    cls = obj.__class__
+    for a in dir(obj):
+        attr_a = getattr(cls, a, cls)
+        if isinstance(attr_a, cached_property):
+            obj.__dict__.pop(attr_a.attrname, None)
 
 
 def split_esc(s, delim):

--- a/resotolib/test/test_graph.py
+++ b/resotolib/test/test_graph.py
@@ -107,13 +107,13 @@ def test_graph_export_iterator():
     g.add_resource(g.root, a)
     assert getrefcount(g) == 2
     gei = GraphExportIterator(g)
-    assert getrefcount(g) == 3
     gei.export_graph()
+    # one ref for g and for the variable passed to getrefcount ==> 2
     assert getrefcount(g) == 2
     assert len(list(gei)) == 3
 
 
-def test_f():
+def test_find_cycles():
     g = Graph()
     n1 = SomeTestResource(id="foo", tags={})
     n2 = SomeTestResource(id="bar", tags={})


### PR DESCRIPTION
# Description

`networkx` introduced `cached_property`s in 2.8.1 which blocked upgrading to the latest version.
This change unsets cached properties after the graph is exported and eliminates the references.
See: https://github.com/networkx/networkx/issues/6235

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`


# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
