### PR TITLE
[feat][resotocore] Serve https and http requests

### DIFF
--- a/resotocore/resotocore/__main__.py
+++ b/resotocore/resotocore/__main__.py
@@ -306,6 +306,7 @@ def with_config(
         host=config.api.web_hosts,
         https_port=config.api.https_port,
         http_port=config.api.http_port,
+        default_port=8900,
         ssl_context=cert_handler.host_context,
     )
 

--- a/resotocore/resotocore/__main__.py
+++ b/resotocore/resotocore/__main__.py
@@ -304,7 +304,8 @@ def with_config(
         async_initializer(),
         api.stop,
         host=config.api.web_hosts,
-        port=config.api.web_port,
+        https_port=config.api.https_port,
+        http_port=config.api.http_port,
         ssl_context=cert_handler.host_context,
     )
 

--- a/resotocore/resotocore/core_config.py
+++ b/resotocore/resotocore/core_config.py
@@ -128,7 +128,7 @@ class ApiConfig(ConfigObject):
     web_hosts: List[str] = field(
         factory=default_hosts, metadata={"description": f"TCP host(s) to bind on (default: {default_hosts()})"}
     )
-    https_port: int = field(
+    https_port: Optional[int] = field(
         default=8900, metadata={"description": "TCP port to bind on for TLS encrypted connections (default: 8900)"}
     )
     http_port: Optional[int] = field(
@@ -164,7 +164,7 @@ schema_registry.add(
     schema_name(ApiConfig),
     dict(
         http_port={"type": "integer", "min": 1, "max": 65535, "nullable": True},
-        https_port={"type": "integer", "min": 1, "max": 65535, "nullable": False},
+        https_port={"type": "integer", "min": 1, "max": 65535, "nullable": True},
         tsdb_proxy_url={"type": "string", "nullable": True, "is_url": True},
         max_request_size={"type": "integer", "nullable": True, "min": 1024**2},
     ),

--- a/resotocore/resotocore/core_config.py
+++ b/resotocore/resotocore/core_config.py
@@ -128,7 +128,12 @@ class ApiConfig(ConfigObject):
     web_hosts: List[str] = field(
         factory=default_hosts, metadata={"description": f"TCP host(s) to bind on (default: {default_hosts()})"}
     )
-    web_port: int = field(default=8900, metadata={"description": "TCP port to bind on (default: 8900)"})
+    https_port: int = field(
+        default=8900, metadata={"description": "TCP port to bind on for TLS encrypted connections (default: 8900)"}
+    )
+    http_port: Optional[int] = field(
+        default=8980, metadata={"description": "TCP port to bind on for plain HTTP connections (default: 8980)"}
+    )
     web_path: str = field(
         default="/",
         metadata={
@@ -158,6 +163,8 @@ class ApiConfig(ConfigObject):
 schema_registry.add(
     schema_name(ApiConfig),
     dict(
+        http_port={"type": "integer", "min": 1, "max": 65535, "nullable": True},
+        https_port={"type": "integer", "min": 1, "max": 65535, "nullable": False},
         tsdb_proxy_url={"type": "string", "nullable": True, "is_url": True},
         max_request_size={"type": "integer", "nullable": True, "min": 1024**2},
     ),
@@ -810,6 +817,12 @@ def migrate_core_config(config: Json) -> Json:
 
     # 3.0 -> 3.1: delete `api.ui_path`
     del_value_in_path(adapted, "api.ui_path")
+
+    # 3.5 -> 3.6: web_port -> https_port
+    if web_port := value_in_path(cfg, "api.web_port"):
+        set_value_in_path(web_port, "api.https_port", adapted)
+        del_value_in_path(adapted, "api.web_port")
+
     return {ResotoCoreRoot: adapted}
 
 

--- a/resotocore/resotocore/dependencies.py
+++ b/resotocore/resotocore/dependencies.py
@@ -123,7 +123,7 @@ def parse_args(args: Optional[List[str]] = None) -> Namespace:
         dest="graphdb_request_timeout",
         help="Request timeout in seconds (default: 900)",
     )
-    parser.add_argument("--no-tls", default=False, action="store_true", help="Disable TLS and use plain HTTP.")
+    parser.add_argument("--no-tls", default=False, action="store_true", help=argparse.SUPPRESS)
     parser.add_argument(
         "--cert",
         type=is_file("can not parse --cert"),
@@ -175,7 +175,7 @@ def parse_args(args: Optional[List[str]] = None) -> Namespace:
         "The existing configuration will be patched with the provided values. "
         "A value can be a simple value or a comma separated list of values if a list is required. "
         "Note: this argument allows multiple overrides separated by space. "
-        "Example: --override resotocore.api.web_hosts=localhost,some.domain resotocore.api.web_port=12345",
+        "Example: --override resotocore.api.web_hosts=localhost,some.domain resotocore.api.https_port=12345",
     )
     parser.add_argument(
         "--override-path",

--- a/resotocore/resotocore/util.py
+++ b/resotocore/resotocore/util.py
@@ -250,10 +250,8 @@ def deep_merge(left: Json, right: Json) -> Json:
         left_value: JsonElement = left.get(key)
         right_value: JsonElement = right.get(key)
         if isinstance(right_value, dict):
-            left_value = left_value if isinstance(left_value, dict) else {}
-            # noinspection PyTypeChecker
-            return deep_merge(left_value, right_value)
-        elif right_value is not None:
+            return deep_merge(left_value if isinstance(left_value, dict) else {}, right_value)
+        elif key in right:
             return right_value
         else:
             return left_value

--- a/resotocore/resotocore/web/certificate_handler.py
+++ b/resotocore/resotocore/web/certificate_handler.py
@@ -44,7 +44,7 @@ class CertificateHandler:
         self._ca_cert_bytes = cert_to_bytes(ca_cert)
         self._ca_cert_fingerprint = cert_fingerprint(ca_cert)
         self._host_key, self._host_cert = self.__create_host_certificate(config.api.host_certificate, ca_key, ca_cert)
-        self._host_context = self.__create_host_context(config, self._host_cert, self._host_key)
+        self._host_context = self._create_host_context(config, self._host_cert, self._host_key)
         self._client_context = self.__create_client_context(config, ca_cert)
         self._ca_bundle = temp_dir / "ca-bundle.crt"
         self.__recreate_ca_file()  # write the CA bundle to the temp dir
@@ -134,7 +134,7 @@ class CertificateHandler:
         return key, cert
 
     @staticmethod
-    def __create_host_context(config: CoreConfig, host_cert: Certificate, host_key: RSAPrivateKey) -> SSLContext:
+    def _create_host_context(config: CoreConfig, host_cert: Certificate, host_key: RSAPrivateKey) -> SSLContext:
         args = config.args
         # noinspection PyTypeChecker
         ctx = create_default_context(purpose=Purpose.CLIENT_AUTH)

--- a/resotocore/resotocore/web/certificate_handler.py
+++ b/resotocore/resotocore/web/certificate_handler.py
@@ -134,30 +134,24 @@ class CertificateHandler:
         return key, cert
 
     @staticmethod
-    def __create_host_context(
-        config: CoreConfig, host_cert: Certificate, host_key: RSAPrivateKey
-    ) -> Optional[SSLContext]:
+    def __create_host_context(config: CoreConfig, host_cert: Certificate, host_key: RSAPrivateKey) -> SSLContext:
         args = config.args
-        if args.no_tls:
-            log.info("TLS disabled.")
-            return None
+        # noinspection PyTypeChecker
+        ctx = create_default_context(purpose=Purpose.CLIENT_AUTH)
+        if config.args.cert:
+            log.info("Using TLS certificate from command line.")
+            # Use the certificate provided via cmd line flags
+            ctx.load_cert_chain(args.cert, args.cert_key, args.cert_key_pass)
         else:
-            # noinspection PyTypeChecker
-            ctx = create_default_context(purpose=Purpose.CLIENT_AUTH)
-            if config.args.cert:
-                log.info("Using TLS certificate from command line.")
-                # Use the certificate provided via cmd line flags
-                ctx.load_cert_chain(args.cert, args.cert_key, args.cert_key_pass)
-            else:
-                log.info("Using TLS certificate from data store.")
-                # ssl library wants to load cert/key from file: put it into a temp directory for loading
-                with TemporaryDirectory() as td:
-                    cert_file = Path(td, "cert")
-                    key_file = Path(td, "key")
-                    write_cert_to_file(host_cert, str(cert_file))
-                    write_key_to_file(host_key, str(key_file))
-                    ctx.load_cert_chain(str(cert_file), str(key_file), args.ca_cert_key_pass)
-            return ctx
+            log.info("Using TLS certificate from data store.")
+            # ssl library wants to load cert/key from file: put it into a temp directory for loading
+            with TemporaryDirectory() as td:
+                cert_file = Path(td, "cert")
+                key_file = Path(td, "key")
+                write_cert_to_file(host_cert, str(cert_file))
+                write_key_to_file(host_key, str(key_file))
+                ctx.load_cert_chain(str(cert_file), str(key_file), args.ca_cert_key_pass)
+        return ctx
 
     @staticmethod
     def __create_client_context(config: CoreConfig, ca_cert: Certificate) -> SSLContext:

--- a/resotocore/tests/resotocore/core_config_test.py
+++ b/resotocore/tests/resotocore/core_config_test.py
@@ -153,6 +153,9 @@ def test_migration() -> None:
     cfg3 = migrate_core_config(dict(resotocore=dict(runtime=dict(analytics_opt_out=True, usage_metrics=True))))
     assert value_in_path(cfg3, "resotocore.runtime.usage_metrics") is True
     assert value_in_path(cfg1, "resotocore.runtime.analytics_opt_out") is None
+    cfg4 = migrate_core_config(dict(resotocore=dict(api=dict(web_port=1234))))
+    assert value_in_path(cfg4, "resotocore.api.https_port") == 1234
+    assert value_in_path(cfg4, "resotocore.api.web_port") is None
 
 
 def test_migrate_commands() -> None:

--- a/resotocore/tests/resotocore/core_config_test.py
+++ b/resotocore/tests/resotocore/core_config_test.py
@@ -35,24 +35,24 @@ def test_parse_broken(config_json: Json) -> None:
     # config_json is a valid parsable config
     cfg = deepcopy(config_json)
 
-    # adjust the config: rename web_hosts -> hosts, and web_port -> port
+    # adjust the config: rename web_hosts -> hosts, and https_port -> port
     hosts = cfg["resotocore"]["api"]["web_hosts"]
-    port = cfg["resotocore"]["api"]["web_port"]
+    port = cfg["resotocore"]["api"]["https_port"]
     cfg["resotocore"]["api"]["hosts"] = hosts
     cfg["resotocore"]["api"]["port"] = port
     del cfg["resotocore"]["api"]["web_hosts"]
-    del cfg["resotocore"]["api"]["web_port"]
+    del cfg["resotocore"]["api"]["https_port"]
 
     # parse this configuration
     parsed = parse_config(parse_args(["--analytics-opt-out"]), cfg, lambda: None)
     parsed_json = to_js(parsed.editable, strip_attr="kind")
 
-    # web_hosts and web_port were not available and are reverted to the default values
+    # web_hosts and https_port were not available and are reverted to the default values
     default = EditableConfig()
     assert parsed.api.web_hosts != hosts
     assert parsed.api.web_hosts == default.api.web_hosts
-    assert parsed.api.web_port != port
-    assert parsed.api.web_port == default.api.web_port
+    assert parsed.api.https_port != port
+    assert parsed.api.https_port == default.api.https_port
 
     # other config values are still unchanged
     assert parsed_json["cli"] == config_json["resotocore"]["cli"]
@@ -97,7 +97,7 @@ def test_config_override(config_json: Json) -> None:
     # config_json is a valid parsable config
     cfg = deepcopy(config_json)
 
-    overrides = {"resoto.core": {"resotocore": {"api": {"web_hosts": ["11.12.13.14"], "web_port": "$(WEB_PORT)"}}}}
+    overrides = {"resoto.core": {"resotocore": {"api": {"web_hosts": ["11.12.13.14"], "https_port": "$(WEB_PORT)"}}}}
 
     os.environ["WEB_PORT"] = "1337"
 
@@ -108,7 +108,7 @@ def test_config_override(config_json: Json) -> None:
         lambda: overrides.get(ResotoCoreConfigId),
     )
     assert parsed.api.web_hosts == ["11.12.13.14"]
-    assert parsed.api.web_port == 1337
+    assert parsed.api.https_port == 1337
 
 
 def test_model() -> None:
@@ -177,7 +177,8 @@ def config_json() -> Json:
             "api": {
                 "access_token_expiration_seconds": 3600,
                 "web_hosts": ["1.2.3.4"],
-                "web_port": 1234,
+                "https_port": 443,
+                "http_port": 80,
                 "web_path": "/",
                 "tsdb_proxy_url": "test",
                 "max_request_size": 5242880,

--- a/resotocore/tests/resotocore/web/api_test.py
+++ b/resotocore/tests/resotocore/web/api_test.py
@@ -63,7 +63,6 @@ async def create_core_client(
           It also ensures to clean up the process, when the test is done.
     """
     http_port = get_free_port()  # use a different port than the default one
-    https_port = get_free_port()  # use a different port than the default one
     additional_args = ["--psk", psk] if psk else []
 
     # wipe and cleanly import the test model
@@ -103,7 +102,7 @@ l1:
                 "--debug",
                 "--analytics-opt-out",
                 "--override",
-                f"resotocore.api.https_port={https_port}",
+                f"resotocore.api.https_port=null",
                 f"resotocore.api.http_port={http_port}",
                 "resotocore.api.web_hosts=0.0.0.0",
                 "--override-path",

--- a/resotocore/tests/resotocore/web/api_test.py
+++ b/resotocore/tests/resotocore/web/api_test.py
@@ -62,7 +62,8 @@ async def create_core_client(
           The fixture ensures that the underlying process has entered the ready state.
           It also ensures to clean up the process, when the test is done.
     """
-    port = get_free_port()  # use a different port than the default one
+    http_port = get_free_port()  # use a different port than the default one
+    https_port = get_free_port()  # use a different port than the default one
     additional_args = ["--psk", psk] if psk else []
 
     # wipe and cleanly import the test model
@@ -101,9 +102,9 @@ l1:
                 "test",
                 "--debug",
                 "--analytics-opt-out",
-                "--no-tls",
                 "--override",
-                f"resotocore.api.web_port={port}",
+                f"resotocore.api.https_port={https_port}",
+                f"resotocore.api.http_port={http_port}",
                 "resotocore.api.web_hosts=0.0.0.0",
                 "--override-path",
                 str(config_path),
@@ -117,12 +118,12 @@ l1:
     while not ready:
         await sleep(0.5)
         with suppress(Exception):
-            async with client_session.get(f"http://localhost:{port}/system/ready"):
+            async with client_session.get(f"http://localhost:{http_port}/system/ready"):
                 ready = True
         count -= 1
         if count == 0:
             raise AssertionError("Process does not came up as expected")
-    async with ResotoClient(f"http://localhost:{port}", psk=psk) as client:
+    async with ResotoClient(f"http://localhost:{http_port}", psk=psk) as client:
         yield client
     # terminate the process
     process.terminate()
@@ -302,7 +303,8 @@ async def test_graph_api(core_client: ResotoClient) -> None:
         assert len(result) == 0
 
     # create a snapshot
-    [result async for result in core_client.cli_execute("graph snapshot graphtest test_label")]
+    async for _ in core_client.cli_execute("graph snapshot graphtest test_label"):
+        pass
     # now we should see some snapshots
     result_graph = [res async for res in search_graph_at('id("3") -[0:]->', graph=g, at=utc_str())]
     assert len(result_graph) == 21  # 11 nodes + 10 edges

--- a/resotolib/resotolib/asynchronous/web/runner.py
+++ b/resotolib/resotolib/asynchronous/web/runner.py
@@ -1,33 +1,30 @@
 import asyncio
 import logging
-import socket
+import sys
 from ssl import SSLContext
-from typing import Optional, Union, Awaitable, Callable, Type
+from typing import Optional, Union, Awaitable, Callable, Type, List, cast
 
 from aiohttp.abc import AbstractAccessLogger
-
-# noinspection PyProtectedMember
-from aiohttp.helpers import all_tasks
 from aiohttp.log import access_logger
 
 # noinspection PyProtectedMember
-from aiohttp.web import HostSequence, _run_app, _cancel_tasks
+from aiohttp.web import HostSequence, _cancel_tasks
 from aiohttp.web_app import Application
 from aiohttp.web_log import AccessLogger
-from aiohttp.web_runner import GracefulExit
+from aiohttp.web_runner import GracefulExit, BaseSite, TCPSite, AppRunner
 
 
-# This method is copied from aiohttp.web.run_app with one 2 additional steps:
+# This method is derived from aiohttp.web.run_app with additional steps:
 # - it allows a callable that is executed on shutdown.
 # - it does not swallow terminal exceptions
+# - it exposes a http and https port
 def run_app(
     app: Union[Application, Awaitable[Application]],
     on_shutdown: Callable[[], Awaitable[None]],
+    host: Union[str, HostSequence],
+    https_port: int,
+    http_port: Optional[int],
     *,
-    host: Optional[Union[str, HostSequence]] = None,
-    port: Optional[int] = None,
-    path: Optional[str] = None,
-    sock: Optional[socket.socket] = None,
     shutdown_timeout: float = 60.0,
     keepalive_timeout: float = 75.0,
     ssl_context: Optional[SSLContext] = None,
@@ -56,9 +53,8 @@ def run_app(
         _run_app(
             app,
             host=host,
-            port=port,
-            path=path,
-            sock=sock,
+            https_port=https_port,
+            http_port=http_port,
             shutdown_timeout=shutdown_timeout,
             keepalive_timeout=keepalive_timeout,
             ssl_context=ssl_context,
@@ -81,6 +77,98 @@ def run_app(
     finally:
         loop.run_until_complete(on_shutdown())
         _cancel_tasks({main_task}, loop)
-        _cancel_tasks(all_tasks(loop), loop)
+        _cancel_tasks(asyncio.all_tasks(loop), loop)
         loop.run_until_complete(loop.shutdown_asyncgens())
         loop.close()
+
+
+async def _run_app(
+    app: Union[Application, Awaitable[Application]],
+    host: Union[str, HostSequence],
+    https_port: int,
+    http_port: Optional[int],
+    *,
+    shutdown_timeout: float = 60.0,
+    keepalive_timeout: float = 75.0,
+    ssl_context: Optional[SSLContext] = None,
+    print: Optional[Callable[..., None]] = print,
+    backlog: int = 128,
+    access_log_class: Type[AbstractAccessLogger] = AccessLogger,
+    access_log_format: str = AccessLogger.LOG_FORMAT,
+    access_log: Optional[logging.Logger] = access_logger,
+    handle_signals: bool = True,
+    reuse_address: Optional[bool] = None,
+    reuse_port: Optional[bool] = None,
+) -> None:
+    # An internal function to actually do all dirty job for application running
+    if asyncio.iscoroutine(app):
+        app = await app
+
+    app = cast(Application, app)
+
+    runner = AppRunner(
+        app,
+        handle_signals=handle_signals,
+        access_log_class=access_log_class,
+        access_log_format=access_log_format,
+        access_log=access_log,
+        keepalive_timeout=keepalive_timeout,
+    )
+
+    await runner.setup()
+
+    sites: List[BaseSite] = []
+
+    def with_port(port: int, ssl: Optional[SSLContext] = None) -> None:
+        if isinstance(host, (str, bytes, bytearray, memoryview)):
+            sites.append(
+                TCPSite(
+                    runner,
+                    host,
+                    port,
+                    shutdown_timeout=shutdown_timeout,
+                    ssl_context=ssl,
+                    backlog=backlog,
+                    reuse_address=reuse_address,
+                    reuse_port=reuse_port,
+                )
+            )
+        else:
+            for h in host:
+                sites.append(
+                    TCPSite(
+                        runner,
+                        h,
+                        port,
+                        shutdown_timeout=shutdown_timeout,
+                        ssl_context=ssl,
+                        backlog=backlog,
+                        reuse_address=reuse_address,
+                        reuse_port=reuse_port,
+                    )
+                )
+
+    try:
+        with_port(https_port, ssl_context)
+        if http_port is not None:
+            with_port(http_port)
+
+        for site in sites:
+            await site.start()
+
+        if print:
+            names = sorted(str(s.name) for s in runner.sites)
+            print("======== Running on {} ========\n" "(Press CTRL+C to quit)".format(", ".join(names)))
+
+        # sleep forever by 1 hour intervals,
+        # on Windows before Python 3.8 wake up every 1 second to handle
+        # Ctrl+C smoothly
+        if sys.platform == "win32" and sys.version_info < (3, 8):
+            delay = 1
+        else:
+            delay = 3600
+
+        while True:
+            await asyncio.sleep(delay)
+    finally:
+        await runner.cleanup()


### PR DESCRIPTION
# Description

`resotocore` now provides a port for SSL-encrypted HTTP and another for plain HTTP.

<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
