### PR TITLE
[aws][feat] Allow glob style service filters

### DIFF
--- a/plugins/aws/resoto_plugin_aws/configuration.py
+++ b/plugins/aws/resoto_plugin_aws/configuration.py
@@ -252,8 +252,8 @@ class AwsConfig:
         # no_collect has precedence over collect
         if self.no_collect and any(fnmatch(name, p) for p in self.no_collect):
             return False
-        if self.collect and any(fnmatch(name, p) for p in self.collect):
-            return True
+        if self.collect:
+            return any(fnmatch(name, p) for p in self.collect)
         return True
 
     def shared_tasks_per_key(self, regions: List[str]) -> Callable[[str], int]:

--- a/plugins/aws/test/configuration_test.py
+++ b/plugins/aws/test/configuration_test.py
@@ -33,11 +33,23 @@ def test_should_collect() -> None:
     assert not simple.should_collect("s3")
     assert not simple.should_collect("not_defined")
 
-    glob = AwsConfig(collect=["*sagemaker*"], no_collect=["ec?"])
-    assert not glob.should_collect("ec2")
-    assert not glob.should_collect("electronic")
-    assert glob.should_collect("aws_sagemaker_artifact")
-    assert not glob.should_collect("not_defined")
+    glob_collect = AwsConfig(collect=["*sagemaker*"])
+    assert not glob_collect.should_collect("ec2")
+    assert glob_collect.should_collect("aws_sagemaker_artifact")
+    assert not glob_collect.should_collect("not_defined")
+
+    glob_no_collect = AwsConfig(no_collect=["ec?"])
+    assert not glob_no_collect.should_collect("ec2")
+    assert not glob_no_collect.should_collect("ec3")
+    assert glob_no_collect.should_collect("aws_sagemaker_artifact")
+    assert glob_no_collect.should_collect("not_defined")
+
+    glob_combined = AwsConfig(collect=["*ec*"], no_collect=["ec?"])
+    assert glob_combined.should_collect("electronics")
+    assert glob_combined.should_collect("ec")
+    assert not glob_combined.should_collect("ec2")
+    assert not glob_combined.should_collect("ec3")
+    assert not glob_combined.should_collect("not_defined")
 
 
 def test_session() -> None:

--- a/plugins/aws/test/configuration_test.py
+++ b/plugins/aws/test/configuration_test.py
@@ -33,7 +33,7 @@ def test_should_collect() -> None:
     assert not simple.should_collect("s3")
     assert not simple.should_collect("not_defined")
 
-    glob = AwsConfig(collect=["*sagemaker*"], no_collect=["*ec*"])
+    glob = AwsConfig(collect=["*sagemaker*"], no_collect=["ec?"])
     assert not glob.should_collect("ec2")
     assert not glob.should_collect("electronic")
     assert glob.should_collect("aws_sagemaker_artifact")

--- a/plugins/aws/test/configuration_test.py
+++ b/plugins/aws/test/configuration_test.py
@@ -24,6 +24,17 @@ def test_default_config() -> None:
     assert len(Config.aws.no_collect) == 0
 
 
+def test_should_collect() -> None:
+    simple = AwsConfig(collect=["ec2", "s3"], no_collect=["s3"])
+    assert simple.should_collect("ec2")
+    assert not simple.should_collect("s3")
+
+    glob = AwsConfig(collect=["*sagemaker*"], no_collect=["*ec*"])
+    assert not glob.should_collect("ec2")
+    assert not glob.should_collect("electronic")
+    assert simple.should_collect("aws_sagemaker_artifact")
+
+
 def test_session() -> None:
     config = AwsConfig("test", "test", "test")
     # direct session

--- a/plugins/aws/test/configuration_test.py
+++ b/plugins/aws/test/configuration_test.py
@@ -25,14 +25,19 @@ def test_default_config() -> None:
 
 
 def test_should_collect() -> None:
+    no_filter = AwsConfig()
+    assert no_filter.should_collect("not_defined")  # no filter defined, so everything is collected
+
     simple = AwsConfig(collect=["ec2", "s3"], no_collect=["s3"])
     assert simple.should_collect("ec2")
     assert not simple.should_collect("s3")
+    assert not simple.should_collect("not_defined")
 
     glob = AwsConfig(collect=["*sagemaker*"], no_collect=["*ec*"])
     assert not glob.should_collect("ec2")
     assert not glob.should_collect("electronic")
-    assert simple.should_collect("aws_sagemaker_artifact")
+    assert glob.should_collect("aws_sagemaker_artifact")
+    assert not glob.should_collect("not_defined")
 
 
 def test_session() -> None:


### PR DESCRIPTION
# Description

Define `collect` and `no_collect` with GLOB style wildcards.
Example:
```yaml:
collect:
  - ec?
no_collect:
  - *sagemaker*
```
# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
