### PR TITLE
[resoto][feat] Send individual accounts to Resoto Core

### DIFF
--- a/plugins/aws/resoto_plugin_aws/__init__.py
+++ b/plugins/aws/resoto_plugin_aws/__init__.py
@@ -134,6 +134,7 @@ class AWSCollectorPlugin(BaseCollectorPlugin):
                     log.debug(f"Skipping account graph of invalid type {type(account_graph)}")
                     continue
                 self.send_account_graph(account_graph)
+                del account_graph
 
         # collect done, purge all session caches
         aws_config.sessions().purge_caches()

--- a/plugins/aws/resoto_plugin_aws/__init__.py
+++ b/plugins/aws/resoto_plugin_aws/__init__.py
@@ -27,7 +27,7 @@ from resotolib.config import Config, RunningConfig
 from resotolib.core.actions import CoreFeedback
 from resotolib.core.custom_command import execute_command_on_resource
 from resotolib.core.progress import ProgressDone, ProgressTree
-from resotolib.graph import Graph, GraphMergeKind
+from resotolib.graph import Graph
 from resotolib.logger import log, setup_logger
 from resotolib.types import JsonElement
 from resotolib.utils import log_runtime

--- a/plugins/aws/resoto_plugin_aws/__init__.py
+++ b/plugins/aws/resoto_plugin_aws/__init__.py
@@ -3,10 +3,9 @@ import multiprocessing
 import os
 from concurrent import futures
 from pathlib import Path
-from typing import List, Optional, Tuple, Union, Sequence
+from typing import List, Optional, Tuple, Union, Sequence, Any
 import subprocess
 import json
-from queue import Queue
 
 import boto3
 import botocore.exceptions
@@ -52,7 +51,7 @@ GLOBAL_REGIONS = ("us-east-1", "us-gov-west-1", "cn-north-1")
 class AWSCollectorPlugin(BaseCollectorPlugin):
     cloud = "aws"
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.__regions: List[str] = []
         self.core_feedback: Optional[CoreFeedback] = None

--- a/plugins/aws/resoto_plugin_aws/configuration.py
+++ b/plugins/aws/resoto_plugin_aws/configuration.py
@@ -304,7 +304,7 @@ class AwsConfig:
         if self._holder is None:
             with self._lock:
                 if self._holder is None:
-                    log.info("Create a new AWS session holder")
+                    log.debug("Creating a new AWS session holder")
                     self._holder = AwsSessionHolder(
                         access_key_id=self.access_key_id,
                         secret_access_key=self.secret_access_key,

--- a/plugins/digitalocean/resoto_plugin_digitalocean/__init__.py
+++ b/plugins/digitalocean/resoto_plugin_digitalocean/__init__.py
@@ -87,7 +87,7 @@ class DigitalOceanCollectorPlugin(BaseCollectorPlugin):
             )
             team_graph = self.collect_team(client, self.core_feedback.with_context("digitalocean"))
             if team_graph:
-                self.graph.merge(team_graph)
+                self.send_account_graph(team_graph)
 
     def collect_team(self, client: StreamingWrapper, feedback: CoreFeedback) -> Optional[Graph]:
         """Collects an individual team."""

--- a/plugins/digitalocean/resoto_plugin_digitalocean/__init__.py
+++ b/plugins/digitalocean/resoto_plugin_digitalocean/__init__.py
@@ -21,8 +21,8 @@ import time
 class DigitalOceanCollectorPlugin(BaseCollectorPlugin):
     cloud = "digitalocean"
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
         self.core_feedback: Optional[CoreFeedback] = None
 
     def collect(self) -> None:

--- a/plugins/digitalocean/resoto_plugin_digitalocean/__init__.py
+++ b/plugins/digitalocean/resoto_plugin_digitalocean/__init__.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Tuple, cast
+from typing import Optional, List, Tuple, cast, Any
 
 from resoto_plugin_digitalocean.client import StreamingWrapper, get_team_credentials
 from resoto_plugin_digitalocean.collector import DigitalOceanTeamCollector
@@ -21,7 +21,7 @@ import time
 class DigitalOceanCollectorPlugin(BaseCollectorPlugin):
     cloud = "digitalocean"
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.core_feedback: Optional[CoreFeedback] = None
 

--- a/plugins/dockerhub/resoto_plugin_dockerhub/__init__.py
+++ b/plugins/dockerhub/resoto_plugin_dockerhub/__init__.py
@@ -3,7 +3,7 @@ from resotolib.logger import log
 from resotolib.baseplugin import BaseCollectorPlugin
 from resotolib.config import Config
 from .config import DockerHubConfig
-from typing import Optional
+from typing import Optional, Any
 from .resources import (
     DockerHubNamespace,
     DockerHubRepository,
@@ -13,7 +13,7 @@ from .resources import (
 class DockerHubCollectorPlugin(BaseCollectorPlugin):
     cloud = "dockerhub"
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.dockerhub_uri = "https://hub.docker.com/v2/repositories/"
 

--- a/plugins/gcp/resoto_plugin_gcp/__init__.py
+++ b/plugins/gcp/resoto_plugin_gcp/__init__.py
@@ -26,7 +26,7 @@ class GCPCollectorPlugin(BaseCollectorPlugin):
 
     cloud = "gcp"
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.core_feedback: Optional[CoreFeedback] = None
 

--- a/plugins/gcp/resoto_plugin_gcp/__init__.py
+++ b/plugins/gcp/resoto_plugin_gcp/__init__.py
@@ -80,6 +80,7 @@ class GCPCollectorPlugin(BaseCollectorPlugin):
                     log.error(f"Skipping invalid project_graph {type(project_graph)}")
                     continue
                 self.send_account_graph(project_graph)
+                del project_graph
 
     @staticmethod
     def collect_project(

--- a/plugins/gcp/resoto_plugin_gcp/__init__.py
+++ b/plugins/gcp/resoto_plugin_gcp/__init__.py
@@ -79,7 +79,7 @@ class GCPCollectorPlugin(BaseCollectorPlugin):
                 if not isinstance(project_graph, Graph):
                     log.error(f"Skipping invalid project_graph {type(project_graph)}")
                     continue
-                self.graph.merge(project_graph)
+                self.send_account_graph(project_graph)
 
     @staticmethod
     def collect_project(

--- a/plugins/gcp/resoto_plugin_gcp/__init__.py
+++ b/plugins/gcp/resoto_plugin_gcp/__init__.py
@@ -26,8 +26,8 @@ class GCPCollectorPlugin(BaseCollectorPlugin):
 
     cloud = "gcp"
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
         self.core_feedback: Optional[CoreFeedback] = None
 
     def collect(self) -> None:

--- a/plugins/k8s/resoto_plugin_k8s/__init__.py
+++ b/plugins/k8s/resoto_plugin_k8s/__init__.py
@@ -25,7 +25,7 @@ log = logging.getLogger("resoto.plugins.k8s")
 class KubernetesCollectorPlugin(BaseCollectorPlugin):
     cloud = "k8s"
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         # once defined, it will be set by the worker
         self.core_feedback: Optional[CoreFeedback] = None

--- a/plugins/k8s/resoto_plugin_k8s/__init__.py
+++ b/plugins/k8s/resoto_plugin_k8s/__init__.py
@@ -69,7 +69,7 @@ class KubernetesCollectorPlugin(BaseCollectorPlugin):
                     if not isinstance(cluster_graph, Graph):
                         log.error(f"Skipping invalid cluster_graph {type(cluster_graph)}")
                         continue
-                    self.graph.merge(cluster_graph)
+                    self.send_account_graph(cluster_graph)
 
     @staticmethod
     def collect_cluster(

--- a/plugins/k8s/resoto_plugin_k8s/__init__.py
+++ b/plugins/k8s/resoto_plugin_k8s/__init__.py
@@ -25,8 +25,8 @@ log = logging.getLogger("resoto.plugins.k8s")
 class KubernetesCollectorPlugin(BaseCollectorPlugin):
     cloud = "k8s"
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
         # once defined, it will be set by the worker
         self.core_feedback: Optional[CoreFeedback] = None
 

--- a/plugins/slack/resoto_plugin_slack/__init__.py
+++ b/plugins/slack/resoto_plugin_slack/__init__.py
@@ -3,7 +3,7 @@ import threading
 import time
 import ssl
 import slack_sdk
-from typing import List
+from typing import List, Any
 from retrying import retry
 
 from resotolib.utils import utc_str
@@ -42,7 +42,7 @@ def retry_on_request_limit_exceeded(e):
 class SlackCollectorPlugin(BaseCollectorPlugin):
     cloud = "slack"
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
         self.client = None
 

--- a/plugins/slack/resoto_plugin_slack/__init__.py
+++ b/plugins/slack/resoto_plugin_slack/__init__.py
@@ -42,8 +42,8 @@ def retry_on_request_limit_exceeded(e):
 class SlackCollectorPlugin(BaseCollectorPlugin):
     cloud = "slack"
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.client = None
 
     def collect(self) -> None:

--- a/resotolib/resotolib/baseplugin.py
+++ b/resotolib/resotolib/baseplugin.py
@@ -270,6 +270,8 @@ class BaseCollectorPlugin(BasePlugin):
             self.send_graph(cloud_graph)
         elif self.graph_merge_kind == GraphMergeKind.cloud:
             self.graph.merge(graph, skip_deferred_edges=True)
+        else:
+            raise ValueError(f"Unknown graph merge kind {self.graph_merge_kind}")
 
     def send_graph(self, graph: Graph) -> None:
         if self._graph_queue is None:

--- a/resotolib/resotolib/baseplugin.py
+++ b/resotolib/resotolib/baseplugin.py
@@ -212,7 +212,7 @@ class BaseCollectorPlugin(BasePlugin):
         self.name = str(self.cloud)
         cloud = Cloud(id=self.cloud)
         self.root = cloud
-        self._graph_queue: Queue[Optional[Graph]] = graph_queue
+        self._graph_queue: Optional[Queue[Optional[Graph]]] = graph_queue
         self.graph_merge_kind: GraphMergeKind = graph_merge_kind
         self.graph = self.new_graph()
 
@@ -249,6 +249,7 @@ class BaseCollectorPlugin(BasePlugin):
         if self.graph_merge_kind == GraphMergeKind.cloud or len(self.graph) > 1:
             if self.graph_merge_kind == GraphMergeKind.account:
                 log.debug("Using backwards compatibility mode")
+            assert isinstance(self.graph.root, BaseResource)
             log.debug(f"Sending graph of {self.graph.root.kdname} to queue")
             self.send_graph(self.graph)
 
@@ -261,6 +262,7 @@ class BaseCollectorPlugin(BasePlugin):
             return
 
         if self.graph_merge_kind == GraphMergeKind.account:
+            assert isinstance(graph.root, BaseResource)
             kdname = graph.root.kdname
             cloud_graph = self.new_graph()
             cloud_graph.merge(graph, skip_deferred_edges=True)

--- a/resotolib/resotolib/baseplugin.py
+++ b/resotolib/resotolib/baseplugin.py
@@ -271,6 +271,8 @@ class BaseCollectorPlugin(BasePlugin):
     def send_graph(self, graph: Graph) -> None:
         if self._graph_queue is None:
             raise RuntimeError("Unable to send graph - no graph queue set")
+        if not isinstance(graph, Graph):
+            raise TypeError(f"Unable to send graph - expected type Graph, got {type(graph)}")
         self._graph_queue.put(graph)
 
 

--- a/resotolib/resotolib/baseplugin.py
+++ b/resotolib/resotolib/baseplugin.py
@@ -269,6 +269,8 @@ class BaseCollectorPlugin(BasePlugin):
             self.graph.merge(graph, skip_deferred_edges=True)
 
     def send_graph(self, graph: Graph) -> None:
+        if self._graph_queue is None:
+            raise RuntimeError("Unable to send graph - no graph queue set")
         self._graph_queue.put(graph)
 
 

--- a/resotolib/resotolib/baseplugin.py
+++ b/resotolib/resotolib/baseplugin.py
@@ -262,9 +262,10 @@ class BaseCollectorPlugin(BasePlugin):
 
         if self.graph_merge_kind == GraphMergeKind.account:
             kdname = graph.root.kdname
-            graph = self.new_graph().merge(graph, skip_deferred_edges=True)
+            cloud_graph = self.new_graph()
+            cloud_graph.merge(graph, skip_deferred_edges=True)
             log.debug(f"Sending graph of {kdname} to queue")
-            self.send_graph(graph)
+            self.send_graph(cloud_graph)
         elif self.graph_merge_kind == GraphMergeKind.cloud:
             self.graph.merge(graph, skip_deferred_edges=True)
 

--- a/resotolib/resotolib/graph/__init__.py
+++ b/resotolib/resotolib/graph/__init__.py
@@ -402,6 +402,22 @@ def resource_classes_to_resotocore_model(classes: Set[Type[Any]], **kwargs: Any)
     return list(model.values())
 
 
+def export_model() -> List[Json]:
+    """Return the graph node dataclass model in resotocore format"""
+    model = dataclasses_to_resotocore_model({BaseResource}, aggregate_root=BaseResource)
+    for resource_model in model:
+        if resource_model.get("fqn") == "resource":
+            resource_model.get("properties", []).append(
+                {
+                    "name": "kind",
+                    "kind": "string",
+                    "required": True,
+                    "description": "",
+                }
+            )
+    return model
+
+
 @lru_cache(maxsize=4096)  # Only resolve types once per type
 def resolve_type(clazz: Type[Any]) -> None:
     resolve_types(clazz)  # type: ignore

--- a/resotolib/resotolib/graph/__init__.py
+++ b/resotolib/resotolib/graph/__init__.py
@@ -361,24 +361,7 @@ class Graph(networkx.MultiDiGraph):  # type: ignore
                 node.resolve_deferred_connections(self)
 
     def export_model(self, **kwargs: Any) -> List[Json]:
-        """Return the graph node dataclass model in resotocore format"""
-        classes = set()
-        for node in self.nodes:
-            classes.add(type(node))
-        model = resource_classes_to_resotocore_model(classes, aggregate_root=BaseResource, **kwargs)
-
-        # fixme: workaround to report kind
-        for resource_model in model:
-            if resource_model.get("fqn") == "resource":
-                resource_model.get("properties", []).append(
-                    {
-                        "name": "kind",
-                        "kind": "string",
-                        "required": True,
-                        "description": "",
-                    }
-                )
-        return model
+        return export_model(graph=self, **kwargs)
 
     def export_iterator(self) -> GraphExportIterator:
         return GraphExportIterator(self)
@@ -402,9 +385,16 @@ def resource_classes_to_resotocore_model(classes: Set[Type[Any]], **kwargs: Any)
     return list(model.values())
 
 
-def export_model() -> List[Json]:
+def export_model(graph: Optional[Graph] = None, **kwargs: Any) -> List[Json]:
     """Return the graph node dataclass model in resotocore format"""
-    model = dataclasses_to_resotocore_model({BaseResource}, aggregate_root=BaseResource)
+    classes = set()
+    if graph is None:
+        classes.add(BaseResource)
+    else:
+        for node in graph.nodes:
+            classes.add(type(node))
+
+    model = resource_classes_to_resotocore_model(classes, aggregate_root=BaseResource, **kwargs)
     for resource_model in model:
         if resource_model.get("fqn") == "resource":
             resource_model.get("properties", []).append(

--- a/resotoworker/resotoworker/__main__.py
+++ b/resotoworker/resotoworker/__main__.py
@@ -224,7 +224,6 @@ def core_actions_processor(
     message: Dict[str, Any],
 ) -> Optional[Dict[str, Any]]:
     collectors: List[Type[BaseCollectorPlugin]] = plugin_loader.plugins(PluginType.COLLECTOR)  # type: ignore
-    post_collectors: List[Type[BasePostCollectPlugin]] = plugin_loader.plugins(PluginType.POST_COLLECT)  # type: ignore
     # todo: clean this up
     if not isinstance(message, dict):
         log.error(f"Invalid message: {message}")
@@ -239,7 +238,7 @@ def core_actions_processor(
         try:
             if message_type == "collect":
                 start_time = time.time()
-                collector.collect_and_send(collectors, post_collectors, task_id=task_id, step_name=step_name)
+                collector.collect_and_send(collectors, task_id=task_id, step_name=step_name)
                 run_time = int(time.time() - start_time)
                 log.info(f"Collect ran for {run_time} seconds")
             elif message_type == "cleanup":

--- a/resotoworker/resotoworker/__main__.py
+++ b/resotoworker/resotoworker/__main__.py
@@ -118,7 +118,7 @@ def main() -> None:
     mp_manager = multiprocessing.Manager()
     core_messages: Queue[Json] = mp_manager.Queue()
 
-    collector = Collector(config, core.send_to_resotocore, core_messages)
+    collector = Collector(config, core, core_messages)
 
     # Handle Ctrl+c and other means of termination/shutdown
     resotolib.proc.initializer()

--- a/resotoworker/resotoworker/__main__.py
+++ b/resotoworker/resotoworker/__main__.py
@@ -13,7 +13,7 @@ import requests
 
 import resotolib.proc
 from resotolib.args import ArgumentParser
-from resotolib.baseplugin import BaseActionPlugin, BasePostCollectPlugin, BaseCollectorPlugin, PluginType
+from resotolib.baseplugin import BaseActionPlugin, BaseCollectorPlugin, PluginType
 from resotolib.config import Config
 from resotolib.core import add_args as core_add_args, resotocore, wait_for_resotocore
 from resotolib.core.actions import CoreActions, CoreFeedback

--- a/resotoworker/resotoworker/collect.py
+++ b/resotoworker/resotoworker/collect.py
@@ -41,6 +41,7 @@ class Collector:
 
             graph = Graph(root=GraphRoot(id="root", tags={}))
             graph.merge(collector_graph)
+            del collector_graph
             sanitize(graph)
 
             graph_info = ""

--- a/resotoworker/resotoworker/collect.py
+++ b/resotoworker/resotoworker/collect.py
@@ -7,7 +7,7 @@ from concurrent import futures
 from threading import Lock
 from resotoworker.exceptions import DuplicateMessageError
 from resotoworker.resotocore import Resotocore
-from resotolib.baseplugin import BaseCollectorPlugin, BasePostCollectPlugin
+from resotolib.baseplugin import BaseCollectorPlugin
 from resotolib.baseresources import GraphRoot, BaseCloud, BaseAccount, BaseResource
 from resotolib.core.actions import CoreFeedback
 from resotolib.graph import Graph, sanitize, GraphMergeKind

--- a/resotoworker/resotoworker/collect.py
+++ b/resotoworker/resotoworker/collect.py
@@ -31,10 +31,12 @@ class Collector:
 
     def graph_sender(self, graph_queue: Queue[Optional[Graph]], task_id: TaskId) -> None:
         log.debug("Waiting for collector graphs")
+        start_time = time()
         while True:
             collector_graph = graph_queue.get()
             if collector_graph is None:
-                log.debug(f"Ending graph sender thread for task id {task_id}")
+                run_time = time() - start_time
+                log.debug(f"Ending graph sender thread for task id {task_id} after {run_time} seconds")
                 break
 
             graph = Graph(root=GraphRoot(id="root", tags={}))

--- a/resotoworker/resotoworker/collect.py
+++ b/resotoworker/resotoworker/collect.py
@@ -127,12 +127,12 @@ class Collector:
             graph_sender_pool_size = self._config.resotoworker.graph_sender_pool_size
             try:
                 for i in range(graph_sender_pool_size):
-                    graph_queue_t = threading.Thread(
+                    graph_sender_t = threading.Thread(
                         target=self.graph_sender, args=(graph_queue, task_id), name=f"graph_sender_{i}"
                     )
-                    graph_queue_t.daemon = True
-                    graph_queue_t.start()
-                    graph_sender_threads.append(graph_queue_t)
+                    graph_sender_t.daemon = True
+                    graph_sender_t.start()
+                    graph_sender_threads.append(graph_sender_t)
 
                 self._resotocore.create_graph_and_update_model()
                 collect(collectors, graph_queue)

--- a/resotoworker/resotoworker/collect.py
+++ b/resotoworker/resotoworker/collect.py
@@ -135,6 +135,7 @@ class Collector:
             finally:
                 log.debug("Telling graph sender thread to end")
                 graph_queue.put(None)
+                graph_queue_t.join()
 
         finally:
             with self.processing_lock:

--- a/resotoworker/resotoworker/collect.py
+++ b/resotoworker/resotoworker/collect.py
@@ -60,6 +60,7 @@ class Collector:
                 continue
 
             self._resotocore.send_to_resotocore(graph, task_id)
+            del graph
 
     def collect_and_send(
         self,

--- a/resotoworker/resotoworker/collect.py
+++ b/resotoworker/resotoworker/collect.py
@@ -141,7 +141,7 @@ class Collector:
                 for _ in range(graph_sender_pool_size):
                     graph_queue.put(None)
                 for t in graph_sender_threads:
-                    t.join()
+                    t.join(self._config.resotoworker.timeout)
 
         finally:
             with self.processing_lock:

--- a/resotoworker/resotoworker/collect.py
+++ b/resotoworker/resotoworker/collect.py
@@ -1,19 +1,20 @@
 import multiprocessing
+import threading
 from queue import Queue
-
 import resotolib.proc
 from time import time
 from concurrent import futures
 from threading import Lock
 from resotoworker.exceptions import DuplicateMessageError
+from resotoworker.resotocore import Resotocore
 from resotolib.baseplugin import BaseCollectorPlugin, BasePostCollectPlugin
-from resotolib.baseresources import GraphRoot
+from resotolib.baseresources import GraphRoot, BaseCloud, BaseAccount
 from resotolib.core.actions import CoreFeedback
 from resotolib.graph import Graph, sanitize
 from resotolib.logger import log, setup_logger
 from resotolib.args import ArgumentParser
 from argparse import Namespace
-from typing import List, Optional, Callable, Type, Dict, Any, Set
+from typing import List, Optional, Type, Dict, Any, Set
 from resotolib.config import Config, RunningConfig
 from resotolib.types import Json
 
@@ -21,26 +22,52 @@ TaskId = str
 
 
 class Collector:
-    def __init__(
-        self, config: Config, send_to_resotocore: Callable[[Graph, TaskId], None], core_messages: Queue[Json]
-    ) -> None:
-        self._send_to_resotocore = send_to_resotocore
+    def __init__(self, config: Config, resotocore: Resotocore, core_messages: Queue[Json]) -> None:
+        self._resotocore = resotocore
         self._config = config
         self.core_messages = core_messages
         self.processing: Set[str] = set()
         self.processing_lock = Lock()
 
+    def graph_sender(self, graph_queue: Queue[Optional[Graph]], task_id: TaskId):
+        log.debug("Waiting for collector graphs")
+        while True:
+            collector_graph = graph_queue.get()
+            if collector_graph is None:
+                break
+
+            graph = Graph(root=GraphRoot(id="root", tags={}))
+            graph.merge(collector_graph)
+            sanitize(graph)
+
+            graph_info = ""
+            for cloud in graph.successors(graph.root):
+                if isinstance(cloud, BaseCloud):
+                    graph_info += f" {cloud.kdname}"
+                for account in graph.successors(cloud):
+                    if isinstance(account, BaseAccount):
+                        graph_info += f" {account.kdname}"
+
+            log.info(f"Received collector graph for{graph_info}")
+
+            if (cycle := graph.find_cycle()) is not None:
+                desc = ", ".join, [f"{key.edge_type}: {key.src.kdname}-->{key.dst.kdname}" for key in cycle]
+                log.error(f"Graph of {graph_info} is not acyclic - ignoring. Cycle {desc}")
+                continue
+
+            self._resotocore.send_to_resotocore(graph, task_id)
+
     def collect_and_send(
         self,
         collectors: List[Type[BaseCollectorPlugin]],
         post_collectors: List[Type[BasePostCollectPlugin]],
-        task_id: str,
+        task_id: TaskId,
         step_name: str,
     ) -> None:
         core_feedback = CoreFeedback(task_id, step_name, "collect", self.core_messages)
 
-        def collect(collectors: List[Type[BaseCollectorPlugin]]) -> Optional[Graph]:
-            graph = Graph(root=GraphRoot(id="root", tags={}))
+        def collect(collectors: List[Type[BaseCollectorPlugin]], graph_queue: Queue[Optional[Graph]]) -> bool:
+            all_success = True
 
             max_workers = (
                 len(collectors)
@@ -71,57 +98,16 @@ class Collector:
                         collect_plugin_graph,
                         collector,
                         core_feedback,
+                        graph_queue,
                         **collect_args,
                     )
                     for collector in collectors
                 ]
                 for future in futures.as_completed(wait_for):
-                    collector_graph = future.result()
-                    if not isinstance(collector_graph, Graph):
-                        log.error(f"Skipping invalid collector graph {type(collector_graph)}")
-                        continue
-                    graph.merge(collector_graph)
-            sanitize(graph)
-            return graph
-
-        def post_collect(graph: Graph, post_collectors: List[Type[BasePostCollectPlugin]]) -> Graph:
-            if len(post_collectors) == 0:
-                log.info("No post-collect plugins loaded - skipping")
-                return graph
-            pool_args: Dict[str, Any] = {"max_workers": 1}
-            pool_executor: Type[futures.Executor]
-            collect_args: Dict[str, Any] = {}
-            if self._config.resotoworker.fork_process:
-                pool_args["mp_context"] = multiprocessing.get_context("spawn")
-                pool_args["initializer"] = resotolib.proc.initializer
-                pool_executor = futures.ProcessPoolExecutor
-                collect_args = {
-                    "args": ArgumentParser.args,
-                    "running_config": self._config.running_config,
-                }
-            else:
-                pool_executor = futures.ThreadPoolExecutor
-
-            with pool_executor(**pool_args) as executor:
-                for post_collector in post_collectors:
-                    future = executor.submit(
-                        run_post_collect_plugin, post_collector, graph, core_feedback, **collect_args
-                    )
-                    try:
-                        new_graph = future.result(Config.resotoworker.timeout)
-                    except TimeoutError as e:
-                        log.exception(f"Unhandled exception in {post_collector}: {e} - ignoring plugin")
-                        continue
-                    except Exception as e:
-                        log.exception(f"Unhandled exception in {post_collector}: {e} - ignoring plugin")
-                        continue
-
-                    if new_graph is None:
-                        continue
-                    graph = new_graph
-
-                sanitize(graph)
-                return graph
+                    collector_success = future.result()
+                    if not collector_success:
+                        all_success = False
+            return all_success
 
         processing_id = f"{task_id}:{step_name}"
         try:
@@ -130,11 +116,20 @@ class Collector:
                     raise DuplicateMessageError(f"Already processing {processing_id} - ignoring message")
                 self.processing.add(processing_id)
 
-            collected = collect(collectors)
+            mp_manager = multiprocessing.Manager()
+            graph_queue: Queue[Optional[Graph]] = mp_manager.Queue()
+            try:
+                graph_queue_t = threading.Thread(
+                    target=self.graph_sender, args=(graph_queue, task_id), name="graph_sender"
+                )
+                graph_queue_t.daemon = True
+                graph_queue_t.start()
 
-            if collected:
-                collected = post_collect(collected, post_collectors)
-                self._send_to_resotocore(collected, task_id)
+                self._resotocore.create_graph_and_update_model()
+                collect(collectors, graph_queue)
+            finally:
+                graph_queue.put(None)
+
         finally:
             with self.processing_lock:
                 if processing_id in self.processing:
@@ -177,11 +172,12 @@ def run_post_collect_plugin(
 def collect_plugin_graph(
     collector_plugin: Type[BaseCollectorPlugin],
     core_feedback: CoreFeedback,
+    graph_queue: Queue[Optional[Graph]],
     args: Optional[Namespace] = None,
     running_config: Optional[RunningConfig] = None,
-) -> Optional[Graph]:
+) -> bool:
     try:
-        collector: BaseCollectorPlugin = collector_plugin()
+        collector: BaseCollectorPlugin = collector_plugin(graph_queue=graph_queue)
         core_feedback.progress_done(collector.cloud, 0, 1)
         if core_feedback and hasattr(collector, "core_feedback"):
             setattr(collector, "core_feedback", core_feedback)
@@ -203,16 +199,12 @@ def collect_plugin_graph(
         if not collector.is_alive():  # The plugin has finished its work
             if not collector.finished:
                 log.error(f"Plugin {collector.cloud} did not finish collection" " - ignoring plugin results")
-                return None
-            if (cycle := collector.graph.find_cycle()) is not None:
-                desc = ", ".join, [f"{key.edge_type}: {key.src.kdname}-->{key.dst.kdname}" for key in cycle]
-                log.error(f"Graph of plugin {collector.cloud} is not acyclic - ignoring plugin results. Cycle {desc}")
-                return None
+                return False
             log.info(f"Collector of plugin {collector.cloud} finished in {elapsed:.4f}s")
-            return collector.graph
+            return True
         else:
             log.error(f"Plugin {collector.cloud} timed out - discarding plugin graph")
-            return None
+            return False
     except Exception as e:
         log.exception(f"Unhandled exception in {collector_plugin}: {e} - ignoring plugin")
-        return None
+        return False

--- a/resotoworker/resotoworker/collect.py
+++ b/resotoworker/resotoworker/collect.py
@@ -60,7 +60,10 @@ class Collector:
                 log.error(f"Graph of {graph_info} is not acyclic - ignoring. Cycle {desc}")
                 continue
 
-            self._resotocore.send_to_resotocore(graph, task_id)
+            try:
+                self._resotocore.send_to_resotocore(graph, task_id)
+            except Exception as e:
+                log.error(f"Error sending graph of {graph_info} to resotocore: {e}")
             del graph
 
     def collect_and_send(

--- a/resotoworker/resotoworker/config.py
+++ b/resotoworker/resotoworker/config.py
@@ -58,6 +58,9 @@ class ResotoWorkerConfig:
     )
     timeout: int = field(default=10800, metadata={"description": "Collection/cleanup timeout in seconds"})
     pool_size: int = field(default=5, metadata={"description": "Collector thread/process pool size"})
+    graph_sender_pool_size: int = field(
+        default=5, metadata={"description": "Maximum number of graphs to send to the core concurrently"}
+    )
     fork_process: bool = field(default=True, metadata={"description": "Use forked process instead of threads"})
     graph_merge_kind: GraphMergeKind = field(
         default=GraphMergeKind.account,

--- a/resotoworker/resotoworker/config.py
+++ b/resotoworker/resotoworker/config.py
@@ -59,7 +59,7 @@ class ResotoWorkerConfig:
     timeout: int = field(default=10800, metadata={"description": "Collection/cleanup timeout in seconds"})
     pool_size: int = field(default=5, metadata={"description": "Collector thread/process pool size"})
     graph_sender_pool_size: int = field(
-        default=5, metadata={"description": "Maximum number of graphs to send to the core concurrently"}
+        default=10, metadata={"description": "Maximum number of graphs to send to the core concurrently"}
     )
     fork_process: bool = field(default=True, metadata={"description": "Use forked process instead of threads"})
     graph_merge_kind: GraphMergeKind = field(

--- a/resotoworker/resotoworker/config.py
+++ b/resotoworker/resotoworker/config.py
@@ -60,7 +60,7 @@ class ResotoWorkerConfig:
     pool_size: int = field(default=5, metadata={"description": "Collector thread/process pool size"})
     fork_process: bool = field(default=True, metadata={"description": "Use forked process instead of threads"})
     graph_merge_kind: GraphMergeKind = field(
-        default=GraphMergeKind.cloud,
+        default=GraphMergeKind.account,
         metadata={"description": "Resource kind to merge graph at (cloud or account)"},
     )
     debug_dump_json: bool = field(default=False, metadata={"description": "Dump the generated JSON data to disk"})

--- a/resotoworker/resotoworker/config.py
+++ b/resotoworker/resotoworker/config.py
@@ -59,7 +59,7 @@ class ResotoWorkerConfig:
     timeout: int = field(default=10800, metadata={"description": "Collection/cleanup timeout in seconds"})
     pool_size: int = field(default=5, metadata={"description": "Collector thread/process pool size"})
     graph_sender_pool_size: int = field(
-        default=10, metadata={"description": "Maximum number of graphs to send to the core concurrently"}
+        default=5, metadata={"description": "Maximum number of graphs to send to the core concurrently"}
     )
     fork_process: bool = field(default=True, metadata={"description": "Use forked process instead of threads"})
     graph_merge_kind: GraphMergeKind = field(

--- a/resotoworker/test/test_collect.py
+++ b/resotoworker/test/test_collect.py
@@ -68,7 +68,13 @@ def test_collect_and_send() -> None:
         Config,
         FakeConfig(
             values={
-                "resotoworker": {"pool_size": 1, "fork_process": False, "graph_merge_kind": GraphMergeKind.cloud},
+                "resotoworker": {
+                    "pool_size": 1,
+                    "fork_process": False,
+                    "graph_merge_kind": GraphMergeKind.cloud,
+                    "graph_sender_pool_size": 5,
+                    "timeout": 10800,
+                },
                 "running_config": None,
             }
         ),

--- a/resotoworker/test/test_collect.py
+++ b/resotoworker/test/test_collect.py
@@ -1,9 +1,11 @@
+import requests
 from argparse import ArgumentParser
 from queue import Queue
 
 from resotoworker.collect import Collector
 from resotoworker.config import ResotoWorkerConfig
-from typing import Optional, cast
+from resotoworker.resotocore import Resotocore
+from typing import Optional, cast, Any
 from resotolib.graph import Graph, GraphMergeKind
 from resotolib.config import Config
 from test.fakeconfig import FakeConfig
@@ -40,8 +42,16 @@ class ExampleCollectorPlugin(BaseCollectorPlugin):
         pass
 
 
-class Resotocore:
-    def __init__(self) -> None:
+def make_query(request: requests.Request) -> requests.Response:
+    resp = requests.Response()
+    resp.status_code = 200
+    resp._content = b""
+    return resp
+
+
+class TestResotocore(Resotocore):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
         self.sent_task_id: Optional[str] = None
 
     def send_to_resotocore(self, graph: Graph, task_id: str) -> None:
@@ -52,7 +62,7 @@ class Resotocore:
 
 
 def test_collect_and_send() -> None:
-    resotocore = Resotocore()
+    resotocore = TestResotocore(make_query, Config)
 
     config = cast(
         Config,


### PR DESCRIPTION
# Description

Send individual accounts to Resoto Core to conserve memory.

This PR makes merge on account level the default and sends individual accounts to Resoto Core as soon as they are available, to free up the memory they use.

This removes all post_collect code since we no longer have a complete graph of all clouds in memory. The plugins aws_k8s and digitalocean_k8s need to be rewritten to use the post_collect event, search the core instead of in-memory graph and send deferred edges to the core. Likely the better approach anyways since this allows us to collect different clouds on different workers instead of relying on all K8S cluster being collected on the same worker their cloud is collected on.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
