### PR TITLE
[resotolib][fix] Pin attrs

### DIFF
--- a/resotolib/requirements.txt
+++ b/resotolib/requirements.txt
@@ -14,5 +14,6 @@ parsy==2.0
 tzlocal==4.2
 tzdata==2022.7
 cattrs==22.2.0
+attrs==22.2.0
 setuptools==67.2.0
 PyYAML==6.0


### PR DESCRIPTION
# Description

Pin attrs since cattrs only depends on
```
attrs = ">= 20"
```

which makes `cloud2sql` fail on systems that come with an old attrs version pre-installed.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
