### PR TITLE
[feat][resotocore] Allow loading synchronized benchmarks

### DIFF
--- a/resotocore/resotocore/config/config_handler_service.py
+++ b/resotocore/resotocore/config/config_handler_service.py
@@ -78,7 +78,7 @@ class ConfigHandlerService(ConfigHandler, Service):
         if validator:
             validation = await self.validation_db.get(validator)
             if validation and validation.external_validation and validate:
-                await self.acknowledge_config_change(validator, final_config)
+                await self.acknowledge_config_change(validator, cfg_id, final_config)
 
         # If we come here, everything is fine
         return final_config
@@ -239,7 +239,7 @@ class ConfigHandlerService(ConfigHandler, Service):
         else:
             return None
 
-    async def acknowledge_config_change(self, cfg_id: str, config: Json) -> None:
+    async def acknowledge_config_change(self, validator: str, cfg_id: str, config: Json) -> None:
         """
         In case an external entity should acknowledge this config change.
         This method either return, which signals success or throws an exception.
@@ -248,8 +248,8 @@ class ConfigHandlerService(ConfigHandler, Service):
         task = WorkerTask(
             TaskId(uuid_str()),
             WorkerTaskName.validate_config,
-            {"config_id": cfg_id},
-            {"task": WorkerTaskName.validate_config, "config": config},
+            {"config_id": validator},
+            {"task": WorkerTaskName.validate_config, "config": config, "config_id": cfg_id},
             future,
             timedelta(seconds=30),
         )

--- a/resotocore/resotocore/config/config_handler_service.py
+++ b/resotocore/resotocore/config/config_handler_service.py
@@ -239,7 +239,7 @@ class ConfigHandlerService(ConfigHandler, Service):
         else:
             return None
 
-    async def acknowledge_config_change(self, validator: str, cfg_id: str, config: Json) -> None:
+    async def acknowledge_config_change(self, validator: str, cfg_id: ConfigId, config: Json) -> None:
         """
         In case an external entity should acknowledge this config change.
         This method either return, which signals success or throws an exception.

--- a/resotocore/resotocore/config/core_config_handler.py
+++ b/resotocore/resotocore/config/core_config_handler.py
@@ -108,7 +108,7 @@ class CoreConfigHandler(Service):
         elif CheckConfigRoot in holder:
             return await self.inspector.validate_check_collection_config(task_data["config"])
         elif BenchmarkConfigRoot in holder:
-            return await self.inspector.validate_benchmark_config(task_data["config"])
+            return await self.inspector.validate_benchmark_config(task_data["config_id"], task_data["config"])
         elif ResotoCoreSnapshotsRoot in holder:
             return validate_snapshot_schedule()
         else:

--- a/resotocore/resotocore/report/__init__.py
+++ b/resotocore/resotocore/report/__init__.py
@@ -357,6 +357,18 @@ class Inspector(ABC):
         """
 
     @abstractmethod
+    async def load_benchmarks(
+        self,
+        graph: GraphName,
+        benchmark_names: List[str],
+        *,
+        accounts: Optional[List[str]] = None,
+        severity: Optional[ReportSeverity] = None,
+        only_failing: bool = False,
+    ) -> Dict[str, BenchmarkResult]:
+        pass
+
+    @abstractmethod
     async def perform_benchmarks(
         self,
         graph: GraphName,
@@ -417,7 +429,7 @@ class Inspector(ABC):
         pass
 
     @abstractmethod
-    async def validate_benchmark_config(self, json: Json) -> Optional[Json]:
+    async def validate_benchmark_config(self, cfg_id: ConfigId, json: Json) -> Optional[Json]:
         pass
 
     @abstractmethod

--- a/resotocore/resotocore/static/api-doc.yaml
+++ b/resotocore/resotocore/static/api-doc.yaml
@@ -2752,6 +2752,17 @@ paths:
           required: false
           explode: false
           example: 123456789012,123456789013
+        - name: action
+          in: query
+          description: |
+            The action to perform. You can either run (create) or load the benchmark.
+            Loading the benchmark requires, that a benchmark has been synchronized to the database before.
+            In case the resources haven't changed since the last synchronization, the result is the same,
+            but the load action is much faster.
+          schema:
+            type: string
+            enum: [run, load]
+            default: run
       responses:
         "200":
           description: "The checks result."

--- a/resotocore/resotocore/web/api.py
+++ b/resotocore/resotocore/web/api.py
@@ -629,7 +629,13 @@ class Api(Service):
         graph = GraphName(request.match_info["graph_id"])
         acc = request.query.get("accounts")
         accounts = [a.strip() for a in acc.split(",")] if acc else None
-        results = await deps.inspector.perform_benchmarks(graph, [benchmark], accounts=accounts)
+        action = request.query.get("action", "run")
+        if action == "run":
+            results = await deps.inspector.perform_benchmarks(graph, [benchmark], accounts=accounts)
+        elif action == "load":
+            results = await deps.inspector.load_benchmarks(graph, [benchmark], accounts=accounts)
+        else:
+            raise ValueError(f"Unknown action {action}. One of run or load is expected.")
         result_graph = results[benchmark].to_graph()
         async with stream.iterate(result_graph).stream() as streamer:
             return await self.stream_response_from_gen(request, streamer, len(result_graph))

--- a/resotocore/tests/resotocore/cli/command_test.py
+++ b/resotocore/tests/resotocore/cli/command_test.py
@@ -1059,9 +1059,11 @@ async def test_report(cli: CLI, inspector_service: Inspector, test_benchmark: Be
     # without output transformer, a markdown report is generated
     assert len((await execute("report check run test_test_some_check", str))) == 1
     # execute the test benchmark
-    assert len((await execute("report benchmark run test | dump", Json))) == 9
+    assert len((await execute("report benchmark run test --sync-security-section | dump", Json))) == 9
     assert len((await execute("report benchmark run test --only-failing | dump", Json))) == 9
     assert len((await execute("report benchmark run test --severity critical | dump", Json))) == 0
+    # load the benchmark from the last sync
+    assert len((await execute("report benchmark load test | dump", Json))) == 9
 
 
 @pytest.mark.asyncio

--- a/resotocore/tests/resotocore/config/core_config_handler_test.py
+++ b/resotocore/tests/resotocore/config/core_config_handler_test.py
@@ -14,7 +14,8 @@ from resotocore.core_config import (
     CustomCommandsConfig,
     ResotoCoreSnapshotsRoot,
 )
-from resotocore.report import BenchmarkConfigRoot
+from resotocore.model.typed_model import to_js
+from resotocore.report import BenchmarkConfigRoot, Benchmark
 from resotocore.system_start import empty_config
 from resotocore.message_bus import MessageBus, CoreMessage
 from resotocore.ids import ConfigId
@@ -63,7 +64,7 @@ async def test_exit_on_updated_config(
 
 
 @mark.asyncio
-async def test_validation(core_config_handler: CoreConfigHandler) -> None:
+async def test_validation(core_config_handler: CoreConfigHandler, test_benchmark: Benchmark) -> None:
     validate = core_config_handler.validate_config_entry
 
     # empty config is valid
@@ -94,7 +95,10 @@ async def test_validation(core_config_handler: CoreConfigHandler) -> None:
         await validate({"config": {ResotoCoreSnapshotsRoot: {"foo-label": {"schedule": "foo bar", "retain": 42}}}})
         is not None
     )
+    # make sure that the benchmark id and config_id are the same
     assert await validate({"config": {BenchmarkConfigRoot: {"id": "some"}}, "config_id": "some_other"}) is not None
+    # a valid benchmark config passes the check
+    assert await validate({"config": {BenchmarkConfigRoot: to_js(test_benchmark)}, "config_id": "test"}) is None
 
 
 @mark.asyncio

--- a/resotocore/tests/resotocore/config/core_config_handler_test.py
+++ b/resotocore/tests/resotocore/config/core_config_handler_test.py
@@ -14,6 +14,7 @@ from resotocore.core_config import (
     CustomCommandsConfig,
     ResotoCoreSnapshotsRoot,
 )
+from resotocore.report import BenchmarkConfigRoot
 from resotocore.system_start import empty_config
 from resotocore.message_bus import MessageBus, CoreMessage
 from resotocore.ids import ConfigId
@@ -93,6 +94,7 @@ async def test_validation(core_config_handler: CoreConfigHandler) -> None:
         await validate({"config": {ResotoCoreSnapshotsRoot: {"foo-label": {"schedule": "foo bar", "retain": 42}}}})
         is not None
     )
+    assert await validate({"config": {BenchmarkConfigRoot: {"id": "some"}}, "config_id": "some_other"}) is not None
 
 
 @mark.asyncio


### PR DESCRIPTION
# Description

A previously synced benchmark result can be loaded and shows the same data.
This PR introduces a command (`report benchmark load`) and provides an endpoint to load a benchmark result instead of performing it. 

<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
