### PR TITLE
[aws][fix] Do not use a boto session per thread

### DIFF
--- a/plugins/aws/resoto_plugin_aws/__init__.py
+++ b/plugins/aws/resoto_plugin_aws/__init__.py
@@ -106,7 +106,7 @@ class AWSCollectorPlugin(BaseCollectorPlugin):
         else:
             collect_method = collect_account
 
-        with pool_executor(**pool_args) as executor:
+        with pool_executor(**pool_args) as executor:  # type: ignore
             wait_for = [
                 executor.submit(
                     collect_method,

--- a/plugins/aws/resoto_plugin_aws/__init__.py
+++ b/plugins/aws/resoto_plugin_aws/__init__.py
@@ -70,6 +70,7 @@ class AWSCollectorPlugin(BaseCollectorPlugin):
 
     def collect_aws(self) -> None:
         log.debug("plugin: AWS collecting resources")
+        aws_config: AwsConfig = Config.aws
         assert self.core_feedback, "core_feedback is not set"
         cloud = Cloud(id=self.cloud, name="AWS")
 
@@ -90,7 +91,7 @@ class AWSCollectorPlugin(BaseCollectorPlugin):
             log.debug(f"Found {account.rtdname}{add_str}")
         self.core_feedback.progress(progress)
 
-        max_workers = len(accounts) if len(accounts) < Config.aws.account_pool_size else Config.aws.account_pool_size
+        max_workers = len(accounts) if len(accounts) < aws_config.account_pool_size else aws_config.account_pool_size
         pool_args = {"max_workers": max_workers}
         # TODO: revert this when memory leak in AWS collector is fixed
         # if Config.aws.fork_process:
@@ -100,7 +101,7 @@ class AWSCollectorPlugin(BaseCollectorPlugin):
         # else:
         #     pool_executor = futures.ThreadPoolExecutor  # type: ignore
         pool_executor = futures.ThreadPoolExecutor
-        if Config.aws.fork_process:
+        if aws_config.fork_process:
             collect_method = collect_in_process
         else:
             collect_method = collect_account
@@ -124,6 +125,9 @@ class AWSCollectorPlugin(BaseCollectorPlugin):
                     log.debug(f"Skipping account graph of invalid type {type(account_graph)}")
                     continue
                 self.graph.merge(account_graph, skip_deferred_edges=True)
+
+        # collect done, purge all session caches
+        aws_config.sessions().purge_caches()
 
     def regions(self, profile: Optional[str] = None) -> List[str]:
         if len(self.__regions) == 0:

--- a/plugins/aws/test/configuration_test.py
+++ b/plugins/aws/test/configuration_test.py
@@ -28,5 +28,5 @@ def test_default_config() -> None:
 def test_session() -> None:
     config = AwsConfig("test", "test", "test")
     # direct session
-    assert config.sessions().session("1234", aws_role=None) == config.sessions().session("1234", aws_role=None)
+    assert config.sessions()._session("1234", aws_role=None) == config.sessions()._session("1234", aws_role=None)
     # no test for sts session, since this requires sts setup


### PR DESCRIPTION
# Description

Boto sessions are memory hogs. No need to create more than one for the same access settings.

<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
