### PR TITLE
[plugins/aws][fix] Remove duplicate log and skip deferred edge resoving in AWS

### DIFF
--- a/plugins/aws/resoto_plugin_aws/__init__.py
+++ b/plugins/aws/resoto_plugin_aws/__init__.py
@@ -123,7 +123,7 @@ class AWSCollectorPlugin(BaseCollectorPlugin):
                 if not isinstance(account_graph, Graph):
                     log.debug(f"Skipping account graph of invalid type {type(account_graph)}")
                     continue
-                self.graph.merge(account_graph)
+                self.graph.merge(account_graph, skip_deferred_edges=True)
 
     def regions(self, profile: Optional[str] = None) -> List[str]:
         if len(self.__regions) == 0:

--- a/plugins/aws/resoto_plugin_aws/resource/base.py
+++ b/plugins/aws/resoto_plugin_aws/resource/base.py
@@ -436,7 +436,7 @@ class GraphBuilder:
         :param region: only define the region in case it is different from the region of the graph builder.
         :return: the added node
         """
-        log.debug(f"{self.name}: add node {node}")
+        log.debug(f"Added node {node.kdname}")
         node._cloud = self.cloud
         node._account = self.account
         node._region = region or self.region
@@ -450,7 +450,6 @@ class GraphBuilder:
         to_n = self.node(**to_node)
         if isinstance(from_node, AwsResource) and isinstance(to_n, AwsResource):
             start, end = (to_n, from_node) if reverse else (from_node, to_n)
-            log.debug(f"{self.name}: add edge: {start} -> {end} [{edge_type}]")
             with self.graph_edges_access:
                 self.graph.add_edge(start, end, edge_type=edge_type)
 

--- a/resotolib/resotolib/graph/__init__.py
+++ b/resotolib/resotolib/graph/__init__.py
@@ -92,7 +92,7 @@ class Graph(networkx.MultiDiGraph):
             self.add_node(self.root, label=self.root.name, **get_resource_attributes(self.root))
         self.deferred_edges: List[Tuple[NodeSelector, NodeSelector, EdgeType]] = []
 
-    def merge(self, graph: Graph):
+    def merge(self, graph: Graph, skip_deferred_edges: bool = False):
         """Merge another graph into ourselves
 
         If the other graph has a graph.root an edge will be created between
@@ -110,7 +110,8 @@ class Graph(networkx.MultiDiGraph):
             self.deferred_edges.extend(graph.deferred_edges)
         finally:
             self._log_edge_creation = True
-        self.resolve_deferred_connections()
+        if not skip_deferred_edges:
+            self.resolve_deferred_connections()
 
     def add_resource(
         self,


### PR DESCRIPTION
# Description

The Graph class already emits a debug log message on add_edge. Right now for every edge there's two log messages containing exactly the same information.
This PR remove the duplicate log and skip deferred edge resolving in AWS since the new collector already does it on the account level. It also adjusts the node adding log to have the same format as edge adding messages.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
