### PR TITLE
[ci][fix] Publish docker-compose.yaml without RESOTOWORKER_OVERRIDE env

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,7 +91,7 @@ jobs:
         shell: bash
         run: |
           yq '.services.resotoworker.environment += "RESOTOWORKER_OVERRIDE=resotoworker.collector=example"' docker-compose.yaml > docker-compose-model-gen.yaml
-          PSK= RESOTOCORE_ANALYTICS_OPT_OUT=true docker-compose up -d -f docker-compose-model-gen.yaml
+          PSK= RESOTOCORE_ANALYTICS_OPT_OUT=true docker-compose -f docker-compose-model-gen.yaml up -d
           cd ${{ github.workspace }}/resoto.com/docs/reference/unified-data-model
           python3 ${{ github.workspace }}/resoto.com/tools/export_models.py
 
@@ -266,7 +266,7 @@ jobs:
         shell: bash
         run: |
           yq '.services.resotoworker.environment += "RESOTOWORKER_OVERRIDE=resotoworker.collector=example"' docker-compose.yaml > docker-compose-model-gen.yaml
-          PSK= RESOTOCORE_ANALYTICS_OPT_OUT=true docker-compose up -d -f docker-compose-model-gen.yaml
+          PSK= RESOTOCORE_ANALYTICS_OPT_OUT=true docker-compose -f docker-compose-model-gen.yaml up -d
           cd ${{ github.workspace }}/resoto.com/versioned_docs/version-${{ steps.release.outputs.docsVersion }}/reference/unified-data-model
           python3 ${{ github.workspace }}/resoto.com/tools/export_models.py
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,9 +96,8 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
-          yq -i '.services.resotoworker.environment = ["RESOTOWORKER_OVERRIDE=resotoworker.collector=example"] + .services.resotoworker.environment' docker-compose.yaml
-          PSK= RESOTOCORE_ANALYTICS_OPT_OUT=true docker-compose up -d
-          yq -i 'del(.services.resotoworker.environment[0])' docker-compose.yaml
+          yq '.services.resotoworker.environment = ["RESOTOWORKER_OVERRIDE=resotoworker.collector=example"] + .services.resotoworker.environment' docker-compose.yaml > docker-compose-model-gen.yaml
+          PSK= RESOTOCORE_ANALYTICS_OPT_OUT=true docker-compose up -d -f docker-compose-model-gen.yaml
           cd ${{ github.workspace }}/resoto.com/docs/reference/unified-data-model
           python3 ${{ github.workspace }}/resoto.com/tools/export_models.py
 
@@ -279,9 +278,8 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
-          yq -i '.services.resotoworker.environment = ["RESOTOWORKER_OVERRIDE=resotoworker.collector=example"] + .services.resotoworker.environment' docker-compose.yaml
-          PSK= RESOTOCORE_ANALYTICS_OPT_OUT=true docker-compose up -d
-          yq -i 'del(.services.resotoworker.environment[0])' docker-compose.yaml
+          yq '.services.resotoworker.environment = ["RESOTOWORKER_OVERRIDE=resotoworker.collector=example"] + .services.resotoworker.environment' docker-compose.yaml > docker-compose-model-gen.yaml
+          PSK= RESOTOCORE_ANALYTICS_OPT_OUT=true docker-compose up -d -f docker-compose-model-gen.yaml
           cd ${{ github.workspace }}/resoto.com/versioned_docs/version-${{ steps.release.outputs.docsVersion }}/reference/unified-data-model
           python3 ${{ github.workspace }}/resoto.com/tools/export_models.py
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,9 +98,9 @@ jobs:
         run: |
           yq -i '.services.resotoworker.environment = ["RESOTOWORKER_OVERRIDE=resotoworker.collector=example"] + .services.resotoworker.environment' docker-compose.yaml
           PSK= RESOTOCORE_ANALYTICS_OPT_OUT=true docker-compose up -d
+          yq -i 'del(.services.resotoworker.environment[0])' docker-compose.yaml
           cd ${{ github.workspace }}/resoto.com/docs/reference/unified-data-model
           python3 ${{ github.workspace }}/resoto.com/tools/export_models.py
-          yq -i 'del(.services.resotoworker.environment[0])' docker-compose.yaml
 
       - name: Build
         continue-on-error: true
@@ -281,9 +281,9 @@ jobs:
         run: |
           yq -i '.services.resotoworker.environment = ["RESOTOWORKER_OVERRIDE=resotoworker.collector=example"] + .services.resotoworker.environment' docker-compose.yaml
           PSK= RESOTOCORE_ANALYTICS_OPT_OUT=true docker-compose up -d
+          yq -i 'del(.services.resotoworker.environment[0])' docker-compose.yaml
           cd ${{ github.workspace }}/resoto.com/versioned_docs/version-${{ steps.release.outputs.docsVersion }}/reference/unified-data-model
           python3 ${{ github.workspace }}/resoto.com/tools/export_models.py
-          yq -i 'del(.services.resotoworker.environment[0])' docker-compose.yaml
 
       - name: Build
         if: steps.release.outputs.prerelease == 'false'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,13 +33,7 @@ jobs:
       - name: Update resotocore API YAML
         shell: bash
         run: |
-          cp resotocore/resotocore/static/api-doc.yaml resoto.com/openapi/resotocore-edge.yml
-
-      - name: Modify resotocore API YAML
-        uses: mikefarah/yq@master
-        with:
-          cmd: |
-            yq e -i '.servers[0].url = "https://{host}:{port}" | .servers[0].variables.host.default="localhost" | .servers[0].variables.port.default="8900" | del(.servers[0].description)' resoto.com/openapi/resotocore-edge.yml
+          yq '.servers[0].url = "https://{host}:{port}" | .servers[0].variables.host.default="localhost" | .servers[0].variables.port.default="8900" | del(.servers[0].description)' resotocore/resotocore/static/api-doc.yaml > resoto.com/openapi/resotocore-edge.yml
 
       - name: Regenerate API docs
         working-directory: ./resoto.com
@@ -204,14 +198,7 @@ jobs:
         if: steps.release.outputs.prerelease == 'false'
         shell: bash
         run: |
-          cp resotocore/resotocore/static/api-doc.yaml resoto.com/openapi/resotocore-${{ steps.release.outputs.docsVersion }}.yml
-
-      - name: Modify resotocore API YAML
-        if: steps.release.outputs.prerelease == 'false'
-        uses: mikefarah/yq@master
-        with:
-          cmd: |
-            yq e -i '.servers[0].url = "https://{host}:{port}" | .servers[0].variables.host.default="localhost" | .servers[0].variables.port.default="8900" | del(.servers[0].description)' resoto.com/openapi/resotocore-${{ steps.release.outputs.docsVersion }}.yml
+          yq '.servers[0].url = "https://{host}:{port}" | .servers[0].variables.host.default="localhost" | .servers[0].variables.port.default="8900" | del(.servers[0].description)' resotocore/resotocore/static/api-doc.yaml > resoto.com/openapi/resotocore-${{ steps.release.outputs.docsVersion }}.yml
 
       - name: Regenerate API docs
         if: steps.release.outputs.prerelease == 'false'
@@ -347,9 +334,9 @@ jobs:
       - name: Get current chart version
         if: steps.release.outputs.prerelease == 'false'
         id: current_chart_version
-        uses: mikefarah/yq@master
-        with:
-          cmd: yq '.version' helm-charts/someengineering/resoto/Chart.yaml
+        shell: bash
+        run: |
+          yq '.version' helm-charts/someengineering/resoto/Chart.yaml
 
       - name: Get new chart version
         if: steps.release.outputs.prerelease == 'false'
@@ -360,9 +347,9 @@ jobs:
 
       - name: Update appVersion and bump chart version
         if: steps.release.outputs.prerelease == 'false'
-        uses: mikefarah/yq@master
-        with:
-          cmd: yq e -i '.version = "${{ steps.new_chart_version.outputs.patch }}" | .appVersion = "${{ steps.release.outputs.tag }}"' helm-charts/someengineering/resoto/Chart.yaml
+        shell: bash
+        run: |
+          yq -i '.version = "${{ steps.new_chart_version.outputs.patch }}" | .appVersion = "${{ steps.release.outputs.tag }}"' helm-charts/someengineering/resoto/Chart.yaml
 
       - name: Set up Helm
         if: steps.release.outputs.prerelease == 'false'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,11 +77,6 @@ jobs:
           wget -qO resoto_access.json https://cdn.some.engineering/resoto/gcp/edge/resoto_access.json
           wget -qO resoto_mutate.json https://cdn.some.engineering/resoto/gcp/edge/resoto_mutate.json
 
-      - name: Modify Docker Compose YAML
-        shell: bash
-        run: |
-          yq -i '(.services.resotoworker.environment += "RESOTOWORKER_OVERRIDE=resotoworker.collector=example")' docker-compose.yaml
-
       - name: Clean existing Kroki images
         if: github.event_name == 'workflow_dispatch' # only when triggered manually
         shell: bash
@@ -101,9 +96,11 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
+          yq -i '(.services.resotoworker.environment = ["RESOTOWORKER_OVERRIDE=resotoworker.collector=example"] + .services.resotoworker.environment)' docker-compose.yaml
           PSK= RESOTOCORE_ANALYTICS_OPT_OUT=true docker-compose up -d
           cd ${{ github.workspace }}/resoto.com/docs/reference/unified-data-model
           python3 ${{ github.workspace }}/resoto.com/tools/export_models.py
+          yq -i 'del(.services.resotoworker.environment[0])' docker-compose.yaml
 
       - name: Build
         continue-on-error: true
@@ -260,7 +257,7 @@ jobs:
         if: steps.release.outputs.prerelease == 'false'
         shell: bash
         run: |
-          yq -i '(.services.[].image |= sub(":edge", ":${{ steps.release.outputs.tag }}")) | (.services.resotoworker.environment += "RESOTOWORKER_OVERRIDE=resotoworker.collector=example")' docker-compose.yaml
+          yq -i '(.services.[].image |= sub(":edge", ":${{ steps.release.outputs.tag }}"))' docker-compose.yaml
 
       - name: Clean existing Kroki images
         if: steps.release.outputs.prerelease == 'false'
@@ -282,9 +279,11 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
+          yq -i '(.services.resotoworker.environment = ["RESOTOWORKER_OVERRIDE=resotoworker.collector=example"] + .services.resotoworker.environment)' docker-compose.yaml
           PSK= RESOTOCORE_ANALYTICS_OPT_OUT=true docker-compose up -d
           cd ${{ github.workspace }}/resoto.com/versioned_docs/version-${{ steps.release.outputs.docsVersion }}/reference/unified-data-model
           python3 ${{ github.workspace }}/resoto.com/tools/export_models.py
+          yq -i 'del(.services.resotoworker.environment[0])' docker-compose.yaml
 
       - name: Build
         if: steps.release.outputs.prerelease == 'false'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,7 +96,7 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
-          yq '.services.resotoworker.environment = ["RESOTOWORKER_OVERRIDE=resotoworker.collector=example"] + .services.resotoworker.environment' docker-compose.yaml > docker-compose-model-gen.yaml
+          yq '.services.resotoworker.environment += "RESOTOWORKER_OVERRIDE=resotoworker.collector=example"' docker-compose.yaml > docker-compose-model-gen.yaml
           PSK= RESOTOCORE_ANALYTICS_OPT_OUT=true docker-compose up -d -f docker-compose-model-gen.yaml
           cd ${{ github.workspace }}/resoto.com/docs/reference/unified-data-model
           python3 ${{ github.workspace }}/resoto.com/tools/export_models.py
@@ -278,7 +278,7 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
-          yq '.services.resotoworker.environment = ["RESOTOWORKER_OVERRIDE=resotoworker.collector=example"] + .services.resotoworker.environment' docker-compose.yaml > docker-compose-model-gen.yaml
+          yq '.services.resotoworker.environment += "RESOTOWORKER_OVERRIDE=resotoworker.collector=example"' docker-compose.yaml > docker-compose-model-gen.yaml
           PSK= RESOTOCORE_ANALYTICS_OPT_OUT=true docker-compose up -d -f docker-compose-model-gen.yaml
           cd ${{ github.workspace }}/resoto.com/versioned_docs/version-${{ steps.release.outputs.docsVersion }}/reference/unified-data-model
           python3 ${{ github.workspace }}/resoto.com/tools/export_models.py

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,7 +96,7 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
-          yq -i '(.services.resotoworker.environment = ["RESOTOWORKER_OVERRIDE=resotoworker.collector=example"] + .services.resotoworker.environment)' docker-compose.yaml
+          yq -i '.services.resotoworker.environment = ["RESOTOWORKER_OVERRIDE=resotoworker.collector=example"] + .services.resotoworker.environment' docker-compose.yaml
           PSK= RESOTOCORE_ANALYTICS_OPT_OUT=true docker-compose up -d
           cd ${{ github.workspace }}/resoto.com/docs/reference/unified-data-model
           python3 ${{ github.workspace }}/resoto.com/tools/export_models.py
@@ -257,7 +257,7 @@ jobs:
         if: steps.release.outputs.prerelease == 'false'
         shell: bash
         run: |
-          yq -i '(.services.[].image |= sub(":edge", ":${{ steps.release.outputs.tag }}"))' docker-compose.yaml
+          yq -i '.services.[].image |= sub(":edge", ":${{ steps.release.outputs.tag }}")' docker-compose.yaml
 
       - name: Clean existing Kroki images
         if: steps.release.outputs.prerelease == 'false'
@@ -279,7 +279,7 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
-          yq -i '(.services.resotoworker.environment = ["RESOTOWORKER_OVERRIDE=resotoworker.collector=example"] + .services.resotoworker.environment)' docker-compose.yaml
+          yq -i '.services.resotoworker.environment = ["RESOTOWORKER_OVERRIDE=resotoworker.collector=example"] + .services.resotoworker.environment' docker-compose.yaml
           PSK= RESOTOCORE_ANALYTICS_OPT_OUT=true docker-compose up -d
           cd ${{ github.workspace }}/resoto.com/versioned_docs/version-${{ steps.release.outputs.docsVersion }}/reference/unified-data-model
           python3 ${{ github.workspace }}/resoto.com/tools/export_models.py


### PR DESCRIPTION
# Description

Adds the required env var for model generation only to a new file `docker-compose-model-gen.yaml`.

(This change isn't required for edge, but I added it to both jobs for consistency and to avoid "polluting" the Compose file in case we ever need to use the file elsewhere -- should prevent this oversight from occurring again.)

The `yq` commands were verified/tested locally.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
