### PR TITLE
[feat] [azure] Define Resource Relationship for all Azure compute resources

### DIFF
--- a/plugins/azure/resoto_plugin_azure/resource/compute.py
+++ b/plugins/azure/resoto_plugin_azure/resource/compute.py
@@ -14,6 +14,7 @@ from resotolib.baseresources import (
     VolumeStatus,
     BaseAutoScalingGroup,
     InstanceStatus,
+    InstanceStatus,
 )
 
 

--- a/plugins/azure/resoto_plugin_azure/resource/compute.py
+++ b/plugins/azure/resoto_plugin_azure/resource/compute.py
@@ -1360,10 +1360,12 @@ class AzureManagedDiskParameters(AzureSubResource):
         "disk_encryption_set": S("diskEncryptionSet") >> Bend(AzureDiskEncryptionSetParameters.mapping),
         "disk_parameters_security_profile": S("securityProfile") >> Bend(AzureVMDiskSecurityProfile.mapping),
         "storage_account_type": S("storageAccountType"),
+        "id": S("id"),
     }
     disk_encryption_set: Optional[AzureDiskEncryptionSetParameters] = field(default=None, metadata={'description': 'Describes the parameter of customer managed disk encryption set resource id that can be specified for disk. **note:** the disk encryption set resource id can only be specified for managed disk. Please refer https://aka. Ms/mdssewithcmkoverview for more details.'})  # fmt: skip
     disk_parameters_security_profile: Optional[AzureVMDiskSecurityProfile] = field(default=None, metadata={'description': 'Specifies the security profile settings for the managed disk. **note:** it can only be set for confidential vms.'})  # fmt: skip
     storage_account_type: Optional[str] = field(default=None, metadata={'description': 'Specifies the storage account type for the managed disk. Managed os disk storage account type can only be set when you create the scale set. Note: ultrassd_lrs can only be used with data disks. It cannot be used with os disk. Standard_lrs uses standard hdd. Standardssd_lrs uses standard ssd. Premium_lrs uses premium ssd. Ultrassd_lrs uses ultra disk. Premium_zrs uses premium ssd zone redundant storage. Standardssd_zrs uses standard ssd zone redundant storage. For more information regarding disks supported for windows virtual machines, refer to https://docs. Microsoft. Com/azure/virtual-machines/windows/disks-types and, for linux virtual machines, refer to https://docs. Microsoft. Com/azure/virtual-machines/linux/disks-types.'})  # fmt: skip
+    id: Optional[str] = field(default=None, metadata={'description': ''})  # fmt: skip
 
 
 @define(eq=False, slots=False)
@@ -1945,6 +1947,7 @@ class AzureImageReference(AzureSubResource):
         "shared_gallery_image_id": S("sharedGalleryImageId"),
         "image_reference_sku": S("sku"),
         "version": S("version"),
+        "id": S("id"),
     }
     community_gallery_image_id: Optional[str] = field(default=None, metadata={'description': 'Specified the community gallery image unique id for vm deployment. This can be fetched from community gallery image get call.'})  # fmt: skip
     exact_version: Optional[str] = field(default=None, metadata={'description': 'Specifies in decimal numbers, the version of platform image or marketplace image used to create the virtual machine. This readonly field differs from version , only if the value specified in version field is latest.'})  # fmt: skip
@@ -1953,6 +1956,7 @@ class AzureImageReference(AzureSubResource):
     shared_gallery_image_id: Optional[str] = field(default=None, metadata={'description': 'Specified the shared gallery image unique id for vm deployment. This can be fetched from shared gallery image get call.'})  # fmt: skip
     image_reference_sku: Optional[str] = field(default=None, metadata={"description": "The image sku."})
     version: Optional[str] = field(default=None, metadata={'description': 'Specifies the version of the platform image or marketplace image used to create the virtual machine. The allowed formats are major. Minor. Build or latest. Major, minor, and build are decimal numbers. Specify latest to use the latest version of an image available at deploy time. Even if you use latest , the vm image will not automatically update after deploy time even if a new version becomes available. Please do not use field version for gallery image deployment, gallery image should always use id field for deployment, to use latest version of gallery image, just set /subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft. Compute/galleries/{galleryname}/images/{imagename} in the id field without version input.'})  # fmt: skip
+    id: Optional[str] = field(default=None, metadata={"description": ""})
 
 
 @define(eq=False, slots=False)

--- a/plugins/azure/resoto_plugin_azure/resource/compute.py
+++ b/plugins/azure/resoto_plugin_azure/resource/compute.py
@@ -1891,7 +1891,7 @@ class AzureSnapshot(AzureResource, BaseSnapshot):
     unique_id: Optional[str] = field(default=None, metadata={"description": "Unique guid identifying the resource."})
 
     def connect_in_graph(self, builder: GraphBuilder, source: Json) -> None:
-        if disk_id := self.disk_access_id:
+        if (disk_data := self.creation_data) and (disk_id := disk_data.source_resource_id):
             builder.add_edge(self, edge_type=EdgeType.default, clazz=AzureDisk, id=disk_id)
 
 

--- a/plugins/azure/resoto_plugin_azure/resource/compute.py
+++ b/plugins/azure/resoto_plugin_azure/resource/compute.py
@@ -4,8 +4,9 @@ from typing import ClassVar, Dict, Optional, List, Any, Type
 from attr import define, field
 
 from resoto_plugin_azure.azure_client import AzureApiSpec
-from resoto_plugin_azure.resource.base import AzureResource
+from resoto_plugin_azure.resource.base import AzureResource, GraphBuilder
 from resotolib.json_bender import Bender, S, Bend, MapEnum, ForallBend, K, F
+from resotolib.types import Json
 from resotolib.baseresources import (
     BaseInstance,
     BaseVolume,
@@ -14,7 +15,7 @@ from resotolib.baseresources import (
     VolumeStatus,
     BaseAutoScalingGroup,
     InstanceStatus,
-    InstanceStatus,
+    ModelReference,
 )
 
 
@@ -56,6 +57,9 @@ class AzureAvailabilitySet(AzureResource):
         access_path="value",
         expect_array=True,
     )
+    reference_kinds: ClassVar[ModelReference] = {
+        "successors": {"default": ["azure_proximity_placement_group", "azure_virtual_machine"]},
+    }
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("id"),
         "tags": S("tags", default={}),
@@ -99,6 +103,9 @@ class AzureCapacityReservationGroup(AzureResource):
         access_path="value",
         expect_array=True,
     )
+    reference_kinds: ClassVar[ModelReference] = {
+        "successors": {"default": ["azure_virtual_machine"]},
+    }
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("id"),
         "tags": S("tags", default={}),
@@ -616,6 +623,10 @@ class AzureDisk(AzureResource, BaseVolume):
         access_path="value",
         expect_array=True,
     )
+    reference_kinds: ClassVar[ModelReference] = {
+        "predecessors": {"default": ["azure_disk_access"]},
+        "successors": {"default": ["azure_disk_encryption_set"]},
+    }
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("id"),
         "tags": S("tags", default={}),
@@ -1735,6 +1746,9 @@ class AzureRestorePointCollection(AzureResource):
         access_path="value",
         expect_array=True,
     )
+    reference_kinds: ClassVar[ModelReference] = {
+        "successors": {"default": ["azure_resource"]},
+    }
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("id"),
         "tags": S("tags", default={}),
@@ -1781,6 +1795,9 @@ class AzureSnapshot(AzureResource, BaseSnapshot):
         access_path="value",
         expect_array=True,
     )
+    reference_kinds: ClassVar[ModelReference] = {
+        "predecessors": {"default": ["azure_disk"]},
+    }
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("id"),
         "tags": S("tags", default={}),
@@ -2507,6 +2524,9 @@ class AzureVirtualMachine(AzureResource, BaseInstance):
         access_path="value",
         expect_array=True,
     )
+    reference_kinds: ClassVar[ModelReference] = {
+        "successors": {"default": ["azure_proximity_placement_group", "azure_image", "azure_disk"]},
+    }
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("id"),
         "tags": S("tags", default={}),

--- a/plugins/azure/resoto_plugin_azure/resource/compute.py
+++ b/plugins/azure/resoto_plugin_azure/resource/compute.py
@@ -1768,7 +1768,7 @@ class AzureRestorePointCollection(AzureResource):
         expect_array=True,
     )
     reference_kinds: ClassVar[ModelReference] = {
-        "successors": {"default": ["azure_resource"]},
+        "successors": {"default": ["azure_virtual_machine"]},
     }
     mapping: ClassVar[Dict[str, Bender]] = {
         "id": S("id"),
@@ -1788,8 +1788,8 @@ class AzureRestorePointCollection(AzureResource):
     source: Optional[AzureRestorePointCollectionSourceProperties] = field(default=None, metadata={'description': 'The properties of the source resource that this restore point collection is created from.'})  # fmt: skip
 
     def connect_in_graph(self, builder: GraphBuilder, source: Json) -> None:
-        if self.source and (collection_id := self.source.id):
-            builder.add_edge(self, edge_type=EdgeType.default, clazz=AzureResource, id=collection_id)
+        if collection_id := self.restore_point_collection_id:
+            builder.add_edge(self, edge_type=EdgeType.default, clazz=AzureVirtualMachine, id=collection_id)
 
 
 @define(eq=False, slots=False)

--- a/plugins/azure/resoto_plugin_azure/resource/compute.py
+++ b/plugins/azure/resoto_plugin_azure/resource/compute.py
@@ -1788,8 +1788,8 @@ class AzureRestorePointCollection(AzureResource):
     source: Optional[AzureRestorePointCollectionSourceProperties] = field(default=None, metadata={'description': 'The properties of the source resource that this restore point collection is created from.'})  # fmt: skip
 
     def connect_in_graph(self, builder: GraphBuilder, source: Json) -> None:
-        if collection_id := self.restore_point_collection_id:
-            builder.add_edge(self, edge_type=EdgeType.default, clazz=AzureVirtualMachine, id=collection_id)
+        if (source_id := self.source) and (vm_id := source_id.id):
+            builder.add_edge(self, edge_type=EdgeType.default, clazz=AzureVirtualMachine, id=vm_id)
 
 
 @define(eq=False, slots=False)

--- a/plugins/azure/resoto_plugin_azure/resource/compute.py
+++ b/plugins/azure/resoto_plugin_azure/resource/compute.py
@@ -2639,17 +2639,17 @@ class AzureVirtualMachine(AzureResource, BaseInstance):
             )
 
         if (
-            self.virtual_machine_storage_profile
-            and self.virtual_machine_storage_profile.image_reference
-            and (image_reference_id := self.virtual_machine_storage_profile.image_reference.id)
+            (sp := self.virtual_machine_storage_profile)
+            and (image_ref := sp.image_reference)
+            and (image_reference_id := image_ref.id)
         ):
             builder.add_edge(self, edge_type=EdgeType.default, clazz=AzureImage, id=image_reference_id)
 
         if (
-            self.virtual_machine_storage_profile
-            and self.virtual_machine_storage_profile.os_disk
-            and self.virtual_machine_storage_profile.os_disk.managed_disk
-            and (managed_disk_id := self.virtual_machine_storage_profile.os_disk.managed_disk.id)
+            (sp := self.virtual_machine_storage_profile)
+            and (disk := sp.os_disk)
+            and (managed := disk.managed_disk)
+            and (managed_disk_id := managed.id)
         ):
             builder.add_edge(self, edge_type=EdgeType.default, clazz=AzureDisk, id=managed_disk_id)
 

--- a/plugins/azure/resoto_plugin_azure/resource/compute.py
+++ b/plugins/azure/resoto_plugin_azure/resource/compute.py
@@ -1000,16 +1000,11 @@ class AzureGallery(AzureResource):
     soft_delete_policy: Optional[bool] = field(default=None, metadata={'description': 'Contains information about the soft deletion policy of the gallery.'})  # fmt: skip
 
 
+@define(eq=False, slots=False)
 class AzureSubResource:
     kind: ClassVar[str] = "azure_sub_resource"
     mapping: ClassVar[Dict[str, Bender]] = {"id": S("id")}
     id: Optional[str] = field(default=None, metadata={"description": "Resource id."})
-
-
-@define(eq=False, slots=False)
-class AzureDiskEncryptionSetParameters(AzureSubResource):
-    kind: ClassVar[str] = "azure_disk_encryption_set_parameters"
-    mapping: ClassVar[Dict[str, Bender]] = {}
 
 
 @define(eq=False, slots=False)
@@ -1018,7 +1013,7 @@ class AzureImageDisk:
     mapping: ClassVar[Dict[str, Bender]] = {
         "blob_uri": S("blobUri"),
         "caching": S("caching"),
-        "disk_encryption_set": S("diskEncryptionSet") >> Bend(AzureDiskEncryptionSetParameters.mapping),
+        "disk_encryption_set": S("diskEncryptionSet") >> Bend(AzureSubResource.mapping),
         "disk_size_gb": S("diskSizeGB"),
         "managed_disk": S("managedDisk", "id"),
         "snapshot": S("snapshot", "id"),
@@ -1026,7 +1021,7 @@ class AzureImageDisk:
     }
     blob_uri: Optional[str] = field(default=None, metadata={"description": "The virtual hard disk."})
     caching: Optional[str] = field(default=None, metadata={'description': 'Specifies the caching requirements. Possible values are: **none,** **readonly,** **readwrite. ** the default values are: **none for standard storage. Readonly for premium storage. **.'})  # fmt: skip
-    disk_encryption_set: Optional[AzureDiskEncryptionSetParameters] = field(default=None, metadata={'description': 'Describes the parameter of customer managed disk encryption set resource id that can be specified for disk. **note:** the disk encryption set resource id can only be specified for managed disk. Please refer https://aka. Ms/mdssewithcmkoverview for more details.'})  # fmt: skip
+    disk_encryption_set: Optional[AzureSubResource] = field(default=None, metadata={'description': 'Describes the parameter of customer managed disk encryption set resource id that can be specified for disk. **note:** the disk encryption set resource id can only be specified for managed disk. Please refer https://aka. Ms/mdssewithcmkoverview for more details.'})  # fmt: skip
     disk_size_gb: Optional[int] = field(default=None, metadata={'description': 'Specifies the size of empty data disks in gigabytes. This element can be used to overwrite the name of the disk in a virtual machine image. This value cannot be larger than 1023 gb.'})  # fmt: skip
     managed_disk: Optional[str] = field(default=None, metadata={"description": ""})
     snapshot: Optional[str] = field(default=None, metadata={"description": ""})
@@ -1036,7 +1031,7 @@ class AzureImageDisk:
 @define(eq=False, slots=False)
 class AzureImageOSDisk(AzureImageDisk):
     kind: ClassVar[str] = "azure_image_os_disk"
-    mapping: ClassVar[Dict[str, Bender]] = {"os_state": S("osState"), "os_type": S("osType")}
+    mapping: ClassVar[Dict[str, Bender]] = AzureImageDisk.mapping | {"os_state": S("osState"), "os_type": S("osType")}
     os_state: Optional[str] = field(default=None, metadata={'description': 'The os state. For managed images, use generalized.'})  # fmt: skip
     os_type: Optional[str] = field(default=None, metadata={'description': 'This property allows you to specify the type of the os that is included in the disk if creating a vm from a custom image. Possible values are: **windows,** **linux. **.'})  # fmt: skip
 
@@ -1089,7 +1084,7 @@ class AzureImage(AzureResource):
 @define(eq=False, slots=False)
 class AzureSubResourceWithColocationStatus(AzureSubResource):
     kind: ClassVar[str] = "azure_sub_resource_with_colocation_status"
-    mapping: ClassVar[Dict[str, Bender]] = {
+    mapping: ClassVar[Dict[str, Bender]] = AzureSubResource.mapping | {
         "colocation_status": S("colocationStatus") >> Bend(AzureInstanceViewStatus.mapping)
     }
     colocation_status: Optional[AzureInstanceViewStatus] = field(default=None, metadata={'description': 'Instance view status.'})  # fmt: skip
@@ -1346,26 +1341,24 @@ class AzureDiskEncryptionSettings:
 class AzureVMDiskSecurityProfile:
     kind: ClassVar[str] = "azure_vm_disk_security_profile"
     mapping: ClassVar[Dict[str, Bender]] = {
-        "disk_encryption_set": S("diskEncryptionSet") >> Bend(AzureDiskEncryptionSetParameters.mapping),
+        "disk_encryption_set": S("diskEncryptionSet") >> Bend(AzureSubResource.mapping),
         "security_encryption_type": S("securityEncryptionType"),
     }
-    disk_encryption_set: Optional[AzureDiskEncryptionSetParameters] = field(default=None, metadata={'description': 'Describes the parameter of customer managed disk encryption set resource id that can be specified for disk. **note:** the disk encryption set resource id can only be specified for managed disk. Please refer https://aka. Ms/mdssewithcmkoverview for more details.'})  # fmt: skip
+    disk_encryption_set: Optional[AzureSubResource] = field(default=None, metadata={'description': 'Describes the parameter of customer managed disk encryption set resource id that can be specified for disk. **note:** the disk encryption set resource id can only be specified for managed disk. Please refer https://aka. Ms/mdssewithcmkoverview for more details.'})  # fmt: skip
     security_encryption_type: Optional[str] = field(default=None, metadata={'description': 'Specifies the encryptiontype of the managed disk. It is set to diskwithvmgueststate for encryption of the managed disk along with vmgueststate blob, and vmgueststateonly for encryption of just the vmgueststate blob. **note:** it can be set for only confidential vms.'})  # fmt: skip
 
 
 @define(eq=False, slots=False)
 class AzureManagedDiskParameters(AzureSubResource):
     kind: ClassVar[str] = "azure_managed_disk_parameters"
-    mapping: ClassVar[Dict[str, Bender]] = {
-        "disk_encryption_set": S("diskEncryptionSet") >> Bend(AzureDiskEncryptionSetParameters.mapping),
+    mapping: ClassVar[Dict[str, Bender]] = AzureSubResource.mapping | {
+        "disk_encryption_set": S("diskEncryptionSet") >> Bend(AzureSubResource.mapping),
         "disk_parameters_security_profile": S("securityProfile") >> Bend(AzureVMDiskSecurityProfile.mapping),
         "storage_account_type": S("storageAccountType"),
-        "id": S("id"),
     }
-    disk_encryption_set: Optional[AzureDiskEncryptionSetParameters] = field(default=None, metadata={'description': 'Describes the parameter of customer managed disk encryption set resource id that can be specified for disk. **note:** the disk encryption set resource id can only be specified for managed disk. Please refer https://aka. Ms/mdssewithcmkoverview for more details.'})  # fmt: skip
+    disk_encryption_set: Optional[AzureSubResource] = field(default=None, metadata={'description': 'Describes the parameter of customer managed disk encryption set resource id that can be specified for disk. **note:** the disk encryption set resource id can only be specified for managed disk. Please refer https://aka. Ms/mdssewithcmkoverview for more details.'})  # fmt: skip
     disk_parameters_security_profile: Optional[AzureVMDiskSecurityProfile] = field(default=None, metadata={'description': 'Specifies the security profile settings for the managed disk. **note:** it can only be set for confidential vms.'})  # fmt: skip
     storage_account_type: Optional[str] = field(default=None, metadata={'description': 'Specifies the storage account type for the managed disk. Managed os disk storage account type can only be set when you create the scale set. Note: ultrassd_lrs can only be used with data disks. It cannot be used with os disk. Standard_lrs uses standard hdd. Standardssd_lrs uses standard ssd. Premium_lrs uses premium ssd. Ultrassd_lrs uses ultra disk. Premium_zrs uses premium ssd zone redundant storage. Standardssd_zrs uses standard ssd zone redundant storage. For more information regarding disks supported for windows virtual machines, refer to https://docs. Microsoft. Com/azure/virtual-machines/windows/disks-types and, for linux virtual machines, refer to https://docs. Microsoft. Com/azure/virtual-machines/linux/disks-types.'})  # fmt: skip
-    id: Optional[str] = field(default=None, metadata={'description': ''})  # fmt: skip
 
 
 @define(eq=False, slots=False)
@@ -1379,17 +1372,17 @@ class AzureSubResourceReadOnly:
 class AzureRestorePointEncryption:
     kind: ClassVar[str] = "azure_restore_point_encryption"
     mapping: ClassVar[Dict[str, Bender]] = {
-        "disk_encryption_set": S("diskEncryptionSet") >> Bend(AzureDiskEncryptionSetParameters.mapping),
+        "disk_encryption_set": S("diskEncryptionSet") >> Bend(AzureSubResource.mapping),
         "type": S("type"),
     }
-    disk_encryption_set: Optional[AzureDiskEncryptionSetParameters] = field(default=None, metadata={'description': 'Describes the parameter of customer managed disk encryption set resource id that can be specified for disk. **note:** the disk encryption set resource id can only be specified for managed disk. Please refer https://aka. Ms/mdssewithcmkoverview for more details.'})  # fmt: skip
+    disk_encryption_set: Optional[AzureSubResource] = field(default=None, metadata={'description': 'Describes the parameter of customer managed disk encryption set resource id that can be specified for disk. **note:** the disk encryption set resource id can only be specified for managed disk. Please refer https://aka. Ms/mdssewithcmkoverview for more details.'})  # fmt: skip
     type: Optional[str] = field(default=None, metadata={'description': 'The type of key used to encrypt the data of the disk restore point.'})  # fmt: skip
 
 
 @define(eq=False, slots=False)
 class AzureDiskRestorePointAttributes(AzureSubResourceReadOnly):
     kind: ClassVar[str] = "azure_disk_restore_point_attributes"
-    mapping: ClassVar[Dict[str, Bender]] = {
+    mapping: ClassVar[Dict[str, Bender]] = AzureSubResourceReadOnly.mapping | {
         "encryption": S("encryption") >> Bend(AzureRestorePointEncryption.mapping),
         "source_disk_restore_point": S("sourceDiskRestorePoint", "id"),
     }
@@ -1739,7 +1732,7 @@ class AzureRestorePointInstanceView:
 @define(eq=False, slots=False)
 class AzureRestorePoint(AzureProxyResource):
     kind: ClassVar[str] = "azure_restore_point"
-    mapping: ClassVar[Dict[str, Bender]] = {
+    mapping: ClassVar[Dict[str, Bender]] = AzureProxyResource.mapping | {
         "consistency_mode": S("properties", "consistencyMode"),
         "exclude_disks": S("properties") >> S("excludeDisks", default=[]) >> ForallBend(S("id")),
         "restore_point_instance_view": S("properties", "instanceView") >> Bend(AzureRestorePointInstanceView.mapping),
@@ -1939,7 +1932,7 @@ class AzurePlan:
 @define(eq=False, slots=False)
 class AzureImageReference(AzureSubResource):
     kind: ClassVar[str] = "azure_image_reference"
-    mapping: ClassVar[Dict[str, Bender]] = {
+    mapping: ClassVar[Dict[str, Bender]] = AzureSubResource.mapping | {
         "community_gallery_image_id": S("communityGalleryImageId"),
         "exact_version": S("exactVersion"),
         "offer": S("offer"),
@@ -1947,7 +1940,6 @@ class AzureImageReference(AzureSubResource):
         "shared_gallery_image_id": S("sharedGalleryImageId"),
         "image_reference_sku": S("sku"),
         "version": S("version"),
-        "id": S("id"),
     }
     community_gallery_image_id: Optional[str] = field(default=None, metadata={'description': 'Specified the community gallery image unique id for vm deployment. This can be fetched from community gallery image get call.'})  # fmt: skip
     exact_version: Optional[str] = field(default=None, metadata={'description': 'Specifies in decimal numbers, the version of platform image or marketplace image used to create the virtual machine. This readonly field differs from version , only if the value specified in version field is latest.'})  # fmt: skip
@@ -1956,7 +1948,6 @@ class AzureImageReference(AzureSubResource):
     shared_gallery_image_id: Optional[str] = field(default=None, metadata={'description': 'Specified the shared gallery image unique id for vm deployment. This can be fetched from shared gallery image get call.'})  # fmt: skip
     image_reference_sku: Optional[str] = field(default=None, metadata={"description": "The image sku."})
     version: Optional[str] = field(default=None, metadata={'description': 'Specifies the version of the platform image or marketplace image used to create the virtual machine. The allowed formats are major. Minor. Build or latest. Major, minor, and build are decimal numbers. Specify latest to use the latest version of an image available at deploy time. Even if you use latest , the vm image will not automatically update after deploy time even if a new version becomes available. Please do not use field version for gallery image deployment, gallery image should always use id field for deployment, to use latest version of gallery image, just set /subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft. Compute/galleries/{galleryname}/images/{imagename} in the id field without version input.'})  # fmt: skip
-    id: Optional[str] = field(default=None, metadata={"description": ""})
 
 
 @define(eq=False, slots=False)
@@ -2062,7 +2053,7 @@ class AzureAdditionalCapabilities:
 @define(eq=False, slots=False)
 class AzureNetworkInterfaceReference(AzureSubResource):
     kind: ClassVar[str] = "azure_network_interface_reference"
-    mapping: ClassVar[Dict[str, Bender]] = {
+    mapping: ClassVar[Dict[str, Bender]] = AzureSubResource.mapping | {
         "delete_option": S("properties", "deleteOption"),
         "primary": S("properties", "primary"),
     }
@@ -2749,11 +2740,11 @@ class AzureVirtualMachineScaleSetOSProfile:
 class AzureVirtualMachineScaleSetManagedDiskParameters:
     kind: ClassVar[str] = "azure_virtual_machine_scale_set_managed_disk_parameters"
     mapping: ClassVar[Dict[str, Bender]] = {
-        "disk_encryption_set": S("diskEncryptionSet") >> Bend(AzureDiskEncryptionSetParameters.mapping),
+        "disk_encryption_set": S("diskEncryptionSet") >> Bend(AzureSubResource.mapping),
         "security_profile": S("securityProfile") >> Bend(AzureVMDiskSecurityProfile.mapping),
         "storage_account_type": S("storageAccountType"),
     }
-    disk_encryption_set: Optional[AzureDiskEncryptionSetParameters] = field(default=None, metadata={'description': 'Describes the parameter of customer managed disk encryption set resource id that can be specified for disk. **note:** the disk encryption set resource id can only be specified for managed disk. Please refer https://aka. Ms/mdssewithcmkoverview for more details.'})  # fmt: skip
+    disk_encryption_set: Optional[AzureSubResource] = field(default=None, metadata={'description': 'Describes the parameter of customer managed disk encryption set resource id that can be specified for disk. **note:** the disk encryption set resource id can only be specified for managed disk. Please refer https://aka. Ms/mdssewithcmkoverview for more details.'})  # fmt: skip
     security_profile: Optional[AzureVMDiskSecurityProfile] = field(default=None, metadata={'description': 'Specifies the security profile settings for the managed disk. **note:** it can only be set for confidential vms.'})  # fmt: skip
     storage_account_type: Optional[str] = field(default=None, metadata={'description': 'Specifies the storage account type for the managed disk. Managed os disk storage account type can only be set when you create the scale set. Note: ultrassd_lrs can only be used with data disks. It cannot be used with os disk. Standard_lrs uses standard hdd. Standardssd_lrs uses standard ssd. Premium_lrs uses premium ssd. Ultrassd_lrs uses ultra disk. Premium_zrs uses premium ssd zone redundant storage. Standardssd_zrs uses standard ssd zone redundant storage. For more information regarding disks supported for windows virtual machines, refer to https://docs. Microsoft. Com/azure/virtual-machines/windows/disks-types and, for linux virtual machines, refer to https://docs. Microsoft. Com/azure/virtual-machines/linux/disks-types.'})  # fmt: skip
 
@@ -2949,7 +2940,7 @@ class AzureVirtualMachineScaleSetNetworkProfile:
 @define(eq=False, slots=False)
 class AzureVirtualMachineScaleSetExtension(AzureSubResourceReadOnly):
     kind: ClassVar[str] = "azure_virtual_machine_scale_set_extension"
-    mapping: ClassVar[Dict[str, Bender]] = {
+    mapping: ClassVar[Dict[str, Bender]] = AzureSubResourceReadOnly.mapping | {
         "auto_upgrade_minor_version": S("properties", "autoUpgradeMinorVersion"),
         "enable_automatic_upgrade": S("properties", "enableAutomaticUpgrade"),
         "force_update_tag": S("properties", "forceUpdateTag"),
@@ -3118,7 +3109,7 @@ class AzureVirtualMachineScaleSet(AzureResource, BaseAutoScalingGroup):
         "automatic_repairs_policy": S("properties", "automaticRepairsPolicy")
         >> Bend(AzureAutomaticRepairsPolicy.mapping),
         "constrained_maximum_capacity": S("properties", "constrainedMaximumCapacity"),
-        "do_not_run_extensions_on_overprovisioned_v_ms": S("properties", "doNotRunExtensionsOnOverprovisionedVMs"),
+        "do_not_run_extensions_on_overprovisioned_vm_s": S("properties", "doNotRunExtensionsOnOverprovisionedVMs"),
         "extended_location": S("extendedLocation") >> Bend(AzureExtendedLocation.mapping),
         "host_group": S("properties", "hostGroup", "id"),
         "scale_set_identity": S("identity") >> Bend(AzureVirtualMachineScaleSetIdentity.mapping),
@@ -3143,7 +3134,7 @@ class AzureVirtualMachineScaleSet(AzureResource, BaseAutoScalingGroup):
     scale_set_capabilities: Optional[AzureAdditionalCapabilities] = field(default=None, metadata={'description': 'Enables or disables a capability on the virtual machine or virtual machine scale set.'})  # fmt: skip
     automatic_repairs_policy: Optional[AzureAutomaticRepairsPolicy] = field(default=None, metadata={'description': 'Specifies the configuration parameters for automatic repairs on the virtual machine scale set.'})  # fmt: skip
     constrained_maximum_capacity: Optional[bool] = field(default=None, metadata={'description': 'Optional property which must either be set to true or omitted.'})  # fmt: skip
-    do_not_run_extensions_on_overprovisioned_v_ms: Optional[bool] = field(default=None, metadata={'description': 'When overprovision is enabled, extensions are launched only on the requested number of vms which are finally kept. This property will hence ensure that the extensions do not run on the extra overprovisioned vms.'})  # fmt: skip
+    do_not_run_extensions_on_overprovisioned_vm_s: Optional[bool] = field(default=None, metadata={'description': 'When overprovision is enabled, extensions are launched only on the requested number of vms which are finally kept. This property will hence ensure that the extensions do not run on the extra overprovisioned vms.'})  # fmt: skip
     extended_location: Optional[AzureExtendedLocation] = field(default=None, metadata={'description': 'The complex type of the extended location.'})  # fmt: skip
     host_group: Optional[str] = field(default=None, metadata={"description": ""})
     scale_set_identity: Optional[AzureVirtualMachineScaleSetIdentity] = field(default=None, metadata={'description': 'Identity for the virtual machine scale set.'})  # fmt: skip

--- a/plugins/azure/resoto_plugin_azure/resource/compute.py
+++ b/plugins/azure/resoto_plugin_azure/resource/compute.py
@@ -729,10 +729,10 @@ class AzureDisk(AzureResource, BaseVolume):
     unique_id: Optional[str] = field(default=None, metadata={"description": "Unique guid identifying the resource."})
 
     def connect_in_graph(self, builder: GraphBuilder, source: Json) -> None:
-        if disk_id := self.disk_access_id:
+        if disk_id := self.id:
             builder.add_edge(self, edge_type=EdgeType.default, clazz=AzureDiskAccess, id=disk_id)
-        if self.disk_encryption and (disk_encryption_set_id := self.disk_encryption.disk_encryption_set_id):
-            builder.add_edge(self, edge_type=EdgeType.default, clazz=AzureDiskEncryptionSet, id=disk_encryption_set_id)
+        if (disk_encryption := self.disk_encryption) and (disk_en_set_id := disk_encryption.disk_encryption_set_id):
+            builder.add_edge(self, edge_type=EdgeType.default, clazz=AzureDiskEncryptionSet, id=disk_en_set_id)
 
 
 @define(eq=False, slots=False)

--- a/plugins/azure/test/collector_test.py
+++ b/plugins/azure/test/collector_test.py
@@ -16,4 +16,4 @@ def test_collect(
     collector = AzureSubscriptionCollector(config, Cloud(id="azure"), azure_subscription, credentials, core_feedback)
     collector.collect()
     assert len(collector.graph.nodes) == 61
-    assert len(collector.graph.edges) == 60
+    assert len(collector.graph.edges) == 64

--- a/plugins/azure/test/collector_test.py
+++ b/plugins/azure/test/collector_test.py
@@ -16,4 +16,4 @@ def test_collect(
     collector = AzureSubscriptionCollector(config, Cloud(id="azure"), azure_subscription, credentials, core_feedback)
     collector.collect()
     assert len(collector.graph.nodes) == 60
-    assert len(collector.graph.edges) == 71
+    assert len(collector.graph.edges) == 72

--- a/plugins/azure/test/collector_test.py
+++ b/plugins/azure/test/collector_test.py
@@ -15,5 +15,5 @@ def test_collect(
 ) -> None:
     collector = AzureSubscriptionCollector(config, Cloud(id="azure"), azure_subscription, credentials, core_feedback)
     collector.collect()
-    assert len(collector.graph.nodes) == 61
-    assert len(collector.graph.edges) == 64
+    assert len(collector.graph.nodes) == 60
+    assert len(collector.graph.edges) == 67

--- a/plugins/azure/test/collector_test.py
+++ b/plugins/azure/test/collector_test.py
@@ -16,4 +16,4 @@ def test_collect(
     collector = AzureSubscriptionCollector(config, Cloud(id="azure"), azure_subscription, credentials, core_feedback)
     collector.collect()
     assert len(collector.graph.nodes) == 60
-    assert len(collector.graph.edges) == 69
+    assert len(collector.graph.edges) == 71

--- a/plugins/azure/test/collector_test.py
+++ b/plugins/azure/test/collector_test.py
@@ -16,4 +16,4 @@ def test_collect(
     collector = AzureSubscriptionCollector(config, Cloud(id="azure"), azure_subscription, credentials, core_feedback)
     collector.collect()
     assert len(collector.graph.nodes) == 60
-    assert len(collector.graph.edges) == 72
+    assert len(collector.graph.edges) == 78

--- a/plugins/azure/test/collector_test.py
+++ b/plugins/azure/test/collector_test.py
@@ -16,4 +16,4 @@ def test_collect(
     collector = AzureSubscriptionCollector(config, Cloud(id="azure"), azure_subscription, credentials, core_feedback)
     collector.collect()
     assert len(collector.graph.nodes) == 60
-    assert len(collector.graph.edges) == 67
+    assert len(collector.graph.edges) == 69

--- a/plugins/azure/test/compute_test.py
+++ b/plugins/azure/test/compute_test.py
@@ -19,6 +19,11 @@ def test_capacity_reservation_group(builder: GraphBuilder) -> None:
     collected = roundtrip_check(AzureCapacityReservationGroup, builder)
     assert len(collected) == 2
 
+    resource_type: List[Type[AzureResource]] = [AzureVirtualMachine]
+    connect_resources(builder, resource_type)
+
+    assert len(builder.edges_of(AzureCapacityReservationGroup, AzureVirtualMachine)) == 2
+
 
 def test_cloud_service(builder: GraphBuilder) -> None:
     collected = roundtrip_check(AzureCloudService, builder)

--- a/plugins/azure/test/compute_test.py
+++ b/plugins/azure/test/compute_test.py
@@ -137,6 +137,11 @@ def test_snapshot(builder: GraphBuilder) -> None:
     collected = roundtrip_check(AzureSnapshot, builder)
     assert len(collected) == 2
 
+    resource_type: List[Type[AzureResource]] = [AzureDisk]
+    connect_resources(builder, resource_type)
+
+    assert len(builder.edges_of(AzureSnapshot, AzureDisk)) == 1
+
 
 def test_snapshot_resources(builder: GraphBuilder) -> None:
     collected = roundtrip_check(AzureSnapshot, builder)[1]

--- a/plugins/azure/test/compute_test.py
+++ b/plugins/azure/test/compute_test.py
@@ -10,8 +10,9 @@ def test_availability_sets(builder: GraphBuilder) -> None:
 
     resource_types: List[Type[AzureResource]] = [AzureProximityPlacementGroup, AzureVirtualMachine]
     connect_resources(builder, resource_types)
+
     assert len(builder.edges_of(AzureAvailabilitySet, AzureProximityPlacementGroup)) == 2
-    assert len(builder.edges_of(AzureAvailabilitySet, AzureVirtualMachine)) == 1
+    assert len(builder.edges_of(AzureAvailabilitySet, AzureVirtualMachine)) == 2
 
 
 def test_capacity_reservation_group(builder: GraphBuilder) -> None:

--- a/plugins/azure/test/compute_test.py
+++ b/plugins/azure/test/compute_test.py
@@ -1,12 +1,17 @@
-from conftest import roundtrip_check
-from resoto_plugin_azure.resource.base import GraphBuilder
+from conftest import roundtrip_check, connect_resources
+from resoto_plugin_azure.resource.base import GraphBuilder, AzureResource
 from resoto_plugin_azure.resource.compute import *
 from resotolib.baseresources import VolumeStatus, InstanceStatus
-
+from typing import List, Type
 
 def test_availability_sets(builder: GraphBuilder) -> None:
     collected = roundtrip_check(AzureAvailabilitySet, builder)
     assert len(collected) == 4
+
+    resource_types: List[Type[AzureResource]] = [AzureProximityPlacementGroup, AzureVirtualMachine]
+    connect_resources(builder, resource_types)
+    assert len(builder.edges_of(AzureAvailabilitySet, AzureProximityPlacementGroup)) == 2
+    assert len(builder.edges_of(AzureAvailabilitySet, AzureVirtualMachine)) == 1
 
 
 def test_capacity_reservation_group(builder: GraphBuilder) -> None:

--- a/plugins/azure/test/compute_test.py
+++ b/plugins/azure/test/compute_test.py
@@ -94,6 +94,11 @@ def test_restore_point_collection(builder: GraphBuilder) -> None:
     collected = roundtrip_check(AzureRestorePointCollection, builder)
     assert len(collected) == 2
 
+    resource_type: List[Type[AzureResource]] = [AzureVirtualMachine]
+    connect_resources(builder, resource_type)
+
+    assert len(builder.edges_of(AzureRestorePointCollection, AzureVirtualMachine)) == 2
+
 
 def test_ssh_key(builder: GraphBuilder) -> None:
     collected = roundtrip_check(AzureSshPublicKeyResource, builder)

--- a/plugins/azure/test/compute_test.py
+++ b/plugins/azure/test/compute_test.py
@@ -44,16 +44,6 @@ def test_disks_resource(builder: GraphBuilder) -> None:
     assert collected.volume_encrypted is True
 
 
-def test_disks_resource(builder: GraphBuilder) -> None:
-    collected = roundtrip_check(AzureDisk, builder, all_props=True)[0]
-    assert collected.volume_size == 200
-    assert collected.volume_type == "Premium_LRS"
-    assert collected.volume_status == VolumeStatus.UNKNOWN
-    assert collected.volume_iops == 120
-    assert collected.volume_throughput == 25
-    assert collected.volume_encrypted is True
-
-
 def test_disk_access(builder: GraphBuilder) -> None:
     collected = roundtrip_check(AzureDiskAccess, builder)
     assert len(collected) == 2
@@ -97,12 +87,6 @@ def test_ssh_key(builder: GraphBuilder) -> None:
 def test_virtual_machine(builder: GraphBuilder) -> None:
     collected = roundtrip_check(AzureVirtualMachine, builder)
     assert len(collected) == 2
-
-
-def test_virtual_machine_resources(builder: GraphBuilder) -> None:
-    collected = roundtrip_check(AzureVirtualMachine, builder)[0]
-    assert collected.instance_type == "Standard_A0"
-    assert collected.instance_status == InstanceStatus.RUNNING
 
 
 def test_virtual_machine_resources(builder: GraphBuilder) -> None:

--- a/plugins/azure/test/compute_test.py
+++ b/plugins/azure/test/compute_test.py
@@ -4,6 +4,7 @@ from resoto_plugin_azure.resource.compute import *
 from resotolib.baseresources import VolumeStatus, InstanceStatus
 from typing import List, Type
 
+
 def test_availability_sets(builder: GraphBuilder) -> None:
     collected = roundtrip_check(AzureAvailabilitySet, builder)
     assert len(collected) == 4
@@ -49,6 +50,7 @@ def test_disks(builder: GraphBuilder) -> None:
 
     assert len(builder.edges_of(AzureDisk, AzureDiskAccess)) == 2
     assert len(builder.edges_of(AzureDisk, AzureDiskEncryptionSet)) == 2
+
 
 def test_disks_resource(builder: GraphBuilder) -> None:
     collected = roundtrip_check(AzureDisk, builder, all_props=True)[0]
@@ -108,6 +110,13 @@ def test_ssh_key(builder: GraphBuilder) -> None:
 def test_virtual_machine(builder: GraphBuilder) -> None:
     collected = roundtrip_check(AzureVirtualMachine, builder)
     assert len(collected) == 2
+
+    resource_types: List[Type[AzureResource]] = [AzureProximityPlacementGroup, AzureImage, AzureDisk]
+    connect_resources(builder, resource_types)
+
+    assert len(builder.edges_of(AzureVirtualMachine, AzureProximityPlacementGroup)) == 2
+    assert len(builder.edges_of(AzureVirtualMachine, AzureImage)) == 2
+    assert len(builder.edges_of(AzureVirtualMachine, AzureDisk)) == 2
 
 
 def test_virtual_machine_resources(builder: GraphBuilder) -> None:

--- a/plugins/azure/test/compute_test.py
+++ b/plugins/azure/test/compute_test.py
@@ -44,6 +44,16 @@ def test_disks_resource(builder: GraphBuilder) -> None:
     assert collected.volume_encrypted is True
 
 
+def test_disks_resource(builder: GraphBuilder) -> None:
+    collected = roundtrip_check(AzureDisk, builder, all_props=True)[0]
+    assert collected.volume_size == 200
+    assert collected.volume_type == "Premium_LRS"
+    assert collected.volume_status == VolumeStatus.UNKNOWN
+    assert collected.volume_iops == 120
+    assert collected.volume_throughput == 25
+    assert collected.volume_encrypted is True
+
+
 def test_disk_access(builder: GraphBuilder) -> None:
     collected = roundtrip_check(AzureDiskAccess, builder)
     assert len(collected) == 2
@@ -87,6 +97,12 @@ def test_ssh_key(builder: GraphBuilder) -> None:
 def test_virtual_machine(builder: GraphBuilder) -> None:
     collected = roundtrip_check(AzureVirtualMachine, builder)
     assert len(collected) == 2
+
+
+def test_virtual_machine_resources(builder: GraphBuilder) -> None:
+    collected = roundtrip_check(AzureVirtualMachine, builder)[0]
+    assert collected.instance_type == "Standard_A0"
+    assert collected.instance_status == InstanceStatus.RUNNING
 
 
 def test_virtual_machine_resources(builder: GraphBuilder) -> None:

--- a/plugins/azure/test/compute_test.py
+++ b/plugins/azure/test/compute_test.py
@@ -37,8 +37,13 @@ def test_dedicated_host_group(builder: GraphBuilder) -> None:
 
 def test_disks(builder: GraphBuilder) -> None:
     collected = roundtrip_check(AzureDisk, builder, all_props=True)
-    assert len(collected) == 3
+    assert len(collected) == 2
 
+    resource_types: List[Type[AzureResource]] = [AzureDiskAccess, AzureDiskEncryptionSet]
+    connect_resources(builder, resource_types)
+
+    assert len(builder.edges_of(AzureDisk, AzureDiskAccess)) == 2
+    assert len(builder.edges_of(AzureDisk, AzureDiskEncryptionSet)) == 2
 
 def test_disks_resource(builder: GraphBuilder) -> None:
     collected = roundtrip_check(AzureDisk, builder, all_props=True)[0]

--- a/plugins/azure/test/conftest.py
+++ b/plugins/azure/test/conftest.py
@@ -126,3 +126,17 @@ def roundtrip_check(
         again_js = again.to_json()
         assert js_repr == again_js, f"Left: {js_repr}\nRight: {again_js}"
     return resources
+
+
+def connect_resources(
+    builder: GraphBuilder,
+    collect_resources: Optional[List[Type[AzureResourceType]]] = None,
+    filter_class: Optional[Type[AzureResourceType]] = None,
+) -> None:
+    # collect all defined resource kinds before we can connect them
+    for resource_kind in collect_resources or []:
+        resource_kind.collect_resources(builder)
+    # connect all resources
+    for node, data in list(builder.graph.nodes(data=True)):
+        if not filter_class or isinstance(node, filter_class):
+            node.connect_in_graph(builder, data.get("source", {}))

--- a/plugins/azure/test/conftest.py
+++ b/plugins/azure/test/conftest.py
@@ -125,6 +125,7 @@ def roundtrip_check(
         # since we can not compare objects, we use the json representation to see that no information is lost
         again_js = again.to_json()
         assert js_repr == again_js, f"Left: {js_repr}\nRight: {again_js}"
+    print(resources)
     return resources
 
 

--- a/plugins/azure/test/files/compute/availabilitySets.json
+++ b/plugins/azure/test/files/compute/availabilitySets.json
@@ -10,11 +10,11 @@
                 "platformFaultDomainCount": 3,
                 "virtualMachines": [
                     {
-                        "id": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}"
+                        "id": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{virtualMachineName}"
                     }
                 ],
                 "proximityPlacementGroup": {
-                    "id": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/availabilitySets/{availabilitySetName}"
+                    "id": "/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/proximityPlacementGroups/myProximityPlacementGroup"
                 },
                 "statuses": [
                     {
@@ -45,11 +45,11 @@
                 "platformFaultDomainCount": 3,
                 "virtualMachines": [
                     {
-                        "id": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}"
+                        "id": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{virtualMachineName}"
                     }
                 ],
                 "proximityPlacementGroup": {
-                    "id": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/availabilitySets/{availabilitySetName}"
+                    "id": "/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/proximityPlacementGroups/myProximityPlacementGroup"
                 },
                 "statuses": [
                     {

--- a/plugins/azure/test/files/compute/capacityReservationGroups.json
+++ b/plugins/azure/test/files/compute/capacityReservationGroups.json
@@ -16,10 +16,10 @@
                 ],
                 "virtualMachinesAssociated": [
                     {
-                        "id": "/subscriptions/{subscription-id}/resourceGroups/myResourceGroup1/providers/Microsoft.Compute/virtualMachines/myVM1"
+                        "id": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{virtualMachineName}"
                     },
                     {
-                        "id": "/subscriptions/{subscription-id}/resourceGroups/myResourceGroup1/providers/Microsoft.Compute/virtualMachines/myVM2"
+                        "id": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{virtualMachineName}"
                     }
                 ]
             }
@@ -40,7 +40,7 @@
                 ],
                 "virtualMachinesAssociated": [
                     {
-                        "id": "/subscriptions/{subscription-id}/resourceGroups/myResourceGroup2/providers/Microsoft.Compute/virtualMachines/myVM3"
+                        "id": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{virtualMachineName}"
                     }
                 ]
             }

--- a/plugins/azure/test/files/compute/disks.json
+++ b/plugins/azure/test/files/compute/disks.json
@@ -63,13 +63,19 @@
                 "supportsHibernation": true,
                 "tier": "Premium",
                 "uniqueId": "d1d2d3d4-d5d6-d7d8-d9d0-d1d2d3d4d5d6",
-                "propertyUpdatesInProgress": { "targetTier": "Premium" }
+                "propertyUpdatesInProgress": {
+                    "targetTier": "Premium"
+                }
             },
             "type": "Microsoft.Compute/disks",
             "location": "westus",
-            "extendedLocation": {"name": "test"},
+            "extendedLocation": {
+                "name": "test"
+            },
             "managedBy": "test",
-            "managedByExtended": ["test2"],
+            "managedByExtended": [
+                "test2"
+            ],
             "tags": {
                 "department": "Development",
                 "project": "ManagedDisks"
@@ -124,7 +130,7 @@
                 "project": "ManagedDisks"
             },
             "id": "/subscriptions/{subscription-id}/resourceGroups/mySecondResourceGroup/providers/Microsoft.Compute/diskAccesses/myDiskAccess2",
-            "name": "myManagedDisk3"
+            "name": "myManagedDisk2"
         }
     ],
     "nextLink": "http://disksvchost:99/subscriptions/{subscriptionId}/providers/Microsoft.Compute/disks?$skiptoken={token}/Subscriptions/{subscriptionId}/ResourceGroups/myResourceGroup/Disks/myManagedDisk"

--- a/plugins/azure/test/files/compute/disks.json
+++ b/plugins/azure/test/files/compute/disks.json
@@ -28,6 +28,7 @@
                     ]
                 },
                 "encryption": {
+                    "diskEncryptionSetId": "/subscriptions/{subscriptionId}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/diskEncryptionSets/myDiskEncryptionSet",
                     "type": "EncryptionAtRestWithPlatformKey"
                 },
                 "timeCreated": "2016-12-28T04:41:35.9278721+00:00",
@@ -73,30 +74,12 @@
                 "department": "Development",
                 "project": "ManagedDisks"
             },
-            "id": "/subscriptions/{subscriptionId}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/disks/myManagedDisk1",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/diskAccesses/myDiskAccess",
             "name": "myManagedDisk1",
             "sku": {
                 "name": "Premium_LRS",
                 "tier": "Premium"
             }
-        },
-        {
-            "properties": {
-                "osType": "Windows",
-                "creationData": {
-                    "createOption": "Empty"
-                },
-                "diskSizeGB": 10,
-                "encryption": {
-                    "type": "EncryptionAtRestWithPlatformKey"
-                },
-                "timeCreated": "2016-12-28T04:41:36.872242+00:00",
-                "provisioningState": "Succeeded"
-            },
-            "type": "Microsoft.Compute/disks",
-            "location": "westus",
-            "id": "/subscriptions/{subscriptionId}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/disks/myManagedDisk2",
-            "name": "myManagedDisk2"
         },
         {
             "properties": {
@@ -128,6 +111,7 @@
                     ]
                 },
                 "encryption": {
+                    "diskEncryptionSetId": "/subscriptions/{subscriptionId}/resourceGroups/mySecondResourceGroup/providers/Microsoft.Compute/diskEncryptionSets/myDiskEncryptionSet2",
                     "type": "EncryptionAtRestWithPlatformKey"
                 },
                 "timeCreated": "2016-12-28T04:41:36.3973934+00:00",
@@ -139,7 +123,7 @@
                 "department": "Development",
                 "project": "ManagedDisks"
             },
-            "id": "/subscriptions/{subscriptionId}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/disks/myManagedDisk3",
+            "id": "/subscriptions/{subscription-id}/resourceGroups/mySecondResourceGroup/providers/Microsoft.Compute/diskAccesses/myDiskAccess2",
             "name": "myManagedDisk3"
         }
     ],

--- a/plugins/azure/test/files/compute/restorePointCollections.json
+++ b/plugins/azure/test/files/compute/restorePointCollections.json
@@ -10,7 +10,7 @@
             },
             "properties": {
                 "source": {
-                    "id": "/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/virtualMachines/VM_Test",
+                    "id": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{virtualMachineName}",
                     "location": "westus"
                 },
                 "restorePointCollectionId": "59f04a5d-f783-4200-a1bd-d3f464e8c4b4",
@@ -27,7 +27,7 @@
             },
             "properties": {
                 "source": {
-                    "id": "/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/virtualMachines/VM_Prod",
+                    "id": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{virtualMachineName}",
                     "location": "westus"
                 },
                 "restorePointCollectionId": "2875c590-e337-4102-9668-4f5b7e3f98a4",

--- a/plugins/azure/test/files/compute/snapshots.json
+++ b/plugins/azure/test/files/compute/snapshots.json
@@ -5,7 +5,7 @@
                 "osType": "Windows",
                 "creationData": {
                     "createOption": "Copy",
-                    "sourceResourceId": "subscriptions/{subscriptionId}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/snapshots/mySnapshot"
+                    "sourceResourceId": "/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/diskAccesses/myDiskAccess"
                 },
                 "diskSizeGB": 200,
                 "encryptionSettingsCollection": {

--- a/plugins/azure/test/files/compute/virtualMachines.json
+++ b/plugins/azure/test/files/compute/virtualMachines.json
@@ -22,7 +22,7 @@
                         "exactVersion": "aaaaaaaaaaaaa",
                         "sharedGalleryImageId": "aaaaaaaaaaaaaaa",
                         "communityGalleryImageId": "aaaa",
-                        "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        "id": "/subscriptions/{subscriptionId}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/images/myImage"
                     },
                     "osDisk": {
                         "osType": "Windows",
@@ -67,7 +67,7 @@
                                     "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
                                 }
                             },
-                            "id": "/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/disks/testingexcludedisk_OsDisk_1_74cdaedcea50483d9833c96adefa100f"
+                            "id": "/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/diskAccesses/myDiskAccess"
                         },
                         "deleteOption": "Delete"
                     },
@@ -234,7 +234,7 @@
                     "id": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/availabilitySets/{availabilitySetName}"
                 },
                 "proximityPlacementGroup": {
-                    "id": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/availabilitySets/{availabilitySetName}"
+                    "id": "/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/proximityPlacementGroups/myProximityPlacementGroup"
                 },
                 "priority": "Regular",
                 "evictionPolicy": "Deallocate",
@@ -359,7 +359,7 @@
                         "exactVersion": "aa",
                         "sharedGalleryImageId": "aaaaaaaaaaaaaaaaaaaaaaaaa",
                         "communityGalleryImageId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                        "id": "aaaaaaaa"
+                        "id": "/subscriptions/{subscriptionId}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/images/myImage"
                     },
                     "osDisk": {
                         "osType": "Windows",
@@ -404,7 +404,7 @@
                                     "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
                                 }
                             },
-                            "id": "/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/disks/testingexcludedisk_OsDisk_1_74cdaedcea50483d9833c96adefa100f"
+                            "id": "/subscriptions/{subscription-id}/resourceGroups/mySecondResourceGroup/providers/Microsoft.Compute/diskAccesses/myDiskAccess2"
                         },
                         "deleteOption": "Delete"
                     },
@@ -571,7 +571,7 @@
                     "id": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/availabilitySets/{availabilitySetName}"
                 },
                 "proximityPlacementGroup": {
-                    "id": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/availabilitySets/{availabilitySetName}"
+                    "id": "/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/proximityPlacementGroups/myProximityPlacementGroup"
                 },
                 "priority": "Regular",
                 "evictionPolicy": "Deallocate",


### PR DESCRIPTION
# Description
I have introduced the following relationships to the reference_kinds:
```graph
AzureAvailabilitySet -> AzureProximityPlacementGroup -> AzureVirtualMachine
AzureCapacityReservationGroup -> AzureVirtualMachine
AzureDisk <- AzureDiskAccess -> AzureDiskEncryptionSet
AzureRestorePointCollection -> AzureResource
AzureSnapshot <- AzureDisk
AzureVirtualMachine -> AzureProximityPlacementGroup -> AzureImage -> AzureDisk
```
And I have implemented the connect_in_graph method to support these relationships.
# To-Dos

- [x] Create `reference_kinds` between Azure classes
- [x] Add method `connect_in_graph` that makes edges