### PR TITLE
[resotoshell][feat] Do not store passwords in shell history

### DIFF
--- a/resotocore/resotocore/cli/command.py
+++ b/resotocore/resotocore/cli/command.py
@@ -148,6 +148,7 @@ from resotocore.web.content_renderer import (
     respond_cytoscape,
 )
 from resotocore.worker_task_queue import WorkerTask, WorkerTaskName
+from resotolib.core import CLIEnvelope
 from resotolib.parse_util import (
     double_quoted_or_simple_string_dp,
     space_dp,
@@ -4436,7 +4437,7 @@ class ConfigsCommand(CLICommand):
             return CLISource.single(
                 partial(edit_config, config_id),
                 produces=MediaType.FilePath,
-                envelope={"Resoto-Shell-Action": "edit", "Resoto-Shell-Command": f"configs update {config_id}"},
+                envelope={CLIEnvelope.action: "edit", CLIEnvelope.command: f"configs update {config_id}"},
             )
         elif arg and len(args) == 3 and args[0] == "copy":
             return CLISource.single(partial(copy_config, args[1], args[2]))
@@ -4445,7 +4446,7 @@ class ConfigsCommand(CLICommand):
             return CLISource.single(
                 partial(update_config, config_id),
                 produces=MediaType.FilePath,
-                envelope={"Resoto-Shell-Action": "edit", "Resoto-Shell-Command": f"configs update {config_id}"},
+                envelope={CLIEnvelope.action: "edit", CLIEnvelope.command: f"configs update {config_id}"},
                 requires=[CLIFileRequirement("config.yaml", args[2])],
             )
         elif arg and len(args) == 1 and args[0] == "list":
@@ -5060,14 +5061,14 @@ class InfrastructureAppsCommand(CLICommand):
             return CLISource.single(
                 partial(edit_app, app_name),
                 produces=MediaType.FilePath,
-                envelope={"Resoto-Shell-Action": "edit", "Resoto-Shell-Command": f"apps update {app_name}"},
+                envelope={CLIEnvelope.action: "edit", CLIEnvelope.command: f"apps update {app_name}"},
             )
         elif arg and len(args) == 3 and args[0] == "update":
             app_name = InfraAppName(args[1])
             return CLISource.single(
                 partial(update_app, app_name),
                 produces=MediaType.FilePath,
-                envelope={"Resoto-Shell-Action": "edit", "Resoto-Shell-Command": f"apps update {app_name}"},
+                envelope={CLIEnvelope.action: "edit", CLIEnvelope.command: f"apps update {app_name}"},
                 requires=[CLIFileRequirement("manifest.yaml", args[2])],
             )
         elif len(args) == 2 and args[0] == "uninstall":
@@ -5285,7 +5286,8 @@ class UserCommand(CLICommand):
             parser.add_argument("--role", type=str, action="append", required=True)
             parsed = parser.parse_args(args[1:])
             return CLISource.single(
-                partial(self.add_user, Email(parsed.email), parsed.fullname, Password(parsed.password), parsed.role)
+                partial(self.add_user, Email(parsed.email), parsed.fullname, Password(parsed.password), parsed.role),
+                envelope={CLIEnvelope.no_history: "yes"},
             )
         elif len(args) == 2 and args[0].startswith("del"):
             return CLISource.single(partial(self.delete_user, Email(args[1])))
@@ -5294,7 +5296,10 @@ class UserCommand(CLICommand):
         elif len(args) > 3 and args[0] == "role" and args[1].startswith("del"):
             return CLISource.single(partial(self.delete_role, Email(args[2]), args[3]))
         elif len(args) >= 3 and args[0] in ("passwd", "password"):
-            return CLISource.single(partial(self.change_password, Email(args[1]), Password(args[2])))
+            return CLISource.single(
+                partial(self.change_password, Email(args[1]), Password(args[2])),
+                envelope={CLIEnvelope.no_history: "yes"},
+            )
         elif len(args) == 1 and args[0] == "list":
             return CLISource.no_count(self.list_users)
         elif len(args) == 2 and args[0] == "show":

--- a/resotocore/resotocore/web/api.py
+++ b/resotocore/resotocore/web/api.py
@@ -1157,7 +1157,7 @@ class Api:
                 gen = await force_gen(streamer)
                 if first_result.produces.text:
                     text_gen = ctx.text_generator(first_result, gen)
-                    return await self.stream_response_from_gen(request, text_gen, count)
+                    return await self.stream_response_from_gen(request, text_gen, count, first_result.envelope)
                 elif first_result.produces.file_path:
                     await mp_response.prepare(request)
                     await Api.multi_file_response(first_result, gen, boundary, mp_response)

--- a/resotolib/resotolib/core/__init__.py
+++ b/resotolib/resotolib/core/__init__.py
@@ -7,6 +7,23 @@ from urllib.parse import urlparse, ParseResult
 from typing import Optional
 
 
+class CLIEnvelope:
+    """
+    Envelope fields that are used by the CLI.
+    Those fields are encoded as HTTP Headers into the HTTP response.
+    """
+
+    # Defines the action that should be performed.
+    # Use cases:
+    # - "edit": A file that is returned from the core should be opened in an editor.
+    #           The result of the edit should be sent back to the core, identified by the "command" envelope field.
+    action = "Resoto-Shell-Action"
+    # Defines the command that should be executed after the edit was performed.
+    command = "Resoto-Shell-Command"
+    # Do not add this command to the shell history.
+    no_history = "Resoto-Shell-No-History"
+
+
 def add_args(arg_parser: ArgumentParser) -> None:
     arg_parser.add_argument(
         "--resotocore-uri",

--- a/resotoshell/resotoshell/authorized_client.py
+++ b/resotoshell/resotoshell/authorized_client.py
@@ -134,7 +134,7 @@ class ReshConfig:
     def write(self) -> None:
         if self.dirty:
             self.path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-            with open(os.open(self.path, os.O_CREAT | os.O_WRONLY, 0o600), "w+") as f:
+            with open(os.open(self.path, os.O_CREAT | os.O_WRONLY, 0o600), "w+", encoding="utf-8") as f:
                 self.config.write(f)
 
     @staticmethod


### PR DESCRIPTION
# Description

Enable marking commands that should not be stored in history.
Do not store commands in history marked with no_history.

Move the history file to the `.resoto/shell_history` location.
<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`
- [x] Document new or updated functionality (someengineering/resoto.com#XXXX)


# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
