### PR TITLE
[resotocore][fix] Make infra apps execute full lines not chunks

### DIFF
--- a/resotocore/resotocore/infra_apps/local_runtime.py
+++ b/resotocore/resotocore/infra_apps/local_runtime.py
@@ -5,6 +5,7 @@ from resotocore.types import Json, JsonElement
 from resotocore.ids import GraphName
 from resotocore.db.model import QueryModel
 from resotocore.cli.model import CLI, CLIContext
+from resotolib.asynchronous.utils import async_lines
 from jinja2 import Environment
 import logging
 from aiostream.core import Stream
@@ -61,13 +62,8 @@ class LocalResotocoreAppRuntime(Runtime):
         graphdb = self.dbaccess.get_graph_db(graph)
         env = Environment(extensions=["jinja2.ext.do", "jinja2.ext.loopcontrols"], enable_async=True)
         template = env.from_string(manifest.source)
-        template.globals["args"] = kwargs
-        template.globals["stdin"] = stdin
-        template.globals["config"] = config
-        template.globals["parse_duration"] = parse_duration
 
         model = await self.model_handler.load_model(graph)
-
         async def perform_search(search: str) -> AsyncIterator[Json]:
             # parse query
             query = await self.template_expander.parse_query(search, on_section="reported")
@@ -75,11 +71,12 @@ class LocalResotocoreAppRuntime(Runtime):
                 async for result in ctx:
                     yield result
 
+        template.globals["parse_duration"] = parse_duration
         template.globals["search"] = perform_search
 
-        async for line in template.generate_async(config=config, *kwargs._get_kwargs()):
-            log.debug(f"Rendered infrastructure app line: {line}")
+        async for line in async_lines(template.generate_async(config=config, args=kwargs, stdin=stdin)):
             line = line.strip()
+            log.debug(f"Rendered infrastructure app line: {line}")
             if not line:
                 continue
             yield line

--- a/resotocore/resotocore/infra_apps/local_runtime.py
+++ b/resotocore/resotocore/infra_apps/local_runtime.py
@@ -64,6 +64,7 @@ class LocalResotocoreAppRuntime(Runtime):
         template = env.from_string(manifest.source)
 
         model = await self.model_handler.load_model(graph)
+
         async def perform_search(search: str) -> AsyncIterator[Json]:
             # parse query
             query = await self.template_expander.parse_query(search, on_section="reported")

--- a/resotocore/resotocore/infra_apps/local_runtime.py
+++ b/resotocore/resotocore/infra_apps/local_runtime.py
@@ -5,13 +5,13 @@ from resotocore.types import Json, JsonElement
 from resotocore.ids import GraphName
 from resotocore.db.model import QueryModel
 from resotocore.cli.model import CLI, CLIContext
-from resotolib.asynchronous.utils import async_lines
 from jinja2 import Environment
 import logging
 from aiostream.core import Stream
 from aiostream import stream
 from argparse import Namespace
 from resotolib.durations import parse_duration
+from resotolib.asynchronous.utils import async_lines
 
 
 log = logging.getLogger(__name__)

--- a/resotolib/resotolib/asynchronous/utils.py
+++ b/resotolib/resotolib/asynchronous/utils.py
@@ -1,0 +1,12 @@
+from typing import AsyncGenerator
+
+async def async_lines(async_generator: AsyncGenerator[str, None]) -> AsyncGenerator[str, None]:
+    buffer = ""
+    async for chunk in async_generator:
+        buffer += chunk
+        lines = buffer.split("\n")
+        for line in lines[:-1]:
+            yield line
+        buffer = lines[-1]
+    if buffer:
+        yield buffer

--- a/resotolib/resotolib/asynchronous/utils.py
+++ b/resotolib/resotolib/asynchronous/utils.py
@@ -1,9 +1,9 @@
-from typing import AsyncGenerator
+from typing import AsyncIterator
 
 
-async def async_lines(async_generator: AsyncGenerator[str, None]) -> AsyncGenerator[str, None]:
+async def async_lines(async_iterator: AsyncIterator[str]) -> AsyncIterator[str]:
     buffer = ""
-    async for chunk in async_generator:
+    async for chunk in async_iterator:
         buffer += chunk
         lines = buffer.split("\n")
         for line in lines[:-1]:

--- a/resotolib/resotolib/asynchronous/utils.py
+++ b/resotolib/resotolib/asynchronous/utils.py
@@ -1,5 +1,6 @@
 from typing import AsyncGenerator
 
+
 async def async_lines(async_generator: AsyncGenerator[str, None]) -> AsyncGenerator[str, None]:
     buffer = ""
     async for chunk in async_generator:


### PR DESCRIPTION
# Description

Make infra apps execute full lines not chunks.
Also refactors some of the template args to be passed as args not put in the global space.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
