### PR TITLE
[resotocore][fix] args parser needs to allow empty space

### DIFF
--- a/resotocore/resotocore/cli/__init__.py
+++ b/resotocore/resotocore/cli/__init__.py
@@ -20,13 +20,14 @@ from resotolib.parse_util import (
     space_dp,
     double_quote_dp,
     single_quote_dp,
-    any_non_white_space_string,
+    any_non_whitespace_string,
     comma_p,
     double_quoted_string_part_dp,
     backslash_dp,
     single_quoted_string_part_dp,
     dash_dp,
     equals_p,
+    whitespace,
 )
 
 T = TypeVar("T")
@@ -96,14 +97,14 @@ cmd_with_args_parser = (escaped_token | double_quoted_string | single_quoted_str
 # argument parser which will read the argument list while removing single and double quotes
 # command line arguments: foo "bla: 'foo = bla' -> [foo, bla, foo = bla]
 args_parts_unquoted_parser = (
-    escaped_token | double_quoted_raw_string | single_quoted_raw_string | any_non_white_space_string
-).sep_by(space_dp)
+    escaped_token | double_quoted_raw_string | single_quoted_raw_string | any_non_whitespace_string
+).sep_by(whitespace, min=1)
 
 # argument parser which will read the argument list while removing single quotes
 # Example: "--a \"a or b\" --b 'b or c' --c c d" -> ["--a", "\"a or b\"", "--b", "b or c", "--c", "c", "d"]
 args_parts_parser = (
-    escaped_token | double_quoted_string | single_quoted_raw_string | any_non_white_space_string
-).sep_by(space_dp, min=1)
+    escaped_token | double_quoted_string | single_quoted_raw_string | any_non_whitespace_string
+).sep_by(whitespace, min=1)
 
 
 def strip_quotes(maybe_quoted: str) -> str:

--- a/resotocore/tests/resotocore/cli/cli_test.py
+++ b/resotocore/tests/resotocore/cli/cli_test.py
@@ -3,7 +3,7 @@ from typing import List
 import pytest
 from aiostream import stream
 
-from resotocore.cli import strip_quotes, js_value_at
+from resotocore.cli import strip_quotes, js_value_at, args_parts_parser, args_parts_unquoted_parser
 from resotocore.cli.cli import multi_command_parser, CLIService
 from resotocore.cli.command import (
     ExecuteSearchCommand,
@@ -32,6 +32,15 @@ from resotocore.util import utc
 def test_strip() -> None:
     assert strip_quotes("'test'") == "test"
     assert strip_quotes('"test"') == "test"
+
+
+def test_split_args_parser() -> None:
+    assert args_parts_parser.parse("1 2   3    4") == ["1", "2", "3", "4"]
+    assert args_parts_parser.parse('(id == "1  \\"2 3 () 4 5")') == ["(id", "==", '"1  \\"2 3 () 4 5"', ")"]
+    assert args_parts_parser.parse("'doo' \"bla\" '\\'bar'") == ["doo", '"bla"', "\\'bar"]
+    assert args_parts_unquoted_parser.parse("1 2   3    4") == ["1", "2", "3", "4"]
+    assert args_parts_unquoted_parser.parse('(id == "1  \\"2 3 () 4 5")') == ["(id", "==", '1  \\"2 3 () 4 5', ")"]
+    assert args_parts_unquoted_parser.parse("'doo' \"bla\" '\\'bar'") == ["doo", "bla", "\\'bar"]
 
 
 def test_command_line_parser() -> None:

--- a/resotolib/resotolib/parse_util.py
+++ b/resotolib/resotolib/parse_util.py
@@ -155,7 +155,6 @@ double_quoted_string_part_or_esc_dp = (double_quoted_string_part_dp | string_esc
 double_quoted_string_dp = double_quote_dp >> double_quoted_string_part_or_esc_dp << double_quote_dp
 
 any_string = parsy.any_char.many().concat()
-any_non_white_space_string = parsy.test_char(lambda x: x != " ", "non whitespace").many().concat()
 double_quoted_or_simple_string_dp = double_quoted_string_dp | any_string
 any_non_whitespace_string = parsy.test_char(lambda c: c != " ", "non whitespace").at_least(1).concat()
 


### PR DESCRIPTION
# Description

<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Add test coverage for new or updated functionality
- [x] Lint and test with `tox`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
