### PR TITLE
[gcp][fix] GcpSqlOperation needs GcpDatabaseInstance as query parameter

### DIFF
--- a/plugins/gcp/resoto_plugin_gcp/resources/sqladmin.py
+++ b/plugins/gcp/resoto_plugin_gcp/resources/sqladmin.py
@@ -629,7 +629,7 @@ class GcpSqlDatabaseInstance(GcpResource):
                 builder.add_edge(self, reverse=True, clazz=GcpSslCertificate, link=cert.self_link)
 
     def post_process(self, graph_builder: GraphBuilder, source: Json) -> None:
-        classes: List[Type[GcpResource]] = [GcpSqlBackupRun, GcpSqlDatabase, GcpSqlUser]
+        classes: List[Type[GcpResource]] = [GcpSqlBackupRun, GcpSqlDatabase, GcpSqlUser, GcpSqlOperation]
         for cls in classes:
             if spec := cls.api_spec:
                 items = graph_builder.client.list(spec, instance=self.name, project=self.project)
@@ -770,7 +770,7 @@ class GcpSqlOperation(GcpResource):
         version="v1",
         accessors=["operations"],
         action="list",
-        request_parameter={"project": "{project}"},
+        request_parameter={"instance": "{instance}", "project": "{project}"},
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path=None,
@@ -901,4 +901,4 @@ class GcpSqlUser(GcpResource):
             builder.add_edge(self, reverse=True, clazz=GcpSqlDatabaseInstance)
 
 
-resources = [GcpSqlFlag, GcpSqlDatabaseInstance, GcpSqlOperation]
+resources = [GcpSqlFlag, GcpSqlDatabaseInstance]

--- a/plugins/gcp/test/test_sqladmin.py
+++ b/plugins/gcp/test/test_sqladmin.py
@@ -16,9 +16,4 @@ def test_gcp_sql_database_instance(random_builder: GraphBuilder) -> None:
     assert len(random_builder.edges_of(GcpSqlDatabaseInstance, GcpSqlBackupRun)) > 0
     assert len(random_builder.resources_of(GcpSqlDatabase)) > 0
     assert len(random_builder.resources_of(GcpSqlUser)) > 0
-
-
-def test_gcp_sql_operation(random_builder: GraphBuilder) -> None:
-    op = roundtrip(GcpSqlOperation, random_builder)
-    connect_resource(random_builder, op, GcpSqlDatabaseInstance, name=op.target_id)
-    assert len(random_builder.edges_of(GcpSqlDatabaseInstance, GcpSqlOperation)) == 1
+    assert len(random_builder.resources_of(GcpSqlOperation)) > 0


### PR DESCRIPTION
# Description

`GcpSqlOperation` needs `GcpDatabaseInstance` as [query parameter](https://cloud.google.com/sql/docs/mysql/admin-api/rest/v1/operations/list)

# To-Dos


- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`
- [ ] Document new or updated functionality (someengineering/resoto.com#XXXX)



# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
