### PR TITLE
[aws][feat] Skip an account on resource collect failure is configurable

### DIFF
--- a/plugins/aws/Makefile
+++ b/plugins/aws/Makefile
@@ -30,7 +30,7 @@ clean-test: ## remove test and coverage artifacts
 lint: ## static code analysis
 	black --line-length 120 --check resoto_plugin_aws test
 	flake8 resoto_plugin_aws
-	mypy --python-version 3.9 --strict resoto_plugin_aws test
+	mypy --python-version 3.9 --strict --install-types resoto_plugin_aws test
 
 test: ## run tests quickly with the default Python
 	pytest

--- a/plugins/aws/resoto_plugin_aws/configuration.py
+++ b/plugins/aws/resoto_plugin_aws/configuration.py
@@ -233,6 +233,13 @@ class AwsConfig:
             "Defaults to 1 hour.",
         },
     )
+    discard_account_on_resource_error: bool = field(
+        default=False,
+        metadata={
+            "description": "Fail the whole account if collecting a resource fails. "
+            "If false, the error is logged and the resource is skipped."
+        },
+    )
 
     @staticmethod
     def from_json(json: Json) -> "AwsConfig":

--- a/plugins/aws/resoto_plugin_aws/resource/athena.py
+++ b/plugins/aws/resoto_plugin_aws/resource/athena.py
@@ -113,13 +113,14 @@ class AwsAthenaWorkGroup(AwsResource):
             if result is None:
                 return None
 
-            workgroup = AwsAthenaWorkGroup.from_api(result)
-            workgroup.set_arn(
-                builder=builder,
-                resource=f"workgroup/{workgroup.name}",
-            )
-
-            return workgroup
+            if workgroup := AwsAthenaWorkGroup.from_api(result, builder):
+                workgroup.set_arn(
+                    builder=builder,
+                    resource=f"workgroup/{workgroup.name}",
+                )
+                return workgroup
+            else:
+                return None
 
         def add_tags(data_catalog: AwsAthenaWorkGroup) -> None:
             tags = builder.client.list(
@@ -223,9 +224,10 @@ class AwsAthenaDataCatalog(AwsResource):
             )
             if result is None:
                 return None
-            catalog = AwsAthenaDataCatalog.from_api(result)
-            catalog.set_arn(builder=builder, resource=f"datacatalog/{catalog.name}")
-            return catalog
+            if catalog := AwsAthenaDataCatalog.from_api(result, builder):
+                catalog.set_arn(builder=builder, resource=f"datacatalog/{catalog.name}")
+                return catalog
+            return None
 
         def add_tags(data_catalog: AwsAthenaDataCatalog) -> None:
             tags = builder.client.list(

--- a/plugins/aws/resoto_plugin_aws/resource/base.py
+++ b/plugins/aws/resoto_plugin_aws/resource/base.py
@@ -60,8 +60,8 @@ def parse_json(json: Json, clazz: Type[T], builder: GraphBuilder) -> Optional[T]
     try:
         return from_json(json, clazz)
     except Exception as e:
-        # report the error
-        builder.core_feedback.error(f"Failed to parse json into {clazz.__name__}: {e}. Source: {json}")
+        # report and log the error
+        builder.core_feedback.error(f"Failed to parse json into {clazz.__name__}: {e}. Source: {json}", log)
         # based on the strict flag, either raise the exception or return None
         if builder.config.discard_account_on_resource_error:
             raise

--- a/plugins/aws/resoto_plugin_aws/resource/cloudfront.py
+++ b/plugins/aws/resoto_plugin_aws/resource/cloudfront.py
@@ -27,10 +27,10 @@ class CloudFrontResource:
                 res.tags = bend(ToDict(), tags["Items"])
 
         for js in json:
-            instance = cls.from_api(js)
-            builder.add_node(instance, js)
-            if instance.arn:
-                builder.submit_work(service_name, add_tags, instance)
+            if instance := cls.from_api(js, builder):
+                builder.add_node(instance, js)
+                if instance.arn:
+                    builder.submit_work(service_name, add_tags, instance)
 
     @staticmethod
     def delete_cloudfront_resource(client: AwsClient, resource: str, id: str) -> bool:

--- a/plugins/aws/resoto_plugin_aws/resource/cloudwatch.py
+++ b/plugins/aws/resoto_plugin_aws/resource/cloudwatch.py
@@ -210,9 +210,9 @@ class AwsCloudwatchAlarm(CloudwatchTaggable, AwsResource):
                 alarm.tags = bend(ToDict(), tags)
 
         for js in json:
-            instance = cls.from_api(js)
-            builder.add_node(instance, js)
-            builder.submit_work(service_name, add_tags, instance)
+            if instance := cls.from_api(js, builder):
+                builder.add_node(instance, js)
+                builder.submit_work(service_name, add_tags, instance)
 
     def connect_in_graph(self, builder: GraphBuilder, source: Json) -> None:
         super().connect_in_graph(builder, source)

--- a/plugins/aws/resoto_plugin_aws/resource/dynamodb.py
+++ b/plugins/aws/resoto_plugin_aws/resource/dynamodb.py
@@ -316,9 +316,9 @@ class AwsDynamoDbTable(DynamoDbTaggable, AwsResource):
         def add_instance(table: str) -> None:
             table_description = builder.client.get(service_name, "describe-table", "Table", TableName=table)
             if table_description is not None:
-                instance = cls.from_api(table_description)
-                builder.add_node(instance, table_description)
-                builder.submit_work(service_name, add_tags, instance)
+                if instance := cls.from_api(table_description, builder):
+                    builder.add_node(instance, table_description)
+                    builder.submit_work(service_name, add_tags, instance)
 
         def add_tags(table: AwsDynamoDbTable) -> None:
             tags = builder.client.list(service_name, "list-tags-of-resource", "Tags", ResourceArn=table.arn)
@@ -398,9 +398,9 @@ class AwsDynamoDbGlobalTable(DynamoDbTaggable, AwsResource):
                 GlobalTableName=table["GlobalTableName"],
             )
             if table_description:
-                instance = cls.from_api(table_description)
-                builder.add_node(instance, table_description)
-                builder.submit_work(service_name, add_tags, instance)
+                if instance := cls.from_api(table_description, builder):
+                    builder.add_node(instance, table_description)
+                    builder.submit_work(service_name, add_tags, instance)
 
         def add_tags(table: AwsDynamoDbGlobalTable) -> None:
             tags = builder.client.list(service_name, "list-tags-of-resource", "Tags", ResourceArn=table.arn)

--- a/plugins/aws/resoto_plugin_aws/resource/efs.py
+++ b/plugins/aws/resoto_plugin_aws/resource/efs.py
@@ -116,14 +116,14 @@ class AwsEfsFileSystem(EfsTaggable, AwsResource, BaseNetworkShare):
             for mt_raw in builder.client.list(
                 service_name, "describe-mount-targets", "MountTargets", FileSystemId=fs.id
             ):
-                mt = AwsEfsMountTarget.from_api(mt_raw)
-                builder.add_node(mt, mt_raw)
-                builder.add_edge(fs, node=mt)
+                if mt := AwsEfsMountTarget.from_api(mt_raw, builder):
+                    builder.add_node(mt, mt_raw)
+                    builder.add_edge(fs, node=mt)
 
         for js in json:
-            instance = cls.from_api(js)
-            builder.add_node(instance, js)
-            builder.submit_work(service_name, collect_mount_points, instance)
+            if instance := cls.from_api(js, builder):
+                builder.add_node(instance, js)
+                builder.submit_work(service_name, collect_mount_points, instance)
 
     def connect_in_graph(self, builder: GraphBuilder, source: Json) -> None:
         if kms_key_id := source.get("KmsKeyId"):

--- a/plugins/aws/resoto_plugin_aws/resource/elasticache.py
+++ b/plugins/aws/resoto_plugin_aws/resource/elasticache.py
@@ -294,9 +294,9 @@ class AwsElastiCacheCacheCluster(ElastiCacheTaggable, AwsResource):
                 resource.tags = bend(ToDict(), tags)
 
         for js in json:
-            instance = cls.from_api(js)
-            builder.add_node(instance, js)
-            builder.submit_work(service_name, add_tags, instance)
+            if instance := cls.from_api(js, builder):
+                builder.add_node(instance, js)
+                builder.submit_work(service_name, add_tags, instance)
 
     def connect_in_graph(self, builder: GraphBuilder, source: Json) -> None:
         # TODO add edge to outpost when applicable
@@ -482,9 +482,9 @@ class AwsElastiCacheReplicationGroup(ElastiCacheTaggable, AwsResource):
                 resource.tags = bend(ToDict(), tags)
 
         for js in json:
-            instance = cls.from_api(js)
-            builder.add_node(instance, js)
-            builder.submit_work(service_name, add_tags, instance)
+            if instance := cls.from_api(js, builder):
+                builder.add_node(instance, js)
+                builder.submit_work(service_name, add_tags, instance)
 
     def connect_in_graph(self, builder: GraphBuilder, source: Json) -> None:
         for cluster_name in self.replication_group_member_clusters:

--- a/plugins/aws/resoto_plugin_aws/resource/elb.py
+++ b/plugins/aws/resoto_plugin_aws/resource/elb.py
@@ -221,9 +221,9 @@ class AwsElb(ElbTaggable, AwsResource, BaseLoadBalancer):
                 elb.tags = bend(S("Tags", default=[]) >> ToDict(), tags[0])
 
         for js in json:
-            instance = cls.from_api(js)
-            builder.add_node(instance, js)
-            builder.submit_work(service_name, add_tags, instance)
+            if instance := cls.from_api(js, builder):
+                builder.add_node(instance, js)
+                builder.submit_work(service_name, add_tags, instance)
 
     def connect_in_graph(self, builder: GraphBuilder, source: Json) -> None:
         super().connect_in_graph(builder, source)

--- a/plugins/aws/resoto_plugin_aws/resource/kinesis.py
+++ b/plugins/aws/resoto_plugin_aws/resource/kinesis.py
@@ -123,9 +123,9 @@ class AwsKinesisStream(AwsResource):
                 StreamName=stream_name,
             )
             if len(stream_descriptions) == 1:
-                stream = AwsKinesisStream.from_api(stream_descriptions[0])
-                builder.add_node(stream)
-                builder.submit_work(service_name, add_tags, stream)
+                if stream := AwsKinesisStream.from_api(stream_descriptions[0], builder):
+                    builder.add_node(stream)
+                    builder.submit_work(service_name, add_tags, stream)
 
     def connect_in_graph(self, builder: GraphBuilder, source: Json) -> None:
         if self.kinesis_key_id:

--- a/plugins/aws/resoto_plugin_aws/resource/kms.py
+++ b/plugins/aws/resoto_plugin_aws/resource/kms.py
@@ -104,11 +104,11 @@ class AwsKmsKey(AwsResource, BaseAccessKey):
                 service_name, "describe-key", result_name="KeyMetadata", KeyId=key["KeyId"]
             )
             if key_metadata is not None:
-                instance = AwsKmsKey.from_api(key_metadata)
-                builder.add_node(instance)
-                builder.submit_work(service_name, add_tags, instance)
-                if instance.kms_key_manager == "CUSTOMER" and instance.access_key_status == "Enabled":
-                    builder.submit_work(service_name, add_rotation_status, instance)
+                if instance := AwsKmsKey.from_api(key_metadata, builder):
+                    builder.add_node(instance)
+                    builder.submit_work(service_name, add_tags, instance)
+                    if instance.kms_key_manager == "CUSTOMER" and instance.access_key_status == "Enabled":
+                        builder.submit_work(service_name, add_rotation_status, instance)
 
         def add_rotation_status(key: AwsKmsKey) -> None:
             with suppress(Exception):

--- a/plugins/aws/resoto_plugin_aws/resource/rds.py
+++ b/plugins/aws/resoto_plugin_aws/resource/rds.py
@@ -447,10 +447,10 @@ class AwsRdsInstance(RdsTaggable, AwsResource, BaseDatabase):
                 rds.mtime = t
 
         for js in json:
-            instance = AwsRdsInstance.from_api(js)
-            instances.append(instance)
-            builder.add_node(instance, js)
-            builder.submit_work(service_name, add_tags, instance)
+            if instance := AwsRdsInstance.from_api(js, builder):
+                instances.append(instance)
+                builder.add_node(instance, js)
+                builder.submit_work(service_name, add_tags, instance)
         update_atime_mtime()
 
     def connect_in_graph(self, builder: GraphBuilder, source: Json) -> None:

--- a/plugins/aws/resoto_plugin_aws/resource/redshift.py
+++ b/plugins/aws/resoto_plugin_aws/resource/redshift.py
@@ -419,9 +419,9 @@ class AwsRedshiftCluster(AwsResource):
     @classmethod
     def collect(cls: Type[AwsResource], json: List[Json], builder: GraphBuilder) -> None:
         for js in json:
-            cluster = cls.from_api(js)
-            cluster.set_arn(builder=builder, resource=f"cluster:{cluster.id}")
-            builder.add_node(cluster, js)
+            if cluster := cls.from_api(js, builder):
+                cluster.set_arn(builder=builder, resource=f"cluster:{cluster.id}")
+                builder.add_node(cluster, js)
 
     def connect_in_graph(self, builder: GraphBuilder, source: Json) -> None:
         if self.redshift_vpc_id:

--- a/plugins/aws/resoto_plugin_aws/resource/service_quotas.py
+++ b/plugins/aws/resoto_plugin_aws/resource/service_quotas.py
@@ -92,10 +92,10 @@ class AwsServiceQuota(AwsResource, BaseQuota):
     def collect_service(cls, service_code: str, matchers: List["QuotaMatcher"], builder: GraphBuilder) -> None:
         log.debug(f"Collecting Service quotas for {service_code} in region {builder.region.name}")
         for js in builder.client.list(service_name, "list-service-quotas", "Quotas", ServiceCode=service_code):
-            quota = AwsServiceQuota.from_api(js)
-            for matcher in matchers:
-                if matcher.match(quota):
-                    builder.add_node(quota, dict(source=js, matcher=evolve(matcher, region=builder.region)))
+            if quota := AwsServiceQuota.from_api(js, builder):
+                for matcher in matchers:
+                    if matcher.match(quota):
+                        builder.add_node(quota, dict(source=js, matcher=evolve(matcher, region=builder.region)))
 
     @classmethod
     def collect_resources(cls: Type[AwsResource], builder: GraphBuilder) -> None:

--- a/plugins/aws/resoto_plugin_aws/resource/sqs.py
+++ b/plugins/aws/resoto_plugin_aws/resource/sqs.py
@@ -97,9 +97,9 @@ class AwsSqsQueue(AwsResource):
             if queue_attributes is not None:
                 queue_attributes["QueueUrl"] = queue_url
                 queue_attributes["QueueName"] = queue_url.rsplit("/", 1)[-1]
-                instance = cls.from_api(queue_attributes)
-                builder.add_node(instance)
-                builder.submit_work(service_name, add_tags, instance)
+                if instance := cls.from_api(queue_attributes, builder):
+                    builder.add_node(instance)
+                    builder.submit_work(service_name, add_tags, instance)
 
         def add_tags(queue: AwsSqsQueue) -> None:
             tags = builder.client.get(service_name, "list-queue-tags", result_name="Tags", QueueUrl=queue.sqs_queue_url)

--- a/plugins/aws/test/__init__.py
+++ b/plugins/aws/test/__init__.py
@@ -16,7 +16,7 @@ from test.resources import BotoFileBasedSession
 
 @fixture
 def aws_config() -> AwsConfig:
-    config = AwsConfig()
+    config = AwsConfig(discard_account_on_resource_error=True)
     config.sessions().session_class_factory = BotoFileBasedSession
     return config
 

--- a/resotolib/resotolib/core/actions.py
+++ b/resotolib/resotolib/core/actions.py
@@ -57,7 +57,7 @@ class CoreFeedback:
     def error(self, message: str, logger: Optional[Logger] = None) -> None:
         if logger:
             logger.error(self.context_str + message)
-        self._info_message("error", message[0:250])  # truncate message to 250 characters
+        self._info_message("error", message)
 
     @property
     def context_str(self) -> str:
@@ -72,7 +72,7 @@ class CoreFeedback:
                     "task": self.task_id,
                     "step": self.step_name,
                     "level": level,
-                    "message": self.context_str + message,
+                    "message": self.context_str + message[0:500],  # truncate message to 500 characters
                 },
             }
         )


### PR DESCRIPTION
# Description

When Resoto can not handle a single resource result, it will ignore such errors by default.
The current strict behaviour can be re-enabled, by setting `discard_account_on_resource_error` to true.

<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
