### PR TITLE
[plugins/aws][fix] Add new permissions for cloudformation stack listing

### DIFF
--- a/plugins/aws/resoto_plugin_aws/resource/cloudformation.py
+++ b/plugins/aws/resoto_plugin_aws/resource/cloudformation.py
@@ -168,6 +168,10 @@ class AwsCloudFormationStack(AwsResource, BaseStack):
         return True
 
     @classmethod
+    def called_collect_apis(cls) -> List[AwsApiSpec]:
+        return [cls.api_spec, AwsApiSpec("cloudformation", "list-stacks")]
+
+    @classmethod
     def called_mutator_apis(cls) -> List[AwsApiSpec]:
         return [AwsApiSpec("cloudformation", "update-stack"), AwsApiSpec("cloudformation", "delete-stack")]
 


### PR DESCRIPTION
# Description

AWS CloudFormation now requires that customers have the cloudformation:ListStacks permission when calling DescribeStacks without a target stack. This is in addition to the cloudformation:DescribeStacks permission that is already a requirement.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
