### PR TITLE
[gcp][feat] Export all required GCP permissions

### DIFF
--- a/.github/workflows/check_pr_plugin_aws.yml
+++ b/.github/workflows/check_pr_plugin_aws.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   aws:
-    name: "aws" # Do not rename without updating workflow defined in publish.yml
+    name: "aws"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/check_pr_plugin_gcp.yml
+++ b/.github/workflows/check_pr_plugin_gcp.yml
@@ -82,4 +82,4 @@ jobs:
           export API_TOKEN="${{ secrets.API_TOKEN }}"
           export SPACES_KEY="${{ secrets.SPACES_KEY }}"
           export SPACES_SECRET="${{ secrets.SPACES_SECRET }}"
-          awspolicygen --verbose --spaces-name somecdn --spaces-region ams3 --spaces-path resoto/gcp/
+          gcppolicygen --verbose --spaces-name somecdn --spaces-region ams3 --spaces-path resoto/gcp/

--- a/.github/workflows/check_pr_plugin_gcp.yml
+++ b/.github/workflows/check_pr_plugin_gcp.yml
@@ -69,3 +69,17 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI_RESOTO_PLUGIN_GCP }}
           packages_dir: ./plugins/gcp/dist/
+
+      - name: Upload GCP policies
+        if: github.event_name != 'pull_request'
+        working-directory: ./plugins/gcp
+        run: |
+          pip install --upgrade --editable .
+          pip install --upgrade --editable ./tools/gcppolicygen
+          export GITHUB_REF="${{ github.ref }}"
+          export GITHUB_REF_TYPE="${{ github.ref_type }}"
+          export GITHUB_EVENT_NAME="${{ github.event_name }}"
+          export API_TOKEN="${{ secrets.API_TOKEN }}"
+          export SPACES_KEY="${{ secrets.SPACES_KEY }}"
+          export SPACES_SECRET="${{ secrets.SPACES_SECRET }}"
+          awspolicygen --verbose --spaces-name somecdn --spaces-region ams3 --spaces-path resoto/gcp/

--- a/.github/workflows/create_plugin_workflows.py
+++ b/.github/workflows/create_plugin_workflows.py
@@ -72,6 +72,22 @@ aws_policygen = """
           awspolicygen --verbose --spaces-name somecdn --spaces-region ams3 --spaces-path resoto/aws/ --aws-s3-bucket resotopublic --aws-s3-bucket-path cf/
 """
 
+gcp_policygen = """
+      - name: Upload GCP policies
+        if: github.event_name != 'pull_request'
+        working-directory: ./plugins/gcp
+        run: |
+          pip install --upgrade --editable .
+          pip install --upgrade --editable ./tools/gcppolicygen
+          export GITHUB_REF="${{ github.ref }}"
+          export GITHUB_REF_TYPE="${{ github.ref_type }}"
+          export GITHUB_EVENT_NAME="${{ github.event_name }}"
+          export API_TOKEN="${{ secrets.API_TOKEN }}"
+          export SPACES_KEY="${{ secrets.SPACES_KEY }}"
+          export SPACES_SECRET="${{ secrets.SPACES_SECRET }}"
+          awspolicygen --verbose --spaces-name somecdn --spaces-region ams3 --spaces-path resoto/gcp/
+"""
+
 step_run_test = """
       - name: Run tests
         working-directory: @directory@
@@ -120,3 +136,5 @@ for plugin in os.listdir(plugins_path):
             )
             if plugin == "aws":
                 yml.write(aws_policygen)
+            elif plugin == "gcp":
+                yml.write(gcp_policygen)

--- a/.github/workflows/create_plugin_workflows.py
+++ b/.github/workflows/create_plugin_workflows.py
@@ -85,7 +85,7 @@ gcp_policygen = """
           export API_TOKEN="${{ secrets.API_TOKEN }}"
           export SPACES_KEY="${{ secrets.SPACES_KEY }}"
           export SPACES_SECRET="${{ secrets.SPACES_SECRET }}"
-          awspolicygen --verbose --spaces-name somecdn --spaces-region ams3 --spaces-path resoto/gcp/
+          gcppolicygen --verbose --spaces-name somecdn --spaces-region ams3 --spaces-path resoto/gcp/
 """
 
 step_run_test = """

--- a/plugins/gcp/resoto_plugin_gcp/collector.py
+++ b/plugins/gcp/resoto_plugin_gcp/collector.py
@@ -3,6 +3,7 @@ import logging
 from typing import Type, List
 
 from resoto_plugin_gcp.config import GcpConfig
+from resoto_plugin_gcp.gcp_client import GcpApiSpec
 from resoto_plugin_gcp.utils import Credentials
 from resoto_plugin_gcp.resources import compute, container, billing, sqladmin, storage
 from resoto_plugin_gcp.resources.base import GcpResource, GcpProject, ExecutorQueue, GraphBuilder, GcpRegion, GcpZone
@@ -14,6 +15,22 @@ log = logging.getLogger("resoto.plugins.gcp")
 all_resources: List[Type[GcpResource]] = (
     compute.resources + container.resources + billing.resources + sqladmin.resources + storage.resources
 )
+
+
+def called_collect_apis() -> List[GcpApiSpec]:
+    """
+    Return a list of all the APIs that are called by the collector during the collect cycle.
+    """
+    specs = [spec for r in all_resources for spec in r.called_collect_apis()]
+    return sorted(specs, key=lambda s: s.fqn)
+
+
+def called_mutator_apis() -> List[GcpApiSpec]:
+    """
+    Return a list of all the APIs that are called to mutate resources.
+    """
+    specs = [spec for r in all_resources for spec in r.called_mutator_apis()]
+    return sorted(specs, key=lambda s: s.fqn)
 
 
 class GcpProjectCollector:

--- a/plugins/gcp/resoto_plugin_gcp/resources/base.py
+++ b/plugins/gcp/resoto_plugin_gcp/resources/base.py
@@ -428,6 +428,25 @@ class GcpResource(BaseResource):
         mapped = bend(cls.mapping, json)
         return cls.from_json(mapped)
 
+    @classmethod
+    def called_collect_apis(cls) -> List[GcpApiSpec]:
+        # The default implementation will return the defined api_spec if defined, otherwise an empty list.
+        # In case your resource needs more than this api call, please override this method and return the proper list.
+        if spec := cls.api_spec:
+            return [spec]
+        else:
+            return []
+
+    @classmethod
+    def called_mutator_apis(cls) -> List[GcpApiSpec]:
+        # The default implementation will return the defined api_spec for delete, set_labels and get if defined.
+        # delete: spec.for_delete()
+        # update_tag/delete_tag: spec.for_set_labels(), spec.for_get()
+        if spec := cls.api_spec:
+            return [spec.for_delete(), spec.for_set_labels(), spec.for_get()]
+        else:
+            return []
+
 
 GcpResourceType = TypeVar("GcpResourceType", bound=GcpResource)
 

--- a/plugins/gcp/resoto_plugin_gcp/resources/billing.py
+++ b/plugins/gcp/resoto_plugin_gcp/resources/billing.py
@@ -71,6 +71,7 @@ class GcpProjectBillingInfo(GcpResource):
         request_parameter_in={"name"},
         response_path="projectBillingInfo",
         response_regional_sub_path=None,
+        # valid permission name according to documentation, but gcloud emits an error
         # required_iam_permissions=["billing.resourceAssociations.list"],
         required_iam_permissions=[],
         mutate_iam_permissions=["billing.resourceAssociations.delete"],

--- a/plugins/gcp/resoto_plugin_gcp/resources/billing.py
+++ b/plugins/gcp/resoto_plugin_gcp/resources/billing.py
@@ -9,6 +9,10 @@ from resotolib.baseresources import ModelReference
 from resotolib.json_bender import Bender, S, Bend, ForallBend
 from resotolib.types import Json
 
+# This service is called Cloud Billing in the documentation
+# https://cloud.google.com/billing/docs
+# API https://googleapis.github.io/google-api-python-client/docs/dyn/cloudbilling_v1.html
+
 
 @define(eq=False, slots=False)
 class GcpBillingAccount(GcpResource):
@@ -25,6 +29,8 @@ class GcpBillingAccount(GcpResource):
         request_parameter_in=set(),
         response_path="billingAccounts",
         response_regional_sub_path=None,
+        required_iam_permissions=[],  # does not require any permissions
+        mutate_iam_permissions=[],  # can not be deleted
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -48,6 +54,10 @@ class GcpBillingAccount(GcpResource):
         for info in GcpProjectBillingInfo.collect_resources(graph_builder, name=self.name):
             graph_builder.add_edge(self, node=info)
 
+    @classmethod
+    def called_collect_apis(cls) -> List[GcpApiSpec]:
+        return [cls.api_spec, GcpProjectBillingInfo.api_spec]
+
 
 @define(eq=False, slots=False)
 class GcpProjectBillingInfo(GcpResource):
@@ -61,6 +71,9 @@ class GcpProjectBillingInfo(GcpResource):
         request_parameter_in={"name"},
         response_path="projectBillingInfo",
         response_regional_sub_path=None,
+        # required_iam_permissions=["billing.resourceAssociations.list"],
+        required_iam_permissions=[],
+        mutate_iam_permissions=["billing.resourceAssociations.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -95,6 +108,8 @@ class GcpService(GcpResource):
         request_parameter_in=set(),
         response_path="services",
         response_regional_sub_path=None,
+        required_iam_permissions=[],  # does not require any permissions
+        mutate_iam_permissions=[],  # can not be deleted
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("serviceId"),
@@ -133,6 +148,10 @@ class GcpService(GcpResource):
             return isinstance(node, GcpSku) and node.name is not None and node.name.startswith(self.id)
 
         builder.add_edges(self, filter=filter)
+
+    @classmethod
+    def called_collect_apis(cls) -> List[GcpApiSpec]:
+        return [cls.api_spec, GcpSku.api_spec]
 
 
 @define(eq=False, slots=False)
@@ -245,6 +264,8 @@ class GcpSku(GcpResource):
         request_parameter_in={"parent"},
         response_path="skus",
         response_regional_sub_path=None,
+        required_iam_permissions=[],  # does not require any permissions
+        mutate_iam_permissions=[],  # can not be deleted
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("skuId"),

--- a/plugins/gcp/resoto_plugin_gcp/resources/compute.py
+++ b/plugins/gcp/resoto_plugin_gcp/resources/compute.py
@@ -22,6 +22,10 @@ from resotolib.types import Json
 log = logging.getLogger("resoto.plugins.gcp")
 
 
+# This service is called Compute Engine in the GCP API.
+# https://cloud.google.com/kubernetes-engine/docs
+
+
 def health_check_types() -> Tuple[Type[GcpResource], ...]:
     return GcpHealthCheck, GcpHttpsHealthCheck, GcpHttpHealthCheck
 
@@ -38,6 +42,7 @@ class GcpAcceleratorType(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="acceleratorTypes",
+        mutate_iam_permissions=[],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -72,6 +77,7 @@ class GcpAddress(GcpResource):
         response_path="items",
         response_regional_sub_path="addresses",
         get_identifier="address",
+        mutate_iam_permissions=["compute.addresses.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -244,6 +250,7 @@ class GcpAutoscaler(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="autoscalers",
+        mutate_iam_permissions=["compute.autoscalers.update", "compute.autoscalers.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -339,6 +346,7 @@ class GcpBackendBucket(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path=None,
+        mutate_iam_permissions=["compute.backendBuckets.update", "compute.backendBuckets.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("id").or_else(S("bucketName")).or_else(S("selfLink")),
@@ -652,6 +660,7 @@ class GcpBackendService(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="backendServices",
+        mutate_iam_permissions=["compute.backendServices.update", "compute.backendServices.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -752,6 +761,7 @@ class GcpDiskType(GcpResource, BaseVolumeType):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="diskTypes",
+        mutate_iam_permissions=[],  # can not be mutated
     )
     reference_kinds: ClassVar[ModelReference] = {"predecessors": {"default": ["gcp_sku"]}}
     mapping: ClassVar[Dict[str, Bender]] = {
@@ -1087,6 +1097,7 @@ class GcpFirewallPolicy(GcpResource):
         request_parameter_in=set(),
         response_path="items",
         response_regional_sub_path=None,
+        mutate_iam_permissions=["compute.firewallPolicies.update", "compute.firewallPolicies.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -1158,6 +1169,7 @@ class GcpFirewall(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path=None,
+        mutate_iam_permissions=["compute.firewalls.update", "compute.firewalls.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -1260,6 +1272,7 @@ class GcpForwardingRule(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="forwardingRules",
+        mutate_iam_permissions=["compute.forwardingRules.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -1387,6 +1400,7 @@ class GcpNetworkEndpointGroup(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="networkEndpointGroups",
+        mutate_iam_permissions=["compute.networkEndpointGroups.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -1536,6 +1550,7 @@ class GcpOperation(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="operations",
+        mutate_iam_permissions=["compute.globalOperations.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -1618,6 +1633,7 @@ class GcpPublicDelegatedPrefix(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="publicDelegatedPrefixes",
+        mutate_iam_permissions=["compute.publicDelegatedPrefixes.update", "compute.publicDelegatedPrefixes.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -1772,6 +1788,7 @@ class GcpHealthCheck(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="healthChecks",
+        mutate_iam_permissions=["compute.healthChecks.update", "compute.healthChecks.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -1821,6 +1838,7 @@ class GcpHttpHealthCheck(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path=None,
+        mutate_iam_permissions=["compute.httpHealthChecks.update", "compute.httpHealthChecks.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -1860,6 +1878,7 @@ class GcpHttpsHealthCheck(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path=None,
+        mutate_iam_permissions=["compute.httpsHealthChecks.update", "compute.httpsHealthChecks.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -2171,6 +2190,7 @@ class GcpInstanceGroupManager(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="instanceGroupManagers",
+        mutate_iam_permissions=["compute.instanceGroupManagers.update", "compute.instanceGroupManagers.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -2243,6 +2263,7 @@ class GcpInstanceGroup(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="instanceGroups",
+        mutate_iam_permissions=["compute.instanceGroups.update", "compute.instanceGroups.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -2632,6 +2653,7 @@ class GcpInstanceTemplate(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path=None,
+        mutate_iam_permissions=["compute.instanceTemplates.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -2832,6 +2854,10 @@ class GcpInstance(GcpResource, BaseInstance):
 
         return result  # type: ignore # list is not covariant
 
+    @classmethod
+    def called_collect_apis(cls) -> List[GcpApiSpec]:
+        return [cls.api_spec, GcpMachineType.collect_individual_api_spec]
+
 
 @define(eq=False, slots=False)
 class GcpInterconnectAttachmentPartnerMetadata:
@@ -2858,6 +2884,8 @@ class GcpInterconnectAttachment(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="interconnectAttachments",
+        required_iam_permissions=[],  # list is not production ready
+        mutate_iam_permissions=[],  # mutate is not production ready
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -2952,6 +2980,8 @@ class GcpInterconnectLocation(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path=None,
+        required_iam_permissions=[],  # not production ready
+        mutate_iam_permissions=[],  # can not be mutated
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -3033,6 +3063,8 @@ class GcpInterconnect(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path=None,
+        required_iam_permissions=[],  # not production ready
+        mutate_iam_permissions=[],  # mutate is not production ready
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -3103,6 +3135,8 @@ class GcpLicense(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path=None,
+        required_iam_permissions=[],  # not production ready
+        mutate_iam_permissions=[],  # mutate is not production ready
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -3239,6 +3273,7 @@ class GcpMachineImage(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path=None,
+        mutate_iam_permissions=["compute.machineImages.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -3308,6 +3343,16 @@ class GcpMachineType(GcpResource, BaseInstanceType):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="machineTypes",
+        mutate_iam_permissions=[],  # can not be mutated
+    )
+    collect_individual_api_spec: ClassVar[GcpApiSpec] = GcpApiSpec(
+        service="compute",
+        version="v1",
+        accessors=["machineTypes"],
+        action="get",
+        response_path="",
+        request_parameter={"project": "{project}", "zone": "{zone}", "machineType": "{machineType}"},
+        request_parameter_in={"project", "zone", "machineType"},
     )
     reference_kinds: ClassVar[ModelReference] = {
         "predecessors": {"default": ["gcp_sku"]},
@@ -3341,17 +3386,8 @@ class GcpMachineType(GcpResource, BaseInstanceType):
 
     @classmethod
     def collect_individual(cls: Type[GcpResource], builder: GraphBuilder, zone: str, name: str) -> None:
-        api_spec: GcpApiSpec = GcpApiSpec(
-            service="compute",
-            version="v1",
-            accessors=["machineTypes"],
-            action="get",
-            response_path="",
-            request_parameter={"project": "{project}", "zone": "{zone}", "machineType": "{machineType}"},
-            request_parameter_in={"project", "zone", "machineType"},
-        )
         result = builder.client.get(
-            api_spec,
+            GcpMachineType.collect_individual_api_spec,
             zone=zone,
             machineType=name,
         )
@@ -3471,6 +3507,10 @@ class GcpNetworkEdgeSecurityService(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="networkEdgeSecurityServices",
+        mutate_iam_permissions=[
+            "compute.networkEdgeSecurityServices.update",
+            "compute.networkEdgeSecurityServices.delete",
+        ],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -3533,6 +3573,7 @@ class GcpNetwork(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path=None,
+        mutate_iam_permissions=["compute.networks.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -3621,6 +3662,7 @@ class GcpNodeGroup(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="nodeGroups",
+        mutate_iam_permissions=["compute.nodeGroups.update", "compute.nodeGroups.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -3691,6 +3733,7 @@ class GcpNodeTemplate(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="nodeTemplates",
+        mutate_iam_permissions=["compute.nodeTemplates.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -3740,6 +3783,7 @@ class GcpNodeType(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="nodeTypes",
+        mutate_iam_permissions=[],  # can not be mutated
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -3834,6 +3878,7 @@ class GcpPacketMirroring(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="packetMirrorings",
+        mutate_iam_permissions=["compute.packetMirrorings.update", "compute.packetMirrorings.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -3897,6 +3942,7 @@ class GcpPublicAdvertisedPrefix(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path=None,
+        mutate_iam_permissions=["compute.publicAdvertisedPrefixes.update", "compute.publicAdvertisedPrefixes.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -4043,6 +4089,8 @@ class GcpCommitment(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="commitments",
+        required_iam_permissions=["compute.commitments.list"],
+        mutate_iam_permissions=["compute.commitments.update"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -4094,6 +4142,7 @@ class GcpHealthCheckService(GcpResource):
         request_parameter_in={"project", "region"},
         response_path="items",
         response_regional_sub_path=None,
+        mutate_iam_permissions=["compute.regionHealthCheckServices.update", "compute.regionHealthCheckServices.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -4146,6 +4195,10 @@ class GcpNotificationEndpoint(GcpResource):
         request_parameter_in={"project", "region"},
         response_path="items",
         response_regional_sub_path=None,
+        mutate_iam_permissions=[
+            "compute.regionNotificationEndpoints.update",
+            "compute.regionNotificationEndpoints.delete",
+        ],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -4331,6 +4384,8 @@ class GcpSecurityPolicy(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="securityPolicies",
+        required_iam_permissions=[],  # not production ready yet
+        mutate_iam_permissions=["compute.securityPolicies.setLabels"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -4393,6 +4448,7 @@ class GcpSslCertificate(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="sslCertificates",
+        mutate_iam_permissions=["compute.sslCertificates.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -4432,6 +4488,8 @@ class GcpSslPolicy(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="sslPolicies",
+        required_iam_permissions=[],  # read is not production ready
+        mutate_iam_permissions=[],  # mutate is not production ready
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -4473,6 +4531,7 @@ class GcpTargetHttpProxy(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="targetHttpProxies",
+        mutate_iam_permissions=["compute.targetHttpProxies.delete", "compute.targetHttpProxies.update"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -4512,6 +4571,7 @@ class GcpTargetHttpsProxy(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="targetHttpsProxies",
+        mutate_iam_permissions=["compute.targetHttpsProxies.delete", "compute.targetHttpsProxies.update"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -4568,6 +4628,7 @@ class GcpTargetTcpProxy(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path=None,
+        mutate_iam_permissions=["compute.targetTcpProxies.delete", "compute.targetTcpProxies.update"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -4934,6 +4995,8 @@ class GcpUrlMap(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="urlMaps",
+        required_iam_permissions=[],  # read is not production ready
+        mutate_iam_permissions=[],  # mutate is not production ready
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -5130,6 +5193,7 @@ class GcpResourcePolicy(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="resourcePolicies",
+        mutate_iam_permissions=["compute.resourcePolicies.update", "compute.resourcePolicies.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -5374,6 +5438,7 @@ class GcpRouter(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="routers",
+        mutate_iam_permissions=["compute.routers.update", "compute.routers.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -5432,6 +5497,7 @@ class GcpRoute(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path=None,
+        mutate_iam_permissions=["compute.routes.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -5524,6 +5590,7 @@ class GcpServiceAttachment(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="serviceAttachments",
+        mutate_iam_permissions=["compute.serviceAttachments.update", "compute.serviceAttachments.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -5684,6 +5751,8 @@ class GcpSubnetwork(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="subnetworks",
+        required_iam_permissions=[],  # read is not production ready
+        mutate_iam_permissions=[],  # mutate is not production ready
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -5753,6 +5822,7 @@ class GcpTargetGrpcProxy(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path=None,
+        mutate_iam_permissions=["compute.targetGrpcProxies.update", "compute.targetGrpcProxies.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -5794,6 +5864,7 @@ class GcpTargetInstance(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="targetInstances",
+        mutate_iam_permissions=["compute.targetInstances.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -5835,6 +5906,7 @@ class GcpTargetPool(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="targetPools",
+        mutate_iam_permissions=["compute.targetPools.delete", "compute.targetPools.update"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -5882,6 +5954,7 @@ class GcpTargetSslProxy(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path=None,
+        mutate_iam_permissions=["compute.targetSslProxies.delete", "compute.targetSslProxies.update"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -5927,6 +6000,7 @@ class GcpTargetVpnGateway(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="targetVpnGateways",
+        mutate_iam_permissions=["compute.targetVpnGateways.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -6026,6 +6100,7 @@ class GcpVpnTunnel(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="vpnTunnels",
+        mutate_iam_permissions=["compute.vpnTunnels.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),

--- a/plugins/gcp/resoto_plugin_gcp/resources/compute.py
+++ b/plugins/gcp/resoto_plugin_gcp/resources/compute.py
@@ -2884,8 +2884,6 @@ class GcpInterconnectAttachment(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="interconnectAttachments",
-        required_iam_permissions=[],  # list is not production ready
-        mutate_iam_permissions=[],  # mutate is not production ready
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -2980,7 +2978,6 @@ class GcpInterconnectLocation(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path=None,
-        required_iam_permissions=[],  # not production ready
         mutate_iam_permissions=[],  # can not be mutated
     )
     mapping: ClassVar[Dict[str, Bender]] = {
@@ -3063,8 +3060,6 @@ class GcpInterconnect(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path=None,
-        required_iam_permissions=[],  # not production ready
-        mutate_iam_permissions=[],  # mutate is not production ready
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -3135,8 +3130,7 @@ class GcpLicense(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path=None,
-        required_iam_permissions=[],  # not production ready
-        mutate_iam_permissions=[],  # mutate is not production ready
+        mutate_iam_permissions=["compute.licenses.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -4384,7 +4378,6 @@ class GcpSecurityPolicy(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="securityPolicies",
-        required_iam_permissions=[],  # not production ready yet
         mutate_iam_permissions=["compute.securityPolicies.setLabels"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
@@ -4488,8 +4481,7 @@ class GcpSslPolicy(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="sslPolicies",
-        required_iam_permissions=[],  # read is not production ready
-        mutate_iam_permissions=[],  # mutate is not production ready
+        mutate_iam_permissions=["compute.sslPolicies.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -4995,8 +4987,7 @@ class GcpUrlMap(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="urlMaps",
-        required_iam_permissions=[],  # read is not production ready
-        mutate_iam_permissions=[],  # mutate is not production ready
+        mutate_iam_permissions=["compute.urlMaps.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -5751,8 +5742,7 @@ class GcpSubnetwork(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path="subnetworks",
-        required_iam_permissions=[],  # read is not production ready
-        mutate_iam_permissions=[],  # mutate is not production ready
+        mutate_iam_permissions=["compute.subnetworks.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),

--- a/plugins/gcp/resoto_plugin_gcp/resources/container.py
+++ b/plugins/gcp/resoto_plugin_gcp/resources/container.py
@@ -9,6 +9,9 @@ from resotolib.baseresources import ModelReference
 from resotolib.json_bender import Bender, S, Bend, ForallBend, MapDict
 from resotolib.types import Json
 
+# This service is called Google Kubernetes Engine in the docs
+# https://cloud.google.com/kubernetes-engine/docs
+
 
 @define(eq=False, slots=False)
 class GcpContainerCloudRunConfig:
@@ -782,6 +785,8 @@ class GcpContainerCluster(GcpResource):
         request_parameter_in={"project"},
         response_path="clusters",
         response_regional_sub_path=None,
+        required_iam_permissions=["container.clusters.list"],
+        mutate_iam_permissions=["container.clusters.update", "container.clusters.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -968,6 +973,8 @@ class GcpContainerOperation(GcpResource):
         request_parameter_in={"project"},
         response_path="operations",
         response_regional_sub_path=None,
+        required_iam_permissions=["container.operations.list"],
+        mutate_iam_permissions=[],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),

--- a/plugins/gcp/resoto_plugin_gcp/resources/sqladmin.py
+++ b/plugins/gcp/resoto_plugin_gcp/resources/sqladmin.py
@@ -36,6 +36,8 @@ class GcpSqlBackupRun(GcpResource):
         request_parameter_in={"instance", "project"},
         response_path="items",
         response_regional_sub_path=None,
+        required_iam_permissions=["cloudsql.backupRuns.list"],
+        mutate_iam_permissions=["cloudsql.backupRuns.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -103,6 +105,8 @@ class GcpSqlDatabase(GcpResource):
         request_parameter_in={"instance", "project"},
         response_path="items",
         response_regional_sub_path=None,
+        required_iam_permissions=["cloudsql.databases.list"],
+        mutate_iam_permissions=["cloudsql.databases.update", "cloudsql.databases.delete"],
     )
     reference_kinds: ClassVar[ModelReference] = {"predecessors": {"default": ["gcp_sql_database_instance"]}}
     mapping: ClassVar[Dict[str, Bender]] = {
@@ -506,6 +510,8 @@ class GcpSqlDatabaseInstance(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path=None,
+        required_iam_permissions=["cloudsql.instances.list"],
+        mutate_iam_permissions=["cloudsql.instances.update", "cloudsql.instances.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -594,6 +600,16 @@ class GcpSqlDatabaseInstance(GcpResource):
             if spec := cls.api_spec:
                 items = graph_builder.client.list(spec, instance=self.name, project=self.project)
                 cls.collect(items, graph_builder)
+
+    @classmethod
+    def called_collect_apis(cls) -> List[GcpApiSpec]:
+        return [
+            cls.api_spec,
+            GcpSqlBackupRun.api_spec,
+            GcpSqlDatabase.api_spec,
+            GcpSqlUser.api_spec,
+            GcpSqlOperation.api_spec,
+        ]
 
 
 @define(eq=False, slots=False)
@@ -725,6 +741,8 @@ class GcpSqlOperation(GcpResource):
         request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path=None,
+        required_iam_permissions=["cloudsql.instances.get"],
+        mutate_iam_permissions=["cloudsql.instances.update", "cloudsql.instances.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),
@@ -817,6 +835,8 @@ class GcpSqlUser(GcpResource):
         request_parameter_in={"instance", "project"},
         response_path="items",
         response_regional_sub_path=None,
+        required_iam_permissions=["cloudsql.users.list"],
+        mutate_iam_permissions=["cloudsql.users.update", "cloudsql.users.delete"],
     )
     reference_kinds: ClassVar[ModelReference] = {"predecessors": {"default": ["gcp_sql_database_instance"]}}
     mapping: ClassVar[Dict[str, Bender]] = {

--- a/plugins/gcp/resoto_plugin_gcp/resources/storage.py
+++ b/plugins/gcp/resoto_plugin_gcp/resources/storage.py
@@ -257,6 +257,7 @@ class GcpBucket(GcpResource):
         # single_request_parameter_in={"project"},
         response_path="items",
         response_regional_sub_path=None,
+        mutate_iam_permissions=["storage.buckets.update", "storage.buckets.delete"],
     )
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("name").or_else(S("id")).or_else(S("selfLink")),

--- a/plugins/gcp/test/test_collector.py
+++ b/plugins/gcp/test/test_collector.py
@@ -70,7 +70,8 @@ def test_role_creation() -> None:
                 f.write(result)
         return result
 
-    c = iam_role_for("resoto_access", "Permissions required to collect resources.", called_collect_apis(), False)
-    m = iam_role_for("resoto_mutate", "Permissions required to mutate resources.", called_mutator_apis(), False)
+    write_files = False
+    c = iam_role_for("resoto_access", "Permissions required to collect resources.", called_collect_apis(), write_files)
+    m = iam_role_for("resoto_mutate", "Permissions required to mutate resources.", called_mutator_apis(), write_files)
     assert c is not None
     assert m is not None

--- a/plugins/gcp/tools/gcppolicygen/MANIFEST.in
+++ b/plugins/gcp/tools/gcppolicygen/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md

--- a/plugins/gcp/tools/gcppolicygen/README.md
+++ b/plugins/gcp/tools/gcppolicygen/README.md
@@ -1,0 +1,19 @@
+# Resoto GCP policy generator
+This script creates and uploads GCP policies to the CDN
+
+## License
+```
+Copyright 2023 Some Engineering Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/plugins/gcp/tools/gcppolicygen/gcppolicygen/__init__.py
+++ b/plugins/gcp/tools/gcppolicygen/gcppolicygen/__init__.py
@@ -1,0 +1,112 @@
+import os
+import logging
+from argparse import ArgumentParser, Namespace
+
+"""
+Resoto GCP policy generator and uploader
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This script generates the required GCP access policy and uploads it to the CDN.
+:copyright: © 2023 Some Engineering Inc.
+:license: Apache 2.0, see LICENSE for more details.
+"""
+
+__title__ = "gcppolicygen"
+__description__ = "Resoto GCP policy generator and uploader."
+__author__ = "Some Engineering Inc."
+__license__ = "Apache 2.0"
+__copyright__ = "Copyright © 2023 Some Engineering Inc."
+__version__ = "0.0.1"
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(levelname)s - %(message)s",
+)
+log = logging.getLogger("gcppolicygen")
+log.setLevel(logging.INFO)
+
+
+def get_arg_parser() -> ArgumentParser:
+    parser = ArgumentParser(description="Resoto GCP policy generator and uploader")
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        help="Verbose logging",
+        dest="verbose",
+        action="store_true",
+        default=False,
+    )
+    return parser
+
+
+def add_args(arg_parser: ArgumentParser) -> None:
+    arg_parser.add_argument(
+        "--api-token",
+        help="DigitalOcean API token - to purge the CDN cache",
+        dest="api_token",
+        default=os.getenv("API_TOKEN", None),
+    )
+    arg_parser.add_argument(
+        "--spaces-key",
+        help="DigitalOcean Spaces Key",
+        dest="spaces_key",
+        default=os.getenv("SPACES_KEY", None),
+    )
+    arg_parser.add_argument(
+        "--spaces-secret",
+        help="DigitalOcean Spaces Secret",
+        dest="spaces_secret",
+        default=os.getenv("SPACES_SECRET", None),
+    )
+    arg_parser.add_argument(
+        "--spaces-region",
+        help="DigitalOcean Spaces Region",
+        dest="spaces_region",
+        default=os.getenv("SPACES_REGION", None),
+    )
+    arg_parser.add_argument(
+        "--spaces-name",
+        help="DigitalOcean Spaces name - the bucket name",
+        dest="spaces_name",
+        default=os.getenv("SPACES_NAME", None),
+    )
+    arg_parser.add_argument(
+        "--spaces-path",
+        help="DigitalOcean Spaces UI path - path where the UI is stored",
+        dest="spaces_path",
+        default=os.getenv("SPACES_PATH", None),
+    )
+    arg_parser.add_argument(
+        "--github-ref",
+        help="Github Ref",
+        dest="github_ref",
+        default=os.getenv("GITHUB_REF", None),
+    )
+    arg_parser.add_argument(
+        "--github-ref-type",
+        help="Github Ref Type",
+        dest="github_ref_type",
+        default=os.getenv("GITHUB_REF_TYPE", None),
+    )
+    arg_parser.add_argument(
+        "--github-event-name",
+        help="Github Event Name",
+        dest="github_event_name",
+        default=os.getenv("GITHUB_EVENT_NAME", None),
+    )
+
+
+def verify_args(args: Namespace) -> None:
+    if None in (
+        args.api_token,
+        args.spaces_key,
+        args.spaces_secret,
+        args.spaces_name,
+        args.spaces_path,
+        args.spaces_region,
+    ):
+        raise ValueError("missing required argument")
+    if not str(args.spaces_path).endswith("/"):
+        raise ValueError(f"spaces path {args.spaces_path} must end with a slash")
+    if str(args.spaces_path).startswith("/"):
+        raise ValueError(f"spaces path {args.spaces_path} must not start with a slash")

--- a/plugins/gcp/tools/gcppolicygen/gcppolicygen/__main__.py
+++ b/plugins/gcp/tools/gcppolicygen/gcppolicygen/__main__.py
@@ -1,0 +1,27 @@
+import logging
+from . import (
+    log,
+    get_arg_parser,
+    add_args,
+    verify_args,
+)
+from .upload import upload_policies
+
+
+def main() -> None:
+    parser = get_arg_parser()
+    add_args(parser)
+    args = parser.parse_args()
+    try:
+        verify_args(args)
+    except ValueError as e:
+        parser.error(e)
+
+    if args.verbose:
+        log.setLevel(logging.DEBUG)
+
+    upload_policies(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/gcp/tools/gcppolicygen/gcppolicygen/gen.py
+++ b/plugins/gcp/tools/gcppolicygen/gcppolicygen/gen.py
@@ -1,0 +1,30 @@
+import os
+from yaml import safe_dump
+from resoto_plugin_gcp.collector import called_collect_apis, called_mutator_apis
+from resoto_plugin_gcp.resource.base import GcpApiSpec
+
+
+def get_policies(org_list: bool = True, collect: bool = True, mutate: bool = True, pricing_list: bool = False) -> list:
+    def iam_statement(name: str, apis: list[AwsApiSpec]) -> tuple[set[str], str]:
+        permissions = {api.iam_permission() for api in apis}
+        statement = {
+            "PolicyName": name,
+            "PolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [{"Effect": "Allow", "Resource": "*", "Action": sorted(permissions)}],
+            },
+        }
+        return statement
+
+    policies = []
+    if org_list:
+        policies.append(org_list_policy)
+    if pricing_list:
+        policies.append(pricing_list_policy)
+    if collect:
+        collect_policy = iam_statement("ResotoCollect", called_collect_apis())
+        policies.append(collect_policy)
+    if mutate:
+        mutate_policy = iam_statement("ResotoMutate", called_mutator_apis())
+        policies.append(mutate_policy)
+    return policies

--- a/plugins/gcp/tools/gcppolicygen/gcppolicygen/upload.py
+++ b/plugins/gcp/tools/gcppolicygen/gcppolicygen/upload.py
@@ -8,6 +8,7 @@ import time
 import mimetypes
 import magic
 import json
+import yaml
 import tempfile
 from botocore.client import BaseClient
 from functools import lru_cache
@@ -52,6 +53,10 @@ def upload_policies(args: Namespace) -> None:
             filename = f"{tmpdirname}/{policy['title']}.json"
             with open(filename, "w") as f:
                 json.dump(policy, f, indent=4)
+
+            filename = f"{tmpdirname}/{policy['title']}.yaml"
+            with open(filename, "w") as f:
+                yaml.safe_dump(policy, f, sort_keys=False)
 
         # Upload the policies to the CDN
         for destination in destinations:

--- a/plugins/gcp/tools/gcppolicygen/gcppolicygen/upload.py
+++ b/plugins/gcp/tools/gcppolicygen/gcppolicygen/upload.py
@@ -49,11 +49,11 @@ def upload_policies(args: Namespace) -> None:
         policies = get_policies()
         log.debug(f"Created temporary directory: {tmpdirname}")
         for policy in policies:
-            filename = f"{tmpdirname}/{policy['PolicyName']}.json"
+            filename = f"{tmpdirname}/{policy['title']}.json"
             with open(filename, "w") as f:
-                json.dump(policy["PolicyDocument"], f, indent=4)
+                json.dump(policy, f, indent=4)
 
-         # Upload the policies to the CDN
+        # Upload the policies to the CDN
         for destination in destinations:
             for filename in glob.iglob(tmpdirname + "**/**", recursive=True):
                 if not os.path.isfile(filename):

--- a/plugins/gcp/tools/gcppolicygen/gcppolicygen/upload.py
+++ b/plugins/gcp/tools/gcppolicygen/gcppolicygen/upload.py
@@ -1,0 +1,150 @@
+import os
+import re
+import sys
+import glob
+import boto3
+import requests
+import time
+import mimetypes
+import magic
+import json
+import tempfile
+from botocore.client import BaseClient
+from functools import lru_cache
+from argparse import Namespace
+from typing import Optional
+from . import log
+from .gen import get_policies
+
+
+mimetypes.init()
+mime = magic.Magic(mime=True)
+
+
+def upload_policies(args: Namespace) -> None:
+    """Upload the Resoto GCP policies to the CDN."""
+    log.info("Uploading Resoto GCP policies to the CDN")
+    cdn_client = spaces_client(args.spaces_region, args.spaces_key, args.spaces_secret)
+
+    # github_ref format:
+    # refs/pull/14/merge
+    # refs/tags/v0.0.1
+    # refs/heads/master
+    destinations = ["edge"]
+    if None not in (args.github_ref, args.github_ref_type, args.github_event_name):
+        log.debug(f"GitHub ref: {args.github_ref}, type: {args.github_ref_type}, event: {args.github_event_name}")
+
+        if str(args.github_event_name) == "pull_request":
+            log.info("Not uploading for PR")
+            sys.exit(0)
+
+        m = re.search(r"^refs/tags/(.+)$", str(args.github_ref))
+        if m and args.github_ref_type == "tag":
+            destination = m.group(1)
+            destinations = ["latest", destination]
+
+    purge_keys = []
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # Create the policy files
+        policies = get_policies()
+        log.debug(f"Created temporary directory: {tmpdirname}")
+        for policy in policies:
+            filename = f"{tmpdirname}/{policy['PolicyName']}.json"
+            with open(filename, "w") as f:
+                json.dump(policy["PolicyDocument"], f, indent=4)
+
+         # Upload the policies to the CDN
+        for destination in destinations:
+            for filename in glob.iglob(tmpdirname + "**/**", recursive=True):
+                if not os.path.isfile(filename):
+                    continue
+                basename = filename[len(tmpdirname) + 1 :]
+                key_name = f"{args.spaces_path}{destination}/{basename}"
+                ctype = content_type(filename, ttl_hash=ttl_hash())
+                log.debug(f"Uploading {filename} to {key_name}, type: {ctype}")
+                upload_to_cdn(cdn_client, filename=filename, key=key_name, spaces_name=args.spaces_name, ctype=ctype)
+                purge_keys.append(key_name)
+
+    try:
+        purge_cdn(purge_keys, args.api_token, args.spaces_name, args.spaces_region)
+    except RuntimeError as e:
+        log.error(e)
+
+
+def spaces_client(region: str, key: str, secret: str) -> BaseClient:
+    session = boto3.session.Session()
+    return session.client(
+        "s3",
+        region_name=region,
+        endpoint_url=f"https://{region}.digitaloceanspaces.com",
+        aws_access_key_id=key,
+        aws_secret_access_key=secret,
+    )
+
+
+def upload_to_cdn(
+    client: BaseClient,
+    filename: str,
+    key: str,
+    spaces_name: str,
+    acl: str = "public-read",
+    ctype: str = "binary/octet-stream",
+) -> None:
+    with open(filename, "rb") as f:
+        client.upload_fileobj(f, spaces_name, key, ExtraArgs={"ACL": acl, "ContentType": ctype})
+
+
+@lru_cache
+def content_type(filename: str, ttl_hash: Optional[int] = None) -> str:
+    if filename.endswith(".template"):
+        return "binary/octet-stream"
+    ctype = mimetypes.guess_type(filename)[0]
+    if ctype is None:
+        ctype = mime.from_file(filename)
+    if ctype in ("inode/x-empty"):
+        ctype = "binary/octet-stream"
+    return ctype
+
+
+def purge_cdn(files: list, api_token: str, spaces_name: str, region: str) -> None:
+    """Purge the CDN cache for the given files."""
+    endpoints = cdn_endpoints(api_token, ttl_hash=ttl_hash())
+    log.info(f"Purging CDN cache for {len(files)} files")
+    endpoint_key = f"{spaces_name}.{region}.digitaloceanspaces.com"
+    if endpoint_key not in endpoints:
+        raise RuntimeError(f"No CDN endpoint for {endpoint_key}")
+    endpoint_id = endpoints[endpoint_key]
+    headers = {"Authorization": f"Bearer {api_token}", "Content-Type": "application/json"}
+    data = {"files": files}
+    response = requests.delete(
+        f"https://api.digitalocean.com/v2/cdn/endpoints/{endpoint_id}/cache", json=data, headers=headers
+    )
+    if response.status_code != 204:
+        raise RuntimeError(f"failed to purge CDN cache: {response.status_code} {response.text}")
+
+
+@lru_cache(maxsize=1)
+def cdn_endpoints(api_token: str, ttl_hash: Optional[int] = None) -> dict:
+    """Get the CDN endpoint from the DigitalOcean API."""
+    log.debug("Getting all CDN endpoints from the DigitalOcean API")
+    headers = {"Authorization": f"Bearer {api_token}", "Content-Type": "application/json"}
+
+    endpoints = {}
+    next_uri = "https://api.digitalocean.com/v2/cdn/endpoints?per_page=200"
+    while True:
+        response = requests.get(next_uri, headers=headers)
+        if response.status_code != 200:
+            raise RuntimeError(f"failed to get CDN endpoint: {response.text}")
+        data = response.json()
+        if "endpoints" not in data:
+            raise ValueError(f"no CDN endpoint in response: {response.text}")
+        for endpoint in data["endpoints"]:
+            endpoints[endpoint["origin"]] = endpoint["id"]
+        if data.get("links", {}).get("pages", {}).get("next", None) is None:
+            break
+        next_uri = data["links"]["pages"]["next"]
+    return endpoints
+
+
+def ttl_hash(ttl: int = 3600) -> int:
+    return round(time.time() / ttl)

--- a/plugins/gcp/tools/gcppolicygen/requirements-test.txt
+++ b/plugins/gcp/tools/gcppolicygen/requirements-test.txt
@@ -1,0 +1,5 @@
+# test dependencies
+pytest==7.3.1
+pytest-cov==4.0.0
+flake8==6.0.0
+black==23.3.0

--- a/plugins/gcp/tools/gcppolicygen/requirements.txt
+++ b/plugins/gcp/tools/gcppolicygen/requirements.txt
@@ -1,0 +1,5 @@
+boto3
+requests
+python-magic
+pyyaml
+resoto-plugin-gcp

--- a/plugins/gcp/tools/gcppolicygen/setup.cfg
+++ b/plugins/gcp/tools/gcppolicygen/setup.cfg
@@ -1,0 +1,6 @@
+[aliases]
+test=pytest
+
+[mypy]
+ignore_missing_imports = True
+

--- a/plugins/gcp/tools/gcppolicygen/setup.py
+++ b/plugins/gcp/tools/gcppolicygen/setup.py
@@ -1,0 +1,50 @@
+import gcppolicygen
+from setuptools import setup, find_packages
+
+
+with open("requirements.txt") as f:
+    requirements = f.read().splitlines()
+
+with open("README.md") as f:
+    readme = f.read()
+
+
+setup(
+    name=gcppolicygen.__title__,
+    version=gcppolicygen.__version__,
+    description=gcppolicygen.__description__,
+    license=gcppolicygen.__license__,
+    packages=find_packages(),
+    long_description=readme,
+    long_description_content_type="text/markdown",
+    entry_points={
+        "console_scripts": [
+            "gcppolicygen = gcppolicygen.__main__:main",
+        ]
+    },
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=requirements,
+    setup_requires=["pytest-runner"],
+    tests_require=["pytest"],
+    classifiers=[
+        # Current project status
+        "Development Status :: 4 - Beta",
+        # Audience
+        "Intended Audience :: System Administrators",
+        "Intended Audience :: Information Technology",
+        # License information
+        "License :: OSI Approved :: Apache Software License",
+        # Supported python versions
+        "Programming Language :: Python :: 3.9",
+        # Supported OS's
+        "Operating System :: POSIX :: Linux",
+        "Operating System :: Unix",
+        # Extra metadata
+        "Environment :: Console",
+        "Natural Language :: English",
+        "Topic :: Security",
+        "Topic :: Utilities",
+    ],
+    keywords="cloud security",
+)

--- a/plugins/gcp/tools/gcppolicygen/tox.ini
+++ b/plugins/gcp/tools/gcppolicygen/tox.ini
@@ -1,0 +1,23 @@
+[tox]
+env_list = syntax, black
+
+[flake8]
+max-line-length=120
+exclude = .git,.tox,__pycache__,.idea,.pytest_cache
+ignore=F403, F405, E722, N806, N813, E266, W503, E203
+
+[pytest]
+testpaths= test
+asyncio_mode= auto
+
+[testenv]
+usedevelop = true
+deps =
+   -rrequirements-test.txt
+   -rrequirements.txt
+
+[testenv:syntax]
+commands = flake8
+
+[testenv:black]
+commands = black --line-length 120 --check --diff --target-version py39 .


### PR DESCRIPTION
# Description

Extract the required permissions required for GCP.
Towards: #1487 

The permissions are created by analyzing all the API Calls made  in the collector.
This is the current result.

```
title: resoto_access
description: Permissions required to collect resources.
stage: GA
includedPermissions:
- cloudsql.backupRuns.list
- cloudsql.databases.list
- cloudsql.instances.get
- cloudsql.instances.list
- cloudsql.users.list
- compute.acceleratorTypes.list
- compute.addresses.list
- compute.autoscalers.list
- compute.backendBuckets.list
- compute.backendServices.list
- compute.commitments.list
- compute.diskTypes.list
- compute.disks.list
- compute.externalVpnGateways.list
- compute.firewalls.list
- compute.forwardingRules.list
- compute.globalOperations.list
- compute.healthChecks.list
- compute.httpHealthChecks.list
- compute.httpsHealthChecks.list
- compute.images.list
- compute.instanceGroupManagers.list
- compute.instanceGroups.list
- compute.instanceTemplates.list
- compute.instances.list
- compute.interconnectAttachments.list
- compute.interconnectLocations.list
- compute.interconnects.list
- compute.licenses.list
- compute.machineImages.list
- compute.machineTypes.get
- compute.machineTypes.list
- compute.networkEdgeSecurityServices.list
- compute.networkEndpointGroups.list
- compute.networks.list
- compute.nodeGroups.list
- compute.nodeTemplates.list
- compute.nodeTypes.list
- compute.packetMirrorings.list
- compute.publicAdvertisedPrefixes.list
- compute.publicDelegatedPrefixes.list
- compute.regionHealthCheckServices.list
- compute.regionNotificationEndpoints.list
- compute.resourcePolicies.list
- compute.routers.list
- compute.routes.list
- compute.securityPolicies.list
- compute.serviceAttachments.list
- compute.snapshots.list
- compute.sslCertificates.list
- compute.sslPolicies.list
- compute.subnetworks.list
- compute.targetGrpcProxies.list
- compute.targetHttpProxies.list
- compute.targetHttpsProxies.list
- compute.targetInstances.list
- compute.targetPools.list
- compute.targetSslProxies.list
- compute.targetTcpProxies.list
- compute.targetVpnGateways.list
- compute.urlMaps.list
- compute.vpnGateways.list
- compute.vpnTunnels.list
- container.clusters.list
- container.operations.list
- storage.buckets.list
```

```
title: resoto_mutate
description: Permissions required to mutate resources.
stage: GA
includedPermissions:
- cloudsql.instances.delete
- cloudsql.instances.update
- compute.addresses.delete
- compute.autoscalers.delete
- compute.autoscalers.update
- compute.backendBuckets.delete
- compute.backendBuckets.update
- compute.backendServices.delete
- compute.backendServices.update
- compute.commitments.update
- compute.disks.delete
- compute.disks.setLabels
- compute.externalVpnGateways.delete
- compute.externalVpnGateways.setLabels
- compute.firewalls.delete
- compute.firewalls.update
- compute.forwardingRules.delete
- compute.globalOperations.delete
- compute.healthChecks.delete
- compute.healthChecks.update
- compute.httpHealthChecks.delete
- compute.httpHealthChecks.update
- compute.httpsHealthChecks.delete
- compute.httpsHealthChecks.update
- compute.images.delete
- compute.images.setLabels
- compute.instanceGroupManagers.delete
- compute.instanceGroupManagers.update
- compute.instanceGroups.delete
- compute.instanceGroups.update
- compute.instanceTemplates.delete
- compute.instances.delete
- compute.instances.setLabels
- compute.interconnectAttachments.delete
- compute.interconnectAttachments.setLabels
- compute.interconnects.delete
- compute.interconnects.setLabels
- compute.licenses.delete
- compute.machineImages.delete
- compute.networkEdgeSecurityServices.delete
- compute.networkEdgeSecurityServices.update
- compute.networkEndpointGroups.delete
- compute.networks.delete
- compute.nodeGroups.delete
- compute.nodeGroups.update
- compute.nodeTemplates.delete
- compute.packetMirrorings.delete
- compute.packetMirrorings.update
- compute.publicAdvertisedPrefixes.delete
- compute.publicAdvertisedPrefixes.update
- compute.publicDelegatedPrefixes.delete
- compute.publicDelegatedPrefixes.update
- compute.regionHealthCheckServices.delete
- compute.regionHealthCheckServices.update
- compute.regionNotificationEndpoints.delete
- compute.regionNotificationEndpoints.update
- compute.resourcePolicies.delete
- compute.resourcePolicies.update
- compute.routers.delete
- compute.routers.update
- compute.routes.delete
- compute.securityPolicies.setLabels
- compute.serviceAttachments.delete
- compute.serviceAttachments.update
- compute.snapshots.delete
- compute.snapshots.setLabels
- compute.sslCertificates.delete
- compute.sslPolicies.delete
- compute.subnetworks.delete
- compute.targetGrpcProxies.delete
- compute.targetGrpcProxies.update
- compute.targetHttpProxies.delete
- compute.targetHttpProxies.update
- compute.targetHttpsProxies.delete
- compute.targetHttpsProxies.update
- compute.targetInstances.delete
- compute.targetPools.delete
- compute.targetPools.update
- compute.targetSslProxies.delete
- compute.targetSslProxies.update
- compute.targetTcpProxies.delete
- compute.targetTcpProxies.update
- compute.targetVpnGateways.delete
- compute.urlMaps.delete
- compute.vpnGateways.delete
- compute.vpnGateways.setLabels
- compute.vpnTunnels.delete
- container.clusters.delete
- container.clusters.update
- storage.buckets.delete
- storage.buckets.update
```
# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
