### PR TITLE
[resotocore][fix] Put commands into correct category

### DIFF
--- a/resotocore/resotocore/cli/command.py
+++ b/resotocore/resotocore/cli/command.py
@@ -4850,7 +4850,7 @@ class ReportCommand(CLICommand, EntityProvider):
             return CLISource.single(show_help)
 
 
-class InfrastructureAppsCommand(CLICommand):
+class AppsCommand(CLICommand):
     """
     ```shell
     apps search [pattern] [--index-url https://cdn.some.engineering/resoto/apps/index.json]
@@ -5513,7 +5513,7 @@ def all_commands(d: CLIDependencies) -> List[CLICommand]:
         ExecuteSearchCommand(d, "search", allowed_in_source_position=True),
         FlattenCommand(d, "misc"),
         FormatCommand(d, "format"),
-        HeadCommand(d, "misc"),
+        HeadCommand(d, "search"),
         HistoryPart(d, "search", allowed_in_source_position=True),
         HttpCommand(d, "action"),
         JobsCommand(d, "action", allowed_in_source_position=True),
@@ -5534,15 +5534,15 @@ def all_commands(d: CLIDependencies) -> List[CLICommand]:
         SuccessorsPart(d, "search"),
         SystemCommand(d, "setup", allowed_in_source_position=True),
         TagCommand(d, "action"),
-        TailCommand(d, "misc"),
+        TailCommand(d, "search"),
         UniqCommand(d, "misc"),
         UserCommand(d, "setup", allowed_in_source_position=True),
         WorkflowsCommand(d, "action", allowed_in_source_position=True),
         WelcomeCommand(d, "misc", allowed_in_source_position=True),
         TipOfTheDayCommand(d, "misc", allowed_in_source_position=True),
         WriteCommand(d, "misc"),
-        InfrastructureAppsCommand(d, "apps", allowed_in_source_position=True),
-        GraphCommand(d, "graph", allowed_in_source_position=True),
+        AppsCommand(d, "misc", allowed_in_source_position=True),
+        GraphCommand(d, "setup", allowed_in_source_position=True),
     ]
     # commands that are only available when the system is started in debug mode
     if d.config.runtime.debug:

--- a/resotocore/tests/resotocore/cli/command_test.py
+++ b/resotocore/tests/resotocore/cli/command_test.py
@@ -19,15 +19,16 @@ from pytest import fixture
 from resotocore import version
 from resotocore.cli import is_node
 from resotocore.cli.cli import CLIService
-from resotocore.cli.command import HttpCommand, JqCommand, AggregateCommand
-from resotocore.cli.model import CLIContext, WorkerCustomCommand, CLI
+from resotocore.cli.command import HttpCommand, JqCommand, AggregateCommand, all_commands
 from resotocore.cli.dependencies import CLIDependencies
+from resotocore.cli.model import CLIContext, WorkerCustomCommand, CLI
 from resotocore.cli.tip_of_the_day import generic_tips
 from resotocore.console_renderer import ConsoleRenderer, ConsoleColorSystem
 from resotocore.db.graphdb import ArangoGraphDB
 from resotocore.db.jobdb import JobDb
 from resotocore.error import CLIParseError
-from resotocore.ids import InfraAppName
+from resotocore.graph_manager.graph_manager import GraphManager
+from resotocore.ids import InfraAppName, GraphName
 from resotocore.infra_apps.package_manager import PackageManager
 from resotocore.infra_apps.runtime import Runtime
 from resotocore.model.model import Model
@@ -41,10 +42,6 @@ from resotocore.types import JsonElement, Json
 from resotocore.user import UsersConfigId
 from resotocore.util import AccessJson, utc_str, utc
 from resotocore.worker_task_queue import WorkerTask
-from resotocore.ids import InfraAppName, GraphName
-from resotocore.infra_apps.package_manager import PackageManager
-from resotocore.infra_apps.runtime import Runtime
-from resotocore.graph_manager.graph_manager import GraphManager
 from tests.resotocore.util_test import not_in_path
 
 
@@ -52,6 +49,12 @@ from tests.resotocore.util_test import not_in_path
 def json_source() -> str:
     nums = ",".join([f'{{ "num": {a}, "inner": {{"num": {a%10}}}}}' for a in range(0, 100)])
     return "json [" + nums + "," + nums + "]"
+
+
+def test_known_category(cli_deps: CLIDependencies) -> None:
+    allowed_categories = {"search", "format", "action", "setup", "misc"}
+    for cmd in all_commands(cli_deps):
+        assert cmd.category in allowed_categories, f"Unknown category {cmd.category} for command {cmd.name}"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description

Current new commands are not displayed via `help`
<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`
- [x] Document new or updated functionality (someengineering/resoto.com#XXXX)

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
