### PR TITLE
[resotocore][chore] Improve Pagerduty details

### DIFF
--- a/resotocore/tests/resotocore/cli/command_test.py
+++ b/resotocore/tests/resotocore/cli/command_test.py
@@ -883,7 +883,7 @@ async def test_jira_alias(cli: CLI, echo_http_server: Tuple[int, List[Tuple[Requ
 async def test_pagerduty_alias(cli: CLI, echo_http_server: Tuple[int, List[Tuple[Request, Json]]]) -> None:
     port, requests = echo_http_server
     result = await cli.execute_cli_command(
-        f'search is(bla) | head 1 | pagerduty --webhook-url "http://localhost:{port}/success" --summary test --routing-key 123 --dedup-key 234',
+        f'search id(0_0) | pagerduty --webhook-url "http://localhost:{port}/success" --summary test --routing-key 123 --dedup-key 234',
         stream.list,
     )
     assert result == [["1 requests with status 200 sent."]]

--- a/resotocore/tests/resotocore/cli/command_test.py
+++ b/resotocore/tests/resotocore/cli/command_test.py
@@ -892,6 +892,7 @@ async def test_pagerduty_alias(cli: CLI, echo_http_server: Tuple[int, List[Tuple
     # override timestamp
     assert response["payload"]["timestamp"] is not None
     response["payload"]["timestamp"] = "2023-02-10T15:03:33Z"
+    print(requests[0][1])
     assert requests[0][1] == {
         "payload": {
             "summary": "test",
@@ -899,9 +900,9 @@ async def test_pagerduty_alias(cli: CLI, echo_http_server: Tuple[int, List[Tuple
             "source": "Resoto",
             "severity": "warning",
             "component": "Resoto",
-            "custom_details": [
-                {"cloud": None, "account": None, "region": None, "name": "yes or no", "kind": "bla"},
-            ],
+            "custom_details": {
+                "no-cloud": {"no-account": {"no-region": {"0_0": {"id": None, "name": "yes or no", "kind": "bla"}}}}
+            },
         },
         "routing_key": "123",
         "dedup_key": "234",

--- a/resotocore/tests/resotocore/cli/command_test.py
+++ b/resotocore/tests/resotocore/cli/command_test.py
@@ -892,7 +892,6 @@ async def test_pagerduty_alias(cli: CLI, echo_http_server: Tuple[int, List[Tuple
     # override timestamp
     assert response["payload"]["timestamp"] is not None
     response["payload"]["timestamp"] = "2023-02-10T15:03:33Z"
-    print(requests[0][1])
     assert requests[0][1] == {
         "payload": {
             "summary": "test",


### PR DESCRIPTION
# Description
This PR changes the custom data send to Pagerduty. With this format Pagerduty is able to render the data visually more appealing in their webUI. Example:

<img width="1304" alt="image" src="https://user-images.githubusercontent.com/330485/220576282-1dca6ec0-1474-4ff1-89db-77fff689117c.png">

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
