### PR TITLE
[resotocore][feat] YAML: support literal blocks for multiline strings

### DIFF
--- a/resotocore/resotocore/core_config.py
+++ b/resotocore/resotocore/core_config.py
@@ -225,7 +225,7 @@ def alias_templates() -> List[AliasTemplateConfig]:
                 "We recommend to define the webhook URL as part of the command configuration. "
                 "This way you do not need to provide it every time you execute the command. "
                 "If you want to use a different webhook URL, you can provide it as a parameter, "
-                "or define different discord commands (e.g. discord-sre, discord-dev). "
+                "or define different discord commands (e.g. discord-sre, discord-dev)."
             ),
             template=(
                 # define the fields to show in the message
@@ -295,7 +295,7 @@ def alias_templates() -> List[AliasTemplateConfig]:
                 "Note that invoking this command will always create a new ticket since JIRA does not have any "
                 "deduplication functionality.\n\n"
                 "We recommend to define the URL, username and token as part of the command configuration. "
-                "This way you do not need to provide it every time you execute the command. "
+                "This way you do not need to provide it every time you execute the command."
             ),
             template=(
                 # defines the fields to show in the message
@@ -336,7 +336,7 @@ def alias_templates() -> List[AliasTemplateConfig]:
                 "The name of the alert is visible in alertmanager and used as deduplication key. "
                 "This way the same alert can be fired multiple times.\n\n"
                 "We recommend to define the URL as part of the command configuration. "
-                "This way you do not need to provide it every time you execute the command. "
+                "This way you do not need to provide it every time you execute the command."
             ),
             template=(
                 "aggregate sum(1) as count | "

--- a/resotocore/tests/resotocore/model/model_test.py
+++ b/resotocore/tests/resotocore/model/model_test.py
@@ -1,4 +1,5 @@
 import json
+import sys
 from datetime import datetime, timedelta
 from textwrap import dedent
 from typing import Type, Any, Union, cast, List
@@ -442,7 +443,7 @@ def test_markup() -> None:
 
 def test_yaml(person_model: Model) -> None:
     person_kind: ComplexKind = person_model["Person"]  # type: ignore
-    address = {"zip": "134", "city": "gotham", "number": 123, "float": 1.2345}
+    address = {"zip": "134", "city": "gotham\nmanor house", "number": 123, "float": 1.2345}
     person = {
         "name": "batman",
         "address": address,
@@ -460,7 +461,9 @@ def test_yaml(person_model: Model) -> None:
           zip: '134'
           # The name of the city.
           # And another line.
-          city: 'gotham'
+          city: |-
+            gotham
+            manor house
           number: 123
           float: 1.2345
         # The list of addresses.
@@ -469,14 +472,18 @@ def test_yaml(person_model: Model) -> None:
             zip: '134'
             # The name of the city.
             # And another line.
-            city: 'gotham'
+            city: |-
+              gotham
+              manor house
             number: 123
             float: 1.2345
           - # The zip code.
             zip: '134'
             # The name of the city.
             # And another line.
-            city: 'gotham'
+            city: |-
+              gotham
+              manor house
             number: 123
             float: 1.2345
         # Other addresses.
@@ -486,7 +493,9 @@ def test_yaml(person_model: Model) -> None:
             zip: '134'
             # The name of the city.
             # And another line.
-            city: 'gotham'
+            city: |-
+              gotham
+              manor house
             number: 123
             float: 1.2345
           work:
@@ -494,7 +503,9 @@ def test_yaml(person_model: Model) -> None:
             zip: '134'
             # The name of the city.
             # And another line.
-            city: 'gotham'
+            city: |-
+              gotham
+              manor house
             number: 123
             float: 1.2345
         simple:


### PR DESCRIPTION
# Description

If a config property contains a multiline string, try to render that as literal block.

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
