### PR TITLE
[resotocore][feat] Allow filtering of report checks

### DIFF
--- a/resotocore/resotocore/cli/cli.py
+++ b/resotocore/resotocore/cli/cli.py
@@ -461,11 +461,13 @@ class CLIService(CLI):
             if parts:
                 query, options, query_parts = await self.create_query(parts, ctx)
                 ctx_wq = evolve(ctx, query=query, query_options=options, commands=commands)
-                remaining = [self.command(c.name, c.arg, ctx_wq) for c in commands[len(parts) :]]  # noqa: E203
+                remaining = [
+                    self.command(c.name, c.arg, ctx_wq, position=pos) for pos, c in enumerate(commands[len(parts) :])
+                ]  # noqa: E203
                 rewritten_parts = [*query_parts, *remaining]
             else:
                 ctx_wq = evolve(ctx, commands=commands)
-                rewritten_parts = [self.command(c.name, c.arg, ctx_wq) for c in commands]
+                rewritten_parts = [self.command(c.name, c.arg, ctx_wq, position=pos) for pos, c in enumerate(commands)]
             # re-evaluate remaining commands - to take the adapted context into account
             return ctx_wq, rewritten_parts
 

--- a/resotocore/resotocore/cli/cli.py
+++ b/resotocore/resotocore/cli/cli.py
@@ -460,11 +460,14 @@ class CLIService(CLI):
             parts = list(takewhile(lambda x: isinstance(x.command, SearchCLIPart), commands))
             if parts:
                 query, options, query_parts = await self.create_query(parts, ctx)
-                ctx_wq = evolve(ctx, query=query, query_options=options)
-                # re-evaluate remaining commands - to take the adapted context into account
+                ctx_wq = evolve(ctx, query=query, query_options=options, commands=commands)
                 remaining = [self.command(c.name, c.arg, ctx_wq) for c in commands[len(parts) :]]  # noqa: E203
-                return ctx_wq, [*query_parts, *remaining]
-            return ctx, commands
+                rewritten_parts = [*query_parts, *remaining]
+            else:
+                ctx_wq = evolve(ctx, commands=commands)
+                rewritten_parts = [self.command(c.name, c.arg, ctx_wq) for c in commands]
+            # re-evaluate remaining commands - to take the adapted context into account
+            return ctx_wq, rewritten_parts
 
         def rewrite_command_line(cmds: List[ExecutableCommand], ctx: CLIContext) -> List[ExecutableCommand]:
             """
@@ -515,13 +518,12 @@ class CLIService(CLI):
 
         async def parse_line(parsed: ParsedCommands) -> ParsedCommandLine:
             ctx = adjust_context(parsed)
-            ctx, commands = await combine_query_parts(
-                [self.command(c.cmd, c.args, ctx, position=i) for i, c in enumerate(parsed.commands)], ctx
-            )
-            rewritten = rewrite_command_line(commands, ctx)
-            not_met = [r for cmd in rewritten for r in cmd.action.required if r.name not in context.uploaded_files]
-            envelope = {k: v for cmd in rewritten for k, v in cmd.action.envelope.items()}
-            return ParsedCommandLine(ctx, parsed, rewritten, not_met, envelope)
+            executable = [self.command(c.cmd, c.args, ctx, position=i) for i, c in enumerate(parsed.commands)]
+            rewritten = rewrite_command_line(executable, ctx)
+            ctx, commands = await combine_query_parts(rewritten, ctx)
+            not_met = [r for cmd in commands for r in cmd.action.required if r.name not in context.uploaded_files]
+            envelope = {k: v for cmd in commands for k, v in cmd.action.envelope.items()}
+            return ParsedCommandLine(ctx, parsed, commands, not_met, envelope)
 
         def expand_aliases(line: ParsedCommands) -> ParsedCommands:
             def expand_alias(alias_cmd: ParsedCommand) -> List[ParsedCommand]:

--- a/resotocore/resotocore/cli/model.py
+++ b/resotocore/resotocore/cli/model.py
@@ -77,7 +77,7 @@ class CLIContext:
         # if there is no entity provider, always assume the root section
         section = (
             self.env.get("section")
-            if self.commands and isinstance(self.commands[0].command, EntityProvider)
+            if self.query or self.commands and isinstance(self.commands[0].command, EntityProvider)
             else PathRoot
         )
         return variable_to_absolute(section, variable)

--- a/resotocore/resotocore/cli/model.py
+++ b/resotocore/resotocore/cli/model.py
@@ -65,6 +65,7 @@ class CLIContext:
     uploaded_files: Dict[str, str] = field(factory=dict)  # id -> path
     query: Optional[Query] = None
     query_options: Dict[str, Any] = field(factory=dict)
+    commands: List[ExecutableCommand] = field(factory=list)
     console_renderer: Optional[ConsoleRenderer] = None
     source: Optional[str] = None  # who is calling
 
@@ -73,8 +74,12 @@ class CLIContext:
         return GraphName(self.env["graph"])
 
     def variable_in_section(self, variable: str) -> str:
-        # if there is no query, always assume the root section
-        section = self.env.get("section") if self.query else PathRoot
+        # if there is no entity provider, always assume the root section
+        section = (
+            self.env.get("section")
+            if self.commands and isinstance(self.commands[0].command, EntityProvider)
+            else PathRoot
+        )
         return variable_to_absolute(section, variable)
 
     def render_console(self, element: Union[str, JupyterMixin]) -> str:
@@ -494,6 +499,12 @@ class InternalPart(ABC):
     """
     Internal parts can be executed but are not shown via help.
     They usually get injected by the CLI Interpreter to ease usability.
+    """
+
+
+class EntityProvider(ABC):
+    """
+    Mark this command as a provider of entities with: id, reported, desired, metadata.
     """
 
 

--- a/resotocore/resotocore/report/__init__.py
+++ b/resotocore/resotocore/report/__init__.py
@@ -284,17 +284,24 @@ class BenchmarkResult(CheckCollectionResult):
             severity=if_set(reported.get("severity"), ReportSeverity),
         )
 
-    def to_graph(self) -> List[Json]:
+    def to_graph(self, only_checks: bool = False) -> List[Json]:
         result = []
 
         def visit_check_collection(collection: CheckCollectionResult) -> None:
-            result.append(collection.to_node())
+            if not only_checks:
+                result.append(collection.to_node())
             for check in collection.checks:
                 result.append(check.to_node())
-                result.append({"from": collection.node_id, "to": check.node_id, "type": "edge", "edge_type": "default"})
+                if not only_checks:
+                    result.append(
+                        {"from": collection.node_id, "to": check.node_id, "type": "edge", "edge_type": "default"}
+                    )
             for child in collection.children:
                 visit_check_collection(child)
-                result.append({"from": collection.node_id, "to": child.node_id, "type": "edge", "edge_type": "default"})
+                if not only_checks:
+                    result.append(
+                        {"from": collection.node_id, "to": child.node_id, "type": "edge", "edge_type": "default"}
+                    )
 
         visit_check_collection(self)
         return result

--- a/resotocore/tests/resotocore/report/benchnmark_renderer_test.py
+++ b/resotocore/tests/resotocore/report/benchnmark_renderer_test.py
@@ -16,3 +16,9 @@ async def test_benchmark_renderer(inspector_service: InspectorService, test_benc
         render_result[0]
         == "# Report for account sub_root\n\nTitle: test\n\nVersion: 1.5\n\nSummary: all 2 checks failed\n\n## Failed Checks \n\n- ❌ medium: Test\n- ❌ medium: Test\n\n\n## Section 1 (all checks ❌)\n\nTest section.\n\n- ❌ **medium**: Test\n\n  - Risk: Some risk\n\n  - There are 11 `foo` resources failing this check.\n\n  - Remediation: Some remediation text. See [Link](https://example.com) for more details.\n\n## Section 2 (all checks ❌)\n\nTest section.\n\n- ❌ **medium**: Test\n\n  - Risk: Some risk\n\n  - There are 11 `foo` resources failing this check.\n\n  - Remediation: Some remediation text. See [Link](https://example.com) for more details.\n\n"  # noqa: E501
     )
+
+    # only render checks
+    check_result = bench_result.to_graph(True)
+    assert len(check_result) == 2
+    for c in check_result:
+        assert c["kind"] == "report_check_result"


### PR DESCRIPTION
# Description

Add a command line flag for the `report` command, which allows filtering only report checks.
This is useful in combination with other commands that expect entity JSON objects.

Example: 
```
report benchmark run aws_cis_1_5 --accounts 7524xxxxxx --only-failing --only-check-results | discord --title "Security Benchmark Issues!\nAccount 7524xxxxxx does not adhere to AWS CIS 1.5"
```

<img width="621" alt="image" src="https://github.com/someengineering/resoto/assets/330485/4ea68f6c-e080-4e61-8493-44cabccc6931">


<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`
- [x] Document new or updated functionality (someengineering/resoto.com#XXXX)


# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
