### PR TITLE
[aws][feat] Get AWS account name from organization

### DIFF
--- a/plugins/aws/resoto_plugin_aws/configuration.py
+++ b/plugins/aws/resoto_plugin_aws/configuration.py
@@ -163,6 +163,14 @@ class AwsConfig:
             " default credentials it was started with to call organizations:ListAccounts"
         },
     )
+    prefer_account_alias_as_name: bool = field(
+        default=True,
+        metadata={
+            "description": "Prefer the account alias as the account name instead of organization."
+            " If set to false, Resoto will try to use the organization name. If scrape_org_role_arn is defined,"
+            " the role will be assumed when calling organizations:DescribeAccount."
+        },
+    )
     fork_process: bool = field(
         default=True,
         metadata={

--- a/plugins/aws/tools/awspolicygen/awspolicygen/gen.py
+++ b/plugins/aws/tools/awspolicygen/awspolicygen/gen.py
@@ -14,6 +14,7 @@ org_list_policy = {
                 "Resource": "*",
                 "Action": [
                     "organizations:ListAccounts",
+                    "organizations:DescribeAccount",
                     "ec2:DescribeRegions",
                     "iam:ListAccountAliases",
                 ],


### PR DESCRIPTION
# Description

Get AWS account name from organization. This is fully backwards compatible with the current naming scheme but if an account alias can not be found an attempt is made to get the account name via the organization. Since this requires root or delegated admin permissions (just like list_accounts) if a scrape org ARN is specified it is assumed for this operation. 
Additionally this introduces a config flag that allows you to specify whether you prefer the account alias or the org account name to be used as the account name.
Also the generated IAM permissions are updated.


# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
