### PR TITLE
[resotocore][feat] Support json schema as model specification

### DIFF
--- a/resotocore/.pylintrc
+++ b/resotocore/.pylintrc
@@ -76,7 +76,8 @@ disable=
     no-member,
     unsupported-binary-operation,
     too-many-branches,
-    use-dict-literal
+    use-dict-literal,
+    too-many-return-statements
 
 
 [REPORTS]

--- a/resotocore/resotocore/model/json_schema.py
+++ b/resotocore/resotocore/model/json_schema.py
@@ -1,0 +1,160 @@
+import re
+from typing import Optional
+
+from resotocore import version
+from resotocore.model.model import (
+    Kind,
+    StringKind,
+    BooleanKind,
+    NumberKind,
+    DateKind,
+    DateTimeKind,
+    DurationKind,
+    TransformKind,
+    DictionaryKind,
+    AnyKind,
+    ComplexKind,
+    ArrayKind,
+    Model,
+    Property,
+    any_kind,
+)
+from resotocore.types import Json
+from resotolib.durations import DurationRe
+
+
+def safe_name(kind: Kind) -> str:
+    return re.sub("[^A-Za-z0-9]", "_", kind.fqn)
+
+
+def simple_type(model: Model, kind: Kind) -> Optional[str]:
+    if isinstance(kind, StringKind) and kind.fqn == "string":
+        return "string"
+    elif isinstance(kind, BooleanKind):
+        return "boolean"
+    elif isinstance(kind, NumberKind) and kind.fqn in ("int32", "int64"):
+        return "integer"
+    elif isinstance(kind, NumberKind) and kind.fqn in ("float", "double"):
+        return "number"
+    elif isinstance(kind, AnyKind):
+        return "object"
+    elif isinstance(kind, TransformKind):
+        return simple_type(model, kind.source_kind or any_kind)
+    else:
+        return None
+
+
+def ref_type(model: Model, kind: Kind) -> Json:
+    if simple := simple_type(model, kind):
+        return {"type": simple}
+    elif isinstance(kind, ArrayKind):
+        return {
+            "type": "array",
+            "items": ref_type(model, kind.inner),
+        }
+    elif isinstance(kind, DictionaryKind):
+        return {
+            "type": "object",
+            "additionalProperties": ref_type(model, kind.value_kind),
+        }
+    else:
+        return {"$ref": f"#/$defs/{safe_name(kind)}"}
+
+
+def export_kind(model: Model, kind: Kind, is_base: bool) -> Optional[Json]:
+    if isinstance(kind, (AnyKind, ArrayKind, DictionaryKind)):
+        # no additional type information can be defined here
+        return None
+    elif isinstance(kind, StringKind):
+        if kind.fqn != "string":
+            result = {"type": "string", "additionalProperties": False}
+            if kind.min_length:
+                result["minLength"] = kind.min_length
+            if kind.max_length:
+                result["maxLength"] = kind.max_length
+            if kind.pattern:
+                result["pattern"] = kind.pattern
+            if kind.enum:
+                result["enum"] = kind.enum
+            return result
+        else:
+            # build in type string does not need any additional information
+            return None
+    elif isinstance(kind, BooleanKind):
+        if kind.fqn != "boolean":
+            return {"type": "boolean", "additionalProperties": False}
+        else:
+            # build in type boolean does not need any additional information
+            return None
+    elif isinstance(kind, NumberKind):
+        if kind.fqn not in ("int32", "int64", "float", "double"):
+            result = {"additionalProperties": False}
+            if kind.runtime_kind in ("int32", "int64"):
+                result["type"] = "integer"
+            elif kind.runtime_kind in ("float", "double"):
+                result["type"] = "number"
+            if kind.minimum:
+                result["minimum"] = kind.minimum
+            if kind.maximum:
+                result["maximum"] = kind.maximum
+            if kind.enum:
+                result["enum"] = kind.enum
+            return result
+        else:
+            # build in type number does not need any additional information
+            return None
+    elif isinstance(kind, DateKind):
+        return {"type": "string", "format": "date"}
+    elif isinstance(kind, DateTimeKind):
+        return {"type": "string", "format": "date-time"}
+    elif isinstance(kind, DurationKind):
+        return {"type": "string", "pattern": DurationRe.pattern}
+    elif isinstance(kind, TransformKind):
+        assert kind.source_kind
+        return export_kind(model, kind.source_kind, is_base)
+    elif isinstance(kind, ComplexKind):
+        ck: ComplexKind = kind
+
+        def prop_model(p: Property) -> Json:
+            pr = ref_type(model, ck.property_kind_of(p.name, any_kind))
+            if desc := p.description:
+                pr["description"] = desc
+            return pr
+
+        # we always need to define all properties.
+        # Otherwise, it is not allowed to forbid additional properties
+        all_props = {rp.name: prop_model(rp) for rp in ck.all_props()}
+        # If this is a final kind, we expect a kind property with the name of the kind (constant)
+        kind_prop = {} if is_base else {"kind": {"const": safe_name(ck)}}
+        result = {
+            "type": "object",
+            "properties": all_props | kind_prop,
+            "required": [prop.name for prop in kind.properties if prop.required],
+            "additionalProperties": is_base | kind.allow_unknown_props,
+        }
+        if kind.bases:
+            result["allOf"] = [ref_type(model, model[base]) for base in kind.bases]
+        return result
+    else:
+        raise ValueError(f"Unknown kind: {kind}")
+
+
+def json_schema(model: Model) -> Json:
+    # filter out the predefined properties holder
+    kinds = [k for k in model.kinds.values() if k.fqn != "predefined_properties"]
+    all_bases = {b for k in kinds if isinstance(k, ComplexKind) for b in k.bases}
+    return {
+        "$id": f"https://resoto.com/schemas/{version()}/resources.json",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",  # latest draft
+        "title": "Resoto Resource Model Schema",
+        "oneOf": [
+            ref_type(model, k)
+            for k in kinds
+            if isinstance(k, ComplexKind) and k.aggregate_root and k.fqn not in all_bases
+        ],
+        "$defs": {
+            n: v
+            for n, v in {safe_name(k): export_kind(model, k, k.fqn in all_bases) for k in kinds}.items()
+            if v is not None
+        },
+    }

--- a/resotocore/resotocore/web/api.py
+++ b/resotocore/resotocore/web/api.py
@@ -36,6 +36,7 @@ from aiohttp.hdrs import METH_ANY
 from aiohttp.web import Request, StreamResponse, WebSocketResponse
 from aiohttp.web_exceptions import HTTPNotFound, HTTPNoContent, HTTPOk, HTTPNotAcceptable
 from aiohttp.web_fileresponse import FileResponse
+from aiohttp.web_response import json_response
 from aiohttp_swagger3 import SwaggerFile, SwaggerUiSettings
 from aiostream import stream
 from aiostream.core import Stream
@@ -66,6 +67,7 @@ from resotocore.ids import TaskId, ConfigId, NodeId, SubscriberId, WorkerId
 from resotocore.message_bus import MessageBus, Message, ActionDone, Action, ActionError, ActionInfo, ActionProgress
 from resotocore.model.db_updater import merge_graph_process
 from resotocore.model.graph_access import Section
+from resotocore.model.json_schema import json_schema
 from resotocore.model.model import Kind
 from resotocore.model.model_handler import ModelHandler
 from resotocore.model.typed_model import to_json, from_js, to_js_str, to_js
@@ -675,7 +677,12 @@ class Api:
 
     async def get_model(self, request: Request) -> StreamResponse:
         md = await self.model_handler.load_model()
-        return await single_result(request, to_js(md.kinds.values(), strip_nulls=True))
+        # default to internal model format, but allow to request json schema format
+        if request.headers.get("accept") == "application/schema+json":
+            return json_response(json_schema(md), content_type="application/schema+json")
+        else:
+            result = to_js(md.kinds.values(), strip_nulls=True)
+            return await single_result(request, result)
 
     async def update_model(self, request: Request) -> StreamResponse:
         js = await self.json_from_request(request)

--- a/resotocore/tests/resotocore/model/json_schema_test.py
+++ b/resotocore/tests/resotocore/model/json_schema_test.py
@@ -1,0 +1,23 @@
+from resotocore.model.json_schema import json_schema
+from resotocore.model.model import Model
+
+
+def test_schema(foo_model: Model) -> None:
+    schema = json_schema(foo_model)
+    # The resource is one of the possible 9 types
+    assert len(schema["oneOf"]) == 9
+
+    # base type - all properties are defined, additional properties are allowed
+    assert schema["$defs"]["base"]["required"] == ["identifier", "kind"]
+    assert schema["$defs"]["base"]["properties"].keys() == {"identifier", "kind", "ctime"}
+    assert schema["$defs"]["base"]["additionalProperties"] is True
+
+    # final resource type - all properties are defined, additional properties are not allowed
+    assert schema["$defs"]["some_complex"]["required"] == []
+    expected = {"identifier", "kind", "ctime", "cloud", "account", "parents", "children", "nested"}
+    assert schema["$defs"]["some_complex"]["properties"].keys() == expected
+    assert schema["$defs"]["some_complex"]["additionalProperties"] is False
+
+    # simple types are defined
+    assert schema["$defs"]["datetime"]["type"] == "string"
+    assert schema["$defs"]["datetime"]["format"] == "date-time"


### PR DESCRIPTION
# Description

When the content type `application/schema+json` is requested on the model endpoint,
json schema of our model is returned.

Test the schema:
1. Create the schema
2. Go to https://www.jsonschemavalidator.net and paste the schema
3. `search is(xxx) limit 1 | jq --no-rewrite .reported | format --json` and paste the json

The validator should report the pasted json as valid.

<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`


# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
