### PR TITLE
[resotolib][fix] Fix config env vars resolving

### DIFF
--- a/resotolib/resotolib/config.py
+++ b/resotolib/resotolib/config.py
@@ -130,6 +130,7 @@ class Config(metaclass=MetaConfig):
                 )
                 # config with env_vars resolved and overrides applied
                 config = config_response["config"]
+                config = {k: replace_env_vars(v, os.environ, keep_unresolved=False) for k, v in config.items()}
                 # raw config as it was stored in the database, to be sent to the core
                 raw_config = config_response["raw_config"]
 


### PR DESCRIPTION
# Description

Fixed a bug where specifying an env var that can't be resolved on the worker will cause a crash.

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [ ] Add test coverage for new or updated functionality
- [ ] Lint and test with `tox`
- [ ] Document new or updated functionality (someengineering/resoto.com#XXXX)

# Issues Fixed

<!-- If this PR will fix/resolve an open issue on the repository, please reference it below. -->
<!-- (Otherwise, feel free to delete this section.) -->

- Fixes #XXXX

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
