### PR TITLE
[resoto][feat] auto enablement of collector plugins

### DIFF
--- a/plugins/aws/resoto_plugin_aws/__init__.py
+++ b/plugins/aws/resoto_plugin_aws/__init__.py
@@ -3,6 +3,7 @@ import multiprocessing
 from concurrent import futures
 from typing import List, Optional, Union, Any, Dict, Iterable
 
+import boto3
 import botocore.exceptions
 from botocore.model import OperationModel, Shape, StringShape, ListShape, StructureShape
 from jsons import pascalcase
@@ -56,6 +57,16 @@ class AWSCollectorPlugin(BaseCollectorPlugin):
     @staticmethod
     def add_config(cfg: Config) -> None:
         cfg.add_config(AwsConfig)
+
+    @staticmethod
+    def auto_enabled() -> bool:
+        try:
+            account_id = boto3.session.Session().client("sts").get_caller_identity().get("Account")
+            log.debug(f"plugin: AWS auto discovery succeeded, running in account {account_id}.")
+            return True
+        except Exception as e:
+            log.debug(f"plugin: AWS auto discovery failed: {e}")
+        return False
 
     @metrics_collect.time()  # type: ignore
     def collect(self) -> None:

--- a/plugins/aws/resoto_plugin_aws/__init__.py
+++ b/plugins/aws/resoto_plugin_aws/__init__.py
@@ -59,7 +59,7 @@ class AWSCollectorPlugin(BaseCollectorPlugin):
         cfg.add_config(AwsConfig)
 
     @staticmethod
-    def auto_enabled() -> bool:
+    def auto_enableable() -> bool:
         try:
             account_id = boto3.session.Session().client("sts").get_caller_identity().get("Account")
             log.debug(f"plugin: AWS auto discovery succeeded, running in account {account_id}.")

--- a/resotolib/resotolib/baseplugin.py
+++ b/resotolib/resotolib/baseplugin.py
@@ -215,6 +215,11 @@ class BaseCollectorPlugin(BasePlugin):
         pass
 
     @staticmethod
+    def auto_enabled() -> bool:
+        """Should this collector be enabled by default?"""
+        return False
+
+    @staticmethod
     def update_tag(config: Config, resource: BaseResource, key: str, value: str) -> bool:
         """Update the tag of a resource"""
         return resource.update_tag(key, value)

--- a/resotolib/resotolib/baseplugin.py
+++ b/resotolib/resotolib/baseplugin.py
@@ -215,7 +215,7 @@ class BaseCollectorPlugin(BasePlugin):
         pass
 
     @staticmethod
-    def auto_enabled() -> bool:
+    def auto_enableable() -> bool:
         """Should this collector be enabled by default?"""
         return False
 

--- a/resotolib/resotolib/config.py
+++ b/resotolib/resotolib/config.py
@@ -17,10 +17,9 @@ from resotolib.core.config import (
 )
 from resotolib.core.events import CoreEvents
 from resotolib.utils import replace_env_vars, merge_json_elements, drop_deleted_attributes
+from resotolib.types import Json
 from typing import Dict, Any, List, Optional, Type, cast
 from attrs import fields
-
-from resotolib.types import Json
 
 
 class RunningConfig:

--- a/resotoworker/resotoworker/__main__.py
+++ b/resotoworker/resotoworker/__main__.py
@@ -93,7 +93,7 @@ def main() -> None:
         tls_data=tls_data,
     )
 
-    add_config(config)
+    add_config(config, plugin_loader.all_collector_plugins())
     plugin_loader.add_plugin_config(config)
     config.load_config()
 

--- a/resotoworker/resotoworker/config.py
+++ b/resotoworker/resotoworker/config.py
@@ -1,4 +1,4 @@
-import concurrent.futures
+from concurrent.futures import ThreadPoolExecutor, TimeoutError
 from collections import namedtuple
 from resotolib.graph import GraphMergeKind
 from resotolib.config import Config
@@ -24,13 +24,13 @@ def get_default_collectors() -> List[str]:
         return PluginAutoEnabledResult(plugin.cloud, plugin.auto_enabled())
 
     try:
-        with concurrent.futures.ThreadPoolExecutor(max_workers=20, thread_name_prefix="AutoDiscovery") as executor:
+        with ThreadPoolExecutor(max_workers=20, thread_name_prefix="AutoDiscovery") as executor:
             return [
                 plugin_result.cloud
                 for plugin_result in executor.map(plugin_auto_enabled, _collector_plugins, timeout=10)
                 if plugin_result.auto_enabled
             ]
-    except concurrent.futures.TimeoutError:
+    except TimeoutError:
         log.error("Timeout while getting auto-enabled collectors")
     except Exception as e:
         log.error(f"Unhandled exception while getting auto-enabled collectors: {e}")

--- a/resotoworker/resotoworker/config.py
+++ b/resotoworker/resotoworker/config.py
@@ -1,19 +1,29 @@
 from resotolib.graph import GraphMergeKind
 from resotolib.config import Config
 from resotolib.proc import num_default_threads
+from resotolib.baseplugin import BaseCollectorPlugin
 from attrs import define, field
-from typing import ClassVar, Optional, List
+from typing import ClassVar, Optional, List, Type
 
 
-def add_config(config: Config) -> None:
+_collector_plugins: List[Type[BaseCollectorPlugin]] = []
+
+
+def add_config(config: Config, collector_plugins: List[Type[BaseCollectorPlugin]]) -> None:
+    global _collector_plugins
+    _collector_plugins = collector_plugins
     config.add_config(ResotoWorkerConfig)
+
+
+def get_default_collectors() -> List[str]:
+    return [plugin.cloud for plugin in _collector_plugins if plugin.auto_enabled()]
 
 
 @define
 class ResotoWorkerConfig:
     kind: ClassVar[str] = "resotoworker"
     collector: List[str] = field(
-        factory=lambda: ["example"],
+        factory=get_default_collectors,
         metadata={"description": "List of collectors to run", "restart_required": True},
     )
     graph: str = field(

--- a/resotoworker/resotoworker/config.py
+++ b/resotoworker/resotoworker/config.py
@@ -14,7 +14,7 @@ _default_collectors: List[str] = []
 @frozen
 class PluginAutoEnabledResult:
     cloud: str
-    auto_enabled: bool
+    auto_enableable: bool
 
 
 def add_config(config: Config, collector_plugins: List[Type[BaseCollectorPlugin]]) -> None:
@@ -26,12 +26,12 @@ def set_default_collectors(collector_plugins: List[Type[BaseCollectorPlugin]]) -
     global _default_collectors
 
     def plugin_auto_enabled(plugin: Type[BaseCollectorPlugin]) -> PluginAutoEnabledResult:
-        return PluginAutoEnabledResult(plugin.cloud, plugin.auto_enabled())
+        return PluginAutoEnabledResult(plugin.cloud, plugin.auto_enableable())
 
     try:
         with ThreadPoolExecutor(max_workers=20, thread_name_prefix="AutoDiscovery") as executor:
             for plugin_result in executor.map(plugin_auto_enabled, collector_plugins, timeout=10):
-                if plugin_result.auto_enabled and plugin_result.cloud not in _default_collectors:
+                if plugin_result.auto_enableable and plugin_result.cloud not in _default_collectors:
                     _default_collectors.append(plugin_result.cloud)
     except TimeoutError:
         log.error("Timeout while getting auto-enabled collectors")

--- a/resotoworker/resotoworker/config.py
+++ b/resotoworker/resotoworker/config.py
@@ -1,12 +1,16 @@
+import concurrent.futures
+from collections import namedtuple
 from resotolib.graph import GraphMergeKind
 from resotolib.config import Config
 from resotolib.proc import num_default_threads
 from resotolib.baseplugin import BaseCollectorPlugin
+from resotolib.logger import log
 from attrs import define, field
 from typing import ClassVar, Optional, List, Type
 
 
 _collector_plugins: List[Type[BaseCollectorPlugin]] = []
+PluginAutoEnabledResult = namedtuple("PluginAutoEnabledResult", ["cloud", "auto_enabled"])
 
 
 def add_config(config: Config, collector_plugins: List[Type[BaseCollectorPlugin]]) -> None:
@@ -16,7 +20,21 @@ def add_config(config: Config, collector_plugins: List[Type[BaseCollectorPlugin]
 
 
 def get_default_collectors() -> List[str]:
-    return [plugin.cloud for plugin in _collector_plugins if plugin.auto_enabled()]
+    def plugin_auto_enabled(plugin: Type[BaseCollectorPlugin]) -> PluginAutoEnabledResult:
+        return PluginAutoEnabledResult(plugin.cloud, plugin.auto_enabled())
+
+    try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=20, thread_name_prefix="AutoDiscovery") as executor:
+            return [
+                plugin_result.cloud
+                for plugin_result in executor.map(plugin_auto_enabled, _collector_plugins, timeout=10)
+                if plugin_result.auto_enabled
+            ]
+    except concurrent.futures.TimeoutError:
+        log.error("Timeout while getting auto-enabled collectors")
+    except Exception as e:
+        log.error(f"Unhandled exception while getting auto-enabled collectors: {e}")
+    return []
 
 
 @define

--- a/resotoworker/resotoworker/pluginloader.py
+++ b/resotoworker/resotoworker/pluginloader.py
@@ -21,7 +21,7 @@ class PluginLoader:
         #   PluginType.PERSISTENT: [SlackNotificationPlugin, VolumeCleanupPlugin]
         # }
         self._plugins: Dict[PluginType, List[Union[Type[BasePlugin], Type[BaseActionPlugin]]]] = {}
-        self._initialized = False
+        self._initialized: bool = False
 
         if plugin_type is not None:
             log.debug(f"Only loading plugins of type {plugin_type}")
@@ -89,6 +89,9 @@ class PluginLoader:
         if plugin_type is not None:
             return self._plugins.get(plugin_type, [])  # type: ignore
         return [plugin for plugins in self._plugins.values() for plugin in plugins]
+
+    def all_collector_plugins(self) -> List[Type[BaseCollectorPlugin]]:
+        return cast(List[Type[BaseCollectorPlugin]], self.all_plugins(plugin_type=PluginType.COLLECTOR))
 
     def add_plugin_args(self, arg_parser: ArgumentParser) -> None:
         """Add args to the arg parser"""


### PR DESCRIPTION
# Description

This PR implements auto enablement of collector plugins.

A `BaseCollectorPlugin` can now implement an `auto_enabled()` method that returns a bool whether the collector should be enabled or not. The default for all collectors is `False`.

This PR also implements `auto_enabled()` for the AWS collector.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
