### PR TITLE
[plugins/aws][fix] Set default region on all sessions

### DIFF
--- a/plugins/aws/resoto_plugin_aws/__init__.py
+++ b/plugins/aws/resoto_plugin_aws/__init__.py
@@ -463,7 +463,7 @@ def probe_partition(account: Optional[str] = None, role: Optional[str] = None, p
         try:
             session = aws_session(account=account, role=role, profile=profile, partition=partition)
             _ = session.client("sts", region_name=region).get_caller_identity().get("Account")
-        except Exception as e:
+        except Exception:
             pass
         else:
             return partition

--- a/plugins/aws/resoto_plugin_aws/utils.py
+++ b/plugins/aws/resoto_plugin_aws/utils.py
@@ -63,16 +63,19 @@ def aws_session(
             aws_access_key_id=credentials["AccessKeyId"],
             aws_secret_access_key=credentials["SecretAccessKey"],
             aws_session_token=credentials["SessionToken"],
+            region_name=global_region,
         )
     else:
         if profile:
             return BotoSession(
                 profile_name=profile,
+                region_name=global_region,
             )
         else:
             return BotoSession(
                 aws_access_key_id=Config.aws.access_key_id,
                 aws_secret_access_key=Config.aws.secret_access_key,
+                region_name=global_region,
             )
 
 


### PR DESCRIPTION
# Description

Set default region on all sessions.

This makes it so that every session that is created, has the partition's global region set as default. A client can then override the region with their own choice of region or if not specified (e.g. IAM) it will use the correct global region for the accounts partition.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
