### PR TITLE
[resotoworker][feat] Define home-directory files as dict

### DIFF
--- a/resotoworker/Makefile
+++ b/resotoworker/Makefile
@@ -1,0 +1,81 @@
+.PHONY: clean clean-test clean-pyc clean-build clean-env docs help setup test test-all coverage list-outdated install-latest
+.DEFAULT_GOAL := help
+.SILENT: clean clean-build clean-pyc clean-test setup
+
+define BROWSER_PYSCRIPT
+import os, webbrowser, sys
+
+from urllib.request import pathname2url
+
+webbrowser.open("file://" + pathname2url(os.path.abspath(sys.argv[1])))
+endef
+export BROWSER_PYSCRIPT
+
+define PRINT_HELP_PYSCRIPT
+import re, sys
+
+for line in sys.stdin:
+	match = re.match(r'^([a-zA-Z_-]+):.*?## (.*)$$', line)
+	if match:
+		target, help = match.groups()
+		print("%-20s %s" % (target, help))
+endef
+export PRINT_HELP_PYSCRIPT
+
+BROWSER := python -c "$$BROWSER_PYSCRIPT"
+
+help:
+	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
+
+clean: clean-build clean-pyc clean-test ## remove all build, test, coverage and Python artifacts
+
+clean-build: ## remove build artifacts
+	rm -fr build/
+	rm -fr out/
+	rm -fr gen/
+	rm -fr dist/
+	rm -fr .eggs/
+	rm -fr .hypothesis/
+	rm -fr .mypy_cache/
+	find . -name '*.egg-info' -exec rm -fr {} +
+	find . -name '*.egg' -exec rm -fr {} +
+
+clean-pyc: ## remove Python file artifacts
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '*~' -exec rm -f {} +
+	find . -name '__pycache__' -exec rm -fr {} +
+
+clean-test: ## remove test and coverage artifacts
+	rm -fr .tox/
+	rm -f .coverage
+	rm -fr htmlcov/
+	rm -fr .pytest_cache
+
+clean-env: ## remove environment
+	rm -fr venv-pypy
+
+lint: ## static code analysis
+	black --line-length 120 --check resotoworker test
+	flake8 resotoworker
+	#pylint resotoworker
+	mypy --python-version 3.9 --strict --install-types --non-interactive resotoworker
+
+test: ## run tests quickly with the default Python
+	pytest
+
+test-all: ## run tests on every Python version with tox
+	tox
+
+coverage: ## check code coverage quickly with the default Python
+	coverage run --source resotoworker -m pytest
+	coverage combine
+	coverage report -m
+	coverage html
+	$(BROWSER) htmlcov/index.html
+
+list-outdated:
+	pip list --outdated
+
+install-latest:
+	pip list --outdated --format=freeze | grep -v '^\-e' | cut -d = -f 1  | xargs -n1 pip install -U

--- a/resotoworker/resotoworker/__main__.py
+++ b/resotoworker/resotoworker/__main__.py
@@ -98,7 +98,7 @@ def main() -> None:
     plugin_loader.add_plugin_config(config)
     config.load_config()
 
-    write_files_to_home_dir(config.resotoworker.write_files_to_home_dir, write_utf8_file)
+    write_files_to_home_dir(config.resotoworker.all_files_in_home_dir(), write_utf8_file)
 
     def send_request(request: requests.Request) -> requests.Response:
         prepared = request.prepare()

--- a/resotoworker/resotoworker/config.py
+++ b/resotoworker/resotoworker/config.py
@@ -110,7 +110,7 @@ class ResotoWorkerConfig:
         },
     )
     # optional for backwards compatibility
-    files_in_home_dir: Optional[Dict[str, str]] = field(
+    files_in_home_dir: Optional[Dict[str, str]] = field(  # type: ignore
         factory=dict,
         metadata={
             "description": (

--- a/resotoworker/test/test_args.py
+++ b/resotoworker/test/test_args.py
@@ -1,6 +1,7 @@
 from resotolib.args import ArgumentParser
 from resotoworker.__main__ import add_args
 from resotolib.core import add_args as core_add_args, resotocore
+from resotoworker.config import ResotoWorkerConfig, HomeDirectoryFile
 
 
 def test_args() -> None:
@@ -12,3 +13,13 @@ def test_args() -> None:
     core_add_args(arg_parser)
     arg_parser.parse_args()
     assert resotocore.http_uri == "https://localhost:8900"
+
+
+def test_config() -> None:
+    cfg = ResotoWorkerConfig(write_files_to_home_dir=[HomeDirectoryFile(path="a", content="a")])
+    assert cfg.all_files_in_home_dir() == [HomeDirectoryFile("a", "a")]
+    cfg = ResotoWorkerConfig(
+        write_files_to_home_dir=[HomeDirectoryFile(path="a", content="a")],
+        files_in_home_dir={"b": "b"},
+    )
+    assert cfg.all_files_in_home_dir() == [HomeDirectoryFile("a", "a"), HomeDirectoryFile("b", "b")]


### PR DESCRIPTION
# Description

Define configuration to allow the path to be used as a key.
This way, having two entries with the same path is impossible.

<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
