### PR TITLE
[resotocore] Fix the usage datapoints representation and only collect metrics from running instances

### DIFF
--- a/plugins/aws/resoto_plugin_aws/resource/ec2.py
+++ b/plugins/aws/resoto_plugin_aws/resource/ec2.py
@@ -1053,7 +1053,7 @@ class AwsEc2Instance(EC2Taggable, AwsResource, BaseInstance):
         instances = {
             instance.id: instance
             for instance in builder.nodes(clazz=AwsEc2Instance)
-            if instance.region().id == builder.region.id
+            if instance.region().id == builder.region.id and instance.instance_status == InstanceStatus.RUNNING
         }
         queries = []
         now = utc()

--- a/resotocore/resotocore/model/graph_access.py
+++ b/resotocore/resotocore/model/graph_access.py
@@ -26,7 +26,6 @@ from resotocore.model.model import (
     DateKind,
     DurationKind,
     UsageDatapoint,
-    UsageMetricValues,
 )
 from resotocore.model.resolve_in_graph import GraphResolver, NodePath, ResolveProp
 from resotocore.model.typed_model import from_js
@@ -163,11 +162,11 @@ class GraphBuilder:
             )
             if Section.usage in js and len(js[Section.usage]):
                 values = {
-                    k: UsageMetricValues(
-                        min=v.get("min", v["avg"]),
-                        avg=v["avg"],
-                        max=v.get("max", v["avg"]),
-                    )
+                    k: [
+                        v.get("min", v["avg"]),
+                        v["avg"],
+                        v.get("max", v["avg"]),
+                    ]
                     for k, v in js[Section.usage].items()
                 }
                 usage = UsageDatapoint(

--- a/resotocore/resotocore/model/model.py
+++ b/resotocore/resotocore/model/model.py
@@ -1459,11 +1459,6 @@ class Model:
         return result
 
 
-class UsageMetricValues(NamedTuple):
-    min: float
-    avg: float
-    max: float
-
 
 @frozen
 class UsageDatapoint:
@@ -1482,7 +1477,7 @@ class UsageDatapoint:
 
     id: str
     at: int
-    v: Dict[str, UsageMetricValues]
+    v: Dict[str, List[float]
 
 
 # register serializer for this class

--- a/resotocore/resotocore/model/model.py
+++ b/resotocore/resotocore/model/model.py
@@ -22,7 +22,6 @@ from typing import (
     Tuple,
     Iterable,
     TypeVar,
-    NamedTuple,
 )
 
 import yaml
@@ -1459,7 +1458,6 @@ class Model:
         return result
 
 
-
 @frozen
 class UsageDatapoint:
     """
@@ -1477,7 +1475,7 @@ class UsageDatapoint:
 
     id: str
     at: int
-    v: Dict[str, List[float]
+    v: Dict[str, List[float]]
 
 
 # register serializer for this class

--- a/resotocore/tests/resotocore/db/graphdb_test.py
+++ b/resotocore/tests/resotocore/db/graphdb_test.py
@@ -18,7 +18,7 @@ from resotocore.db.db_access import DbAccess
 from resotocore.error import ConflictingChangeInProgress, NoSuchChangeError, InvalidBatchUpdate
 from resotocore.ids import NodeId, GraphName
 from resotocore.model.graph_access import GraphAccess, EdgeTypes, Section
-from resotocore.model.model import Model, UsageDatapoint, UsageMetricValues
+from resotocore.model.model import Model, UsageDatapoint
 from resotocore.model.typed_model import from_js, to_js
 from resotocore.query.model import Query, P, Navigation
 from resotocore.query.query_parser import parse_query
@@ -641,7 +641,7 @@ async def test_no_snapshot_usage(graph_db: ArangoGraphDB, foo_model: Model, db_a
     snapshot_db = await graph_db.copy_graph(snapshot_db_name, to_snapshot=True)
 
     with raises(ValueError) as ex:
-        await snapshot_db.insert_usage_data([UsageDatapoint("foo", 42, {"cpu": UsageMetricValues(0.42, 0.42, 0.42)})])
+        await snapshot_db.insert_usage_data([UsageDatapoint("foo", 42, {"cpu": [0.42, 0.42, 0.42]})])
 
     assert str(ex.value) == "Cannot insert usage data into a snapshot graph"
 


### PR DESCRIPTION

# Description

Usage is stored as the list of values in the db, ec2 instances metrics are only collected if the instance status is running.


# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
