### PR TITLE
[resotocore][feat] Enable count and total count for search queries

### DIFF
--- a/resotocore/resotocore/db/arango_query.py
+++ b/resotocore/resotocore/db/arango_query.py
@@ -94,7 +94,8 @@ def to_query(
     bind_vars: Json = {}
     start = from_collection or f"`{db.vertex_name}`"
     cursor, query_str = query_string(db, query, query_model, start, with_edges, bind_vars, count, id_column=id_column)
-    return f"""{query_str} FOR result in {cursor} RETURN UNSET(result, {unset_props})""", bind_vars
+    last_limit = f" LIMIT {ll.offset}, {ll.length}" if (ll := query.current_part.limit) else ""
+    return f"""{query_str} FOR result in {cursor}{last_limit} RETURN UNSET(result, {unset_props})""", bind_vars
 
 
 def query_string(
@@ -467,6 +468,7 @@ def query_string(
     def part(p: Part, in_cursor: str, part_idx: int) -> Tuple[Part, str, str, str]:
         query_part = ""
         filtered_out = ""
+        last_part = len(query.parts) == (part_idx + 1)
 
         def filter_statement(current_cursor: str, part_term: Term, limit: Optional[Limit]) -> str:
             if isinstance(part_term, AllTerm) and limit is None and not p.sort:
@@ -665,9 +667,9 @@ def query_string(
                 query_part += f"LET {nav_crsr} = UNION_DISTINCT({all_walks_combined})"
                 return nav_crsr
 
-        # apply the limit in the filter statement only, when no with clause is present
-        # otherwise the limit is applied in the with clause
-        filter_limit = p.limit if p.with_clause is None else None
+        # If a with-clause exists, the fiter is applied inside the with clause.
+        # Skip the limit in case of last part - it is applied in the outermost for loop.
+        filter_limit = p.limit if (p.with_clause is None and not last_part) else None
         cursor = in_cursor
         part_term = p.term
         if isinstance(p.term, MergeTerm):

--- a/resotocore/resotocore/db/async_arangodb.py
+++ b/resotocore/resotocore/db/async_arangodb.py
@@ -73,6 +73,9 @@ class AsyncCursor(AsyncIterator[Any]):
     def count(self) -> Optional[int]:
         return self.cursor.count()
 
+    def full_count(self) -> Optional[int]:
+        return stats.get("fullCount") if (stats := self.cursor.statistics()) else None
+
     async def next_filtered(self) -> Optional[Json]:
         element = await self.next_from_db()
         vertex: Optional[Json] = None

--- a/resotocore/resotocore/db/graphdb.py
+++ b/resotocore/resotocore/db/graphdb.py
@@ -567,6 +567,7 @@ class ArangoGraphDB(GraphDB):
         return await self.db.aql_cursor(
             query=q_string,
             count=with_count,
+            full_count=with_count,
             bind_vars=bind,
             batch_size=10000,
             ttl=cast(Number, int(timeout.total_seconds())) if timeout else None,
@@ -581,6 +582,7 @@ class ArangoGraphDB(GraphDB):
             query=q_string,
             trafo=self.document_to_instance_fn(query.model, query),
             count=with_count,
+            full_count=with_count,
             bind_vars=bind,
             batch_size=10000,
             ttl=cast(Number, int(timeout.total_seconds())) if timeout else None,
@@ -623,7 +625,13 @@ class ArangoGraphDB(GraphDB):
         )
         ttl = cast(Number, int(timeout.total_seconds())) if timeout else None
         return await self.db.aql_cursor(
-            query=q_string, trafo=trafo, count=with_count, bind_vars=bind, batch_size=10000, ttl=ttl
+            query=q_string,
+            trafo=trafo,
+            count=with_count,
+            full_count=with_count,
+            bind_vars=bind,
+            batch_size=10000,
+            ttl=ttl,
         )
 
     async def search_graph_gen(
@@ -636,6 +644,7 @@ class ArangoGraphDB(GraphDB):
             trafo=self.document_to_instance_fn(query.model, query),
             bind_vars=bind,
             count=with_count,
+            full_count=with_count,
             batch_size=10000,
             ttl=cast(Number, int(timeout.total_seconds())) if timeout else None,
         )
@@ -990,6 +999,7 @@ class ArangoGraphDB(GraphDB):
             for num, (root, graph) in enumerate(graphs):
                 root_kind = GraphResolver.resolved_kind(graph_to_merge.nodes[root])
                 if root_kind:
+                    # noinspection PyTypeChecker
                     log.info(f"Update subgraph: root={root} ({root_kind}, {num+1} of {len(roots)})")
                     node_query = self.query_update_nodes(root_kind), {"update_id": root}
                     edge_query = partial(merge_edges, root, root_kind)

--- a/resotocore/resotocore/infra_apps/local_runtime.py
+++ b/resotocore/resotocore/infra_apps/local_runtime.py
@@ -113,8 +113,8 @@ class LocalResotocoreAppRuntime(Runtime, Service):
         total_nr_outputs: int = 0
         parsed_commands = await self.cli.evaluate_cli_command(line, ctx, True)
         for parsed in parsed_commands:
-            nr_outputs, command_output_stream = await parsed.execute()
-            total_nr_outputs = total_nr_outputs + (nr_outputs or 0)
+            src_ctx, command_output_stream = await parsed.execute()
+            total_nr_outputs = total_nr_outputs + (src_ctx.count or 0)
             command_streams.append(command_output_stream)
 
         return stream.concat(stream.iterate(command_streams), task_limit=1)

--- a/resotocore/resotocore/query/model.py
+++ b/resotocore/resotocore/query/model.py
@@ -916,6 +916,9 @@ class Query:
     def merge_query_by_name(self) -> List[MergeQuery]:
         return [mt for part in self.parts if isinstance(part.term, MergeTerm) for mt in part.term.merge]
 
+    def is_aggregate(self) -> bool:
+        return self.aggregate is not None
+
     def filter(self, term: Union[str, Term], *terms: Union[str, Term]) -> Query:
         res = Query.mk_term(term, *terms)
         parts = self.parts.copy()

--- a/resotocore/resotocore/web/api.py
+++ b/resotocore/resotocore/web/api.py
@@ -646,7 +646,7 @@ class Api(Service):
             raise ValueError(f"Unknown action {action}. One of run or load is expected.")
         result_graph = results[benchmark].to_graph()
         async with stream.iterate(result_graph).stream() as streamer:
-            return await self.stream_response_from_gen(request, streamer, len(result_graph))
+            return await self.stream_response_from_gen(request, streamer, count=len(result_graph))
 
     async def inspection_checks(self, request: Request, deps: TenantDependencies) -> StreamResponse:
         provider = request.query.get("provider")
@@ -1064,6 +1064,7 @@ class Api(Service):
     async def possible_values(self, request: Request, deps: TenantDependencies) -> StreamResponse:
         graph_db, query_model = await self.graph_query_model_from_request(request, deps)
         section = section_of(request)
+        # noinspection PyTypeChecker
         detail: Literal["attributes", "values"] = "attributes" if request.path.endswith("attributes") else "values"
         root_or_section = None if section is None or section == PathRoot else section
         fn = partial(variable_to_absolute, root_or_section)
@@ -1078,7 +1079,9 @@ class Api(Service):
         async with await graph_db.list_possible_values(
             query_model, prop_or_predicate, detail, limit, skip, count
         ) as cursor:
-            return await self.stream_response_from_gen(request, cursor, cursor.count())
+            return await self.stream_response_from_gen(
+                request, cursor, count=cursor.count(), total_count=cursor.full_count()
+            )
 
     async def query_structure(self, request: Request, deps: TenantDependencies) -> StreamResponse:
         _, query_model = await self.graph_query_model_from_request(request, deps)
@@ -1089,7 +1092,9 @@ class Api(Service):
         count = request.query.get("count", "true").lower() != "false"
         timeout = if_set(request.query.get("search_timeout"), duration)
         async with await graph_db.search_list(query_model, count, timeout) as cursor:
-            return await self.stream_response_from_gen(request, cursor, cursor.count())
+            return await self.stream_response_from_gen(
+                request, cursor, count=cursor.count(), total_count=cursor.full_count()
+            )
 
     async def cytoscape(self, request: Request, deps: TenantDependencies) -> StreamResponse:
         graph_db, query_model = await self.graph_query_model_from_request(request, deps)
@@ -1102,12 +1107,16 @@ class Api(Service):
         count = request.query.get("count", "true").lower() != "false"
         timeout = if_set(request.query.get("search_timeout"), duration)
         async with await graph_db.search_graph_gen(query_model, count, timeout) as cursor:
-            return await self.stream_response_from_gen(request, cursor, cursor.count())
+            return await self.stream_response_from_gen(
+                request, cursor, count=cursor.count(), total_count=cursor.full_count()
+            )
 
     async def query_aggregation(self, request: Request, deps: TenantDependencies) -> StreamResponse:
         graph_db, query_model = await self.graph_query_model_from_request(request, deps)
-        async with await graph_db.search_aggregation(query_model) as gen:
-            return await self.stream_response_from_gen(request, gen)
+        async with await graph_db.search_aggregation(query_model) as cursor:
+            return await self.stream_response_from_gen(
+                request, cursor, count=cursor.count(), total_count=cursor.full_count()
+            )
 
     async def query_history(self, request: Request, deps: TenantDependencies) -> StreamResponse:
         graph_db, query_model = await self.graph_query_model_from_request(request, deps)
@@ -1119,8 +1128,10 @@ class Api(Service):
             change=HistoryChange[change] if change else None,
             before=parse_utc(before) if before else None,
             after=parse_utc(after) if after else None,
-        ) as gen:
-            return await self.stream_response_from_gen(request, gen)
+        ) as cursor:
+            return await self.stream_response_from_gen(
+                request, cursor, count=cursor.count(), total_count=cursor.full_count()
+            )
 
     async def serve_debug_ui(self, request: Request) -> FileResponse:
         """
@@ -1273,13 +1284,19 @@ class Api(Service):
             return web.json_response(data, status=424)
         elif len(parsed) == 1:
             first_result = parsed[0]
-            count, generator = await first_result.execute()
+            src_ctx, generator = await first_result.execute()
             # flat the results from 0 or 1
             async with generator.stream() as streamer:
                 gen = await force_gen(streamer)
                 if first_result.produces.text:
                     text_gen = ctx.text_generator(first_result, gen)
-                    return await self.stream_response_from_gen(request, text_gen, count, first_result.envelope)
+                    return await self.stream_response_from_gen(
+                        request,
+                        text_gen,
+                        count=src_ctx.count,
+                        total_count=src_ctx.total_count,
+                        additional_header=first_result.envelope,
+                    )
                 elif first_result.produces.file_path:
                     await mp_response.prepare(request)
                     await Api.multi_file_response(first_result, gen, boundary, mp_response)
@@ -1290,7 +1307,7 @@ class Api(Service):
         elif len(parsed) > 1:
             await mp_response.prepare(request)
             for single in parsed:
-                count, generator = await single.execute()
+                _, generator = await single.execute()
                 async with generator.stream() as streamer:
                     gen = await force_gen(streamer)
                     if single.produces.text:
@@ -1361,15 +1378,22 @@ class Api(Service):
     async def stream_response_from_gen(
         request: Request,
         gen_in: AsyncIterator[JsonElement],
+        *,
         count: Optional[int] = None,
+        total_count: Optional[int] = None,
         additional_header: Optional[Dict[str, str]] = None,
     ) -> StreamResponse:
         # force the async generator, to get an early exception in case of failure
         gen = await force_gen(gen_in)
         content_type, result_gen = await result_binary_gen(request, gen)
-        count_header = {"Resoto-Shell-Element-Count": str(count)} if count else {}
-        hdr = additional_header or {}
-        response = web.StreamResponse(status=200, headers={**hdr, "Content-Type": content_type, **count_header})
+        headers = {"Content-Type": content_type}
+        if additional_header:
+            headers.update(additional_header)
+        if count is not None:
+            headers["Result-Count"] = str(count)
+        if total_count is not None:
+            headers["Total-Count"] = str(total_count)
+        response = web.StreamResponse(status=200, headers=headers)
         enable_compression(request, response)
         writer: AbstractStreamWriter = await response.prepare(request)  # type: ignore
         cr = "\n".encode("utf-8")

--- a/resotocore/tests/resotocore/cli/command_test.py
+++ b/resotocore/tests/resotocore/cli/command_test.py
@@ -625,6 +625,11 @@ async def test_list_command(cli: CLI) -> None:
     )
     # b as a ==> b, c as a ==> c, c ==> c_1, ancestors.account.reported.a ==> account_a, again ==> _1
     assert result[0][0] == "a=a, b=true, c=false, c_1=false, account_a=a, account_a_1=a, foo=a"
+    # source context is passed correctly
+    parsed = await cli.evaluate_cli_command("search is (bla) | head 10 | list")
+    src_ctx, gen = await parsed[0].execute()
+    assert src_ctx.count == 10
+    assert src_ctx.total_count == 100
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description

The search and cli/execute endpoint now return 2 additional headers:

```
Result-Count: 1
Total-Count: 61
```

One indicating the number of elements returned within this response, the other one shows the number of all available elements. There will be only a difference if a limit is applied to the search.


# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
