### PR TITLE
[resoto][fix] Truncate the file before writing to it

### DIFF
--- a/resotolib/resotolib/x509.py
+++ b/resotolib/resotolib/x509.py
@@ -215,7 +215,7 @@ def write_key_to_file(
     rename: bool = True,
 ) -> None:
     tmp_key_path = f"{key_path}.tmp" if rename else key_path
-    with open(os.open(tmp_key_path, os.O_CREAT | os.O_WRONLY, 0o600), "wb") as f:
+    with open(os.open(tmp_key_path, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600), "wb") as f:
         f.write(key_to_bytes(key, passphrase))
     if rename:
         os.rename(tmp_key_path, key_path)

--- a/resotoshell/resotoshell/authorized_client.py
+++ b/resotoshell/resotoshell/authorized_client.py
@@ -134,7 +134,7 @@ class ReshConfig:
     def write(self) -> None:
         if self.dirty:
             self.path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-            with open(os.open(self.path, os.O_CREAT | os.O_WRONLY, 0o600), "w+", encoding="utf-8") as f:
+            with open(os.open(self.path, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600), "w+", encoding="utf-8") as f:
                 self.config.write(f)
 
     @staticmethod

--- a/resotoworker/resotoworker/utils.py
+++ b/resotoworker/resotoworker/utils.py
@@ -10,7 +10,7 @@ def write_utf8_file(path: Path, content: str) -> None:
     """Write a UTF-8 encoded file to disk"""
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        with open(os.open(path, os.O_CREAT | os.O_WRONLY, 0o600), "wb") as f:
+        with open(os.open(path, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600), "wb") as f:
             f.write(content.encode("utf-8"))
 
     except Exception as e:

--- a/resotoworker/test/test_utils.py
+++ b/resotoworker/test/test_utils.py
@@ -9,6 +9,7 @@ from typing import Optional, List, Any
 def test_write_utf8_file() -> None:
     with TemporaryDirectory() as tmpdir:
         f = Path(tmpdir) / "foo" / "test.txt"
+        write_utf8_file(f, "extra long line that must be truncated first")
         write_utf8_file(f, "bar")
         assert f.read_text(encoding="utf-8") == "bar"
         assert f.stat().st_mode & 0o777 == 0o600


### PR DESCRIPTION
# Description

Now when resoto writes into some files, the files are truncated first, so that there are no leftovers from the previous version. 

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [ ] Add test coverage for new or updated functionality
- [ ] Lint and test with `tox`
- [ ] Document new or updated functionality (someengineering/resoto.com#XXXX)

# Issues Fixed

<!-- If this PR will fix/resolve an open issue on the repository, please reference it below. -->
<!-- (Otherwise, feel free to delete this section.) -->

- Fixes #XXXX

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
