### PR TITLE
[resotocore][fix] Do not send path for file names

### DIFF
--- a/resotocore/resotocore/cli/command.py
+++ b/resotocore/resotocore/cli/command.py
@@ -5469,7 +5469,7 @@ class GraphCommand(CLICommand):
             await self.dependencies.graph_manager.delete(graph_name)
             yield f"Graph {graph_name} deleted."
 
-        async def write_result_to_file(export_lines: AsyncIterator[str], file_name: str) -> AsyncIterator[str]:
+        async def write_result_to_file(export_lines: AsyncIterator[str], file_name: str) -> AsyncIterator[JsonElement]:
             async with TemporaryDirectory() as temp_dir:
                 path = os.path.join(temp_dir, uuid_str())
                 async with aiofiles.open(path, "w") as f:

--- a/resotocore/resotocore/cli/command.py
+++ b/resotocore/resotocore/cli/command.py
@@ -3661,7 +3661,7 @@ class WriteCommand(CLICommand, NoTerminalOutput):
     @staticmethod
     async def write_result_to_file(in_stream: Stream, file_name: str) -> AsyncIterator[JsonElement]:
         async with TemporaryDirectory() as temp_dir:
-            path = os.path.join(temp_dir, file_name)
+            path = os.path.join(temp_dir, uuid_str())
             async with aiofiles.open(path, "w") as f:
                 async with in_stream.stream() as streamer:
                     async for out in streamer:
@@ -3669,7 +3669,7 @@ class WriteCommand(CLICommand, NoTerminalOutput):
                             await f.write(out + "\n")
                         else:
                             raise AttributeError("No output format is defined! Consider to use the format command.")
-            yield path
+            yield FilePath.user_local(user=file_name, local=path).json()
 
     @staticmethod
     async def already_file_stream(in_stream: Stream, file_name: str) -> AsyncIterator[JsonElement]:
@@ -5471,11 +5471,11 @@ class GraphCommand(CLICommand):
 
         async def write_result_to_file(export_lines: AsyncIterator[str], file_name: str) -> AsyncIterator[str]:
             async with TemporaryDirectory() as temp_dir:
-                path = os.path.join(temp_dir, file_name)
+                path = os.path.join(temp_dir, uuid_str())
                 async with aiofiles.open(path, "w") as f:
                     async for line in export_lines:
                         await f.write(line + "\n")
-                yield path
+                yield FilePath.user_local(file_name, path).json()
 
         async def graph_export(graph_name: Optional[GraphName], file_name: str) -> AsyncIterator[JsonElement]:
             if not graph_name:

--- a/resotocore/resotocore/web/api.py
+++ b/resotocore/resotocore/web/api.py
@@ -1293,12 +1293,16 @@ class Api:
             if not (path.local.is_file()):
                 raise HTTPNotFound(text=f"No file with this path: {file_path}")
             with open(path.local, "rb") as content:
+                headers = cmd_line.envelope
+                # only add path header if the user path is more than a file name
+                if path.user.name != str(path.user):
+                    headers = {**headers, "file-path": str(path.user)}
                 with MultipartWriter(boundary=boundary) as mp:
                     pl = BufferedReaderPayload(
                         content,
                         content_type="application/octet-stream",
                         filename=path.user.name,
-                        headers=cmd_line.envelope | {"file-path": str(path.user)},
+                        headers=headers,
                     )
                     mp.append_payload(pl)
                     await mp.write(response, close_boundary=False)


### PR DESCRIPTION
# Description

Use a plain name for the local file and leave the user path untouched.
Only send the path header if the user path is more than a file name.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
