### PR TITLE
[resotoworker][fix] Return empty list when no collectors are configured

### DIFF
--- a/resotolib/requirements-test.txt
+++ b/resotolib/requirements-test.txt
@@ -10,4 +10,4 @@ pytest-cov==4.0.0
 pytest-runner==6.0.0
 mypy==1.2.0
 pytest-asyncio==0.21.0
-hypothesis==6.71.0
+hypothesis==6.72.0

--- a/resotoworker/resotoworker/pluginloader.py
+++ b/resotoworker/resotoworker/pluginloader.py
@@ -67,15 +67,14 @@ class PluginLoader:
             self.find_plugins()
         configured_collectors: Set[str] = set(Config.resotoworker.collector)
 
-        if plugin_type == PluginType.POST_COLLECT and len(configured_collectors) > 0:
+        if plugin_type == PluginType.POST_COLLECT:
             post_collect_plugins = cast(List[Type[BasePostCollectPlugin]], self._plugins.get(plugin_type, []))
             return [
                 plugin
                 for plugin in post_collect_plugins
                 if plugin.activate_with.issubset(configured_collectors) or plugin.name in configured_collectors
             ]
-
-        if plugin_type == PluginType.COLLECTOR and len(configured_collectors) > 0:
+        elif plugin_type == PluginType.COLLECTOR:
             plugins: List[Type[BaseCollectorPlugin]] = self._plugins.get(plugin_type, [])  # type: ignore
             return [plugin for plugin in plugins if plugin.cloud in configured_collectors]
 


### PR DESCRIPTION
# Description

Return empty list when no collectors are configured


# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
