### PR TITLE
[resotocore][fix] Do not send raw_config by default

### DIFF
--- a/resotocore/resotocore/web/api.py
+++ b/resotocore/resotocore/web/api.py
@@ -325,7 +325,7 @@ class Api:
                 apply_overrides = get_query_param_bool("apply_overrides", default=False)
                 resolve_env_vars = get_query_param_bool("resolve_env_vars", default=False)
                 # attach the "raw" config version that was stored in the database
-                include_raw_config = get_query_param_bool("include_raw_config", default=True)
+                include_raw_config = get_query_param_bool("include_raw_config", default=False)
             else:
                 # if we request a single object with overrides applied,
                 # we apply overrides and resolve env vars by default

--- a/resotocore/tests/resotocore/web/api_test.py
+++ b/resotocore/tests/resotocore/web/api_test.py
@@ -389,10 +389,8 @@ async def test_config(core_client: ApiClient, foo_kinds: List[rc.Kind]) -> None:
         "raw_config": {"l1": {"l2": 1}},
     }
 
-    # raw config is not sent by default 
-    resp = await core_client._get(
-        f"/config/{cfg_override_id}", params={"separate_overrides": "true"}
-    )
+    # raw config is not sent by default
+    resp = await core_client._get(f"/config/{cfg_override_id}", params={"separate_overrides": "true"})
     json = await resp.json()
     assert json == {
         "config": {"l1": {"l2": 1}},

--- a/resotocore/tests/resotocore/web/api_test.py
+++ b/resotocore/tests/resotocore/web/api_test.py
@@ -388,3 +388,13 @@ async def test_config(core_client: ApiClient, foo_kinds: List[rc.Kind]) -> None:
         "overrides": {"l1": {"l2": 42}},
         "raw_config": {"l1": {"l2": 1}},
     }
+
+    # raw config is not sent by default 
+    resp = await core_client._get(
+        f"/config/{cfg_override_id}", params={"separate_overrides": "true"}
+    )
+    json = await resp.json()
+    assert json == {
+        "config": {"l1": {"l2": 1}},
+        "overrides": {"l1": {"l2": 42}},
+    }


### PR DESCRIPTION
# Description

The raw_config which is used only on demand by overrides is not sent by default in using the API endpoint.

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`
- [ ] Document new or updated functionality (someengineering/resoto.com#XXXX)

# Issues Fixed

<!-- If this PR will fix/resolve an open issue on the repository, please reference it below. -->
<!-- (Otherwise, feel free to delete this section.) -->

- Fixes #XXXX

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
