### PR TITLE
[plugins/digitalocean] Fill in backends when collecting load balancers.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,7 +13,7 @@
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
     "python.formatting.provider": "black",
-    "cSpell.words": [
-        "popleft"
-    ]
+    "editor.codeActionsOnSave": {
+        "source.organizeImports": true
+    }
 }

--- a/plugins/digitalocean/resoto_plugin_digitalocean/collector.py
+++ b/plugins/digitalocean/resoto_plugin_digitalocean/collector.py
@@ -798,6 +798,7 @@ class DigitalOceanTeamCollector:
                 "public_ip_address": "ip",
                 "nr_nodes": get_nr_nodes,
                 "loadbalancer_status": "status",
+                "backends": lambda lb: [droplet_id(id) for id in (lb.get("droplet_ids", []) or [])],
                 "redirect_http_to_https": "redirect_http_to_https",
                 "enable_proxy_protocol": "enable_proxy_protocol",
                 "enable_backend_keepalive": "enable_backend_keepalive",


### PR DESCRIPTION
# Description

Digitalocean collector will fill in the backends field when collecting load balancers. Also, a small vscode configuration improvement. 

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [ ] Add test coverage for new or updated functionality
- [ ] Lint and test with `tox`
- [ ] Document new or updated functionality (someengineering/resoto.com#XXXX)

# Issues Fixed

<!-- If this PR will fix/resolve an open issue on the repository, please reference it below. -->
<!-- (Otherwise, feel free to delete this section.) -->

- Fixes #1316  (partly, only the Digitalocean part of the problem)

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
