### PR TITLE
[resotocore][fix] Invalid yaml generation

### DIFF
--- a/resotocore/resotocore/model/model.py
+++ b/resotocore/resotocore/model/model.py
@@ -963,11 +963,13 @@ class ComplexKind(Kind):
 
     def create_yaml(self, elem: JsonElement, initial_level: int = 0, overrides: Optional[Json] = None) -> str:
         def safe_string(s: str, indent: int, default_style: Optional[str] = None) -> str:
-            return remove_suffix(
-                # 2 spaces per indent
-                yaml.dump(s, indent=indent * 2, allow_unicode=True, width=sys.maxsize, default_style=default_style),
-                "\n...\n",
-            ).strip()
+            # 2 spaces per indent
+            yml = yaml.dump(s, indent=indent * 2, allow_unicode=True, width=sys.maxsize, default_style=default_style)
+            # Fix for this pyyaml issue: https://github.com/yaml/pyyaml/issues/717
+            if default_style == "|" and len(yml) > 1 and yml[1].isdigit():
+                yml = re.sub("^\\|\\d+", "|", yml)
+            # pyyaml might add an object delimiter
+            return remove_suffix(yml, "\n...\n").strip()
 
         def override_note(overrides: Optional[Json], prop_name: str) -> Optional[str]:
             if overrides:

--- a/resotocore/tests/resotocore/hypothesis_extension.py
+++ b/resotocore/tests/resotocore/hypothesis_extension.py
@@ -42,8 +42,8 @@ class Drawer:
         return self.draw(optional(st))
 
 
-any_string = text(alphabet=string.ascii_letters + string.whitespace + string.digits, min_size=3, max_size=10)
-ascii_string = text(alphabet=string.ascii_letters, min_size=3, max_size=10)
+any_ws_digits_string = text(alphabet=string.ascii_letters + string.whitespace + string.digits, min_size=0, max_size=10)
+any_string = text(alphabet=string.ascii_letters, min_size=3, max_size=10)
 kind_gen = sampled_from(["volume", "instance", "load_balancer", "volume_type"])
 
 
@@ -52,8 +52,8 @@ def json_element_gen(ud: UD) -> JsonElement:
     return cast(JsonElement, ud(json_object_gen | json_simple_element_gen | json_array_gen))
 
 
-json_simple_element_gen = any_string | booleans() | integers(min_value=0, max_value=100000) | just(None)
-json_object_gen = dictionaries(ascii_string, json_element_gen(), min_size=1, max_size=5)
+json_simple_element_gen = any_ws_digits_string | booleans() | integers(min_value=0, max_value=100000) | just(None)
+json_object_gen = dictionaries(any_string, json_element_gen(), min_size=1, max_size=5)
 json_array_gen = lists(json_element_gen(), max_size=5)
 
 

--- a/resotocore/tests/resotocore/hypothesis_extension.py
+++ b/resotocore/tests/resotocore/hypothesis_extension.py
@@ -42,7 +42,8 @@ class Drawer:
         return self.draw(optional(st))
 
 
-any_string = text(alphabet=string.ascii_letters, min_size=3, max_size=10)
+any_string = text(alphabet=string.ascii_letters + string.whitespace + string.digits, min_size=3, max_size=10)
+ascii_string = text(alphabet=string.ascii_letters, min_size=3, max_size=10)
 kind_gen = sampled_from(["volume", "instance", "load_balancer", "volume_type"])
 
 
@@ -52,7 +53,7 @@ def json_element_gen(ud: UD) -> JsonElement:
 
 
 json_simple_element_gen = any_string | booleans() | integers(min_value=0, max_value=100000) | just(None)
-json_object_gen = dictionaries(any_string, json_element_gen(), min_size=1, max_size=5)
+json_object_gen = dictionaries(ascii_string, json_element_gen(), min_size=1, max_size=5)
 json_array_gen = lists(json_element_gen(), max_size=5)
 
 

--- a/resotocore/tests/resotocore/model/model_test.py
+++ b/resotocore/tests/resotocore/model/model_test.py
@@ -542,15 +542,8 @@ def test_yaml(person_model: Model) -> None:
     assert person == yaml.safe_load(person_kind.create_yaml(person))
 
 
-def test_issue_pyyaml_717(person_model: Model) -> None:
-    person = cast(ComplexKind, person_model["Person"])
-    yml = person.create_yaml({"name": "\ntest\n"})
-    # no number after |
-    assert yml == "\n# The name of the person.\nname: |\n\n  test"
-
-
 @given(json_object_gen)
-@settings(max_examples=50, suppress_health_check=HealthCheck.all())
+@settings(max_examples=200, suppress_health_check=HealthCheck.all())
 def test_yaml_generation(js: Json) -> None:
     kind = ComplexKind("test", [], [])
     assert js == yaml.safe_load(kind.create_yaml(js))

--- a/resotocore/tests/resotocore/model/model_test.py
+++ b/resotocore/tests/resotocore/model/model_test.py
@@ -542,6 +542,13 @@ def test_yaml(person_model: Model) -> None:
     assert person == yaml.safe_load(person_kind.create_yaml(person))
 
 
+def test_issue_pyyaml_717(person_model: Model) -> None:
+    person = cast(ComplexKind, person_model["Person"])
+    yml = person.create_yaml({"name": "\ntest\n"})
+    # no number after |
+    assert yml == "\n# The name of the person.\nname: |\n\n  test"
+
+
 @given(json_object_gen)
 @settings(max_examples=50, suppress_health_check=HealthCheck.all())
 def test_yaml_generation(js: Json) -> None:

--- a/resotocore/tests/resotocore/model/model_test.py
+++ b/resotocore/tests/resotocore/model/model_test.py
@@ -483,6 +483,7 @@ def test_yaml(person_model: Model) -> None:
           city: |-
             gotham
             manor house
+
           number: 123
           float: 1.2345
         # The list of addresses.
@@ -494,6 +495,7 @@ def test_yaml(person_model: Model) -> None:
             city: |-
               gotham
               manor house
+
             number: 123
             float: 1.2345
           - # The zip code.
@@ -503,6 +505,7 @@ def test_yaml(person_model: Model) -> None:
             city: |-
               gotham
               manor house
+
             number: 123
             float: 1.2345
         # Other addresses.
@@ -515,6 +518,7 @@ def test_yaml(person_model: Model) -> None:
             city: |-
               gotham
               manor house
+
             number: 123
             float: 1.2345
           work:
@@ -525,6 +529,7 @@ def test_yaml(person_model: Model) -> None:
             city: |-
               gotham
               manor house
+
             number: 123
             float: 1.2345
         simple:


### PR DESCRIPTION
# Description

pyyamls indent parameter should not be used for indenting the value.

# To-Dos

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
