### PR TITLE
[resotocore][fix] fix case for certificate_transparency_logging value

### DIFF
--- a/resotocore/resotocore/static/report/checks/aws/aws_acm.json
+++ b/resotocore/resotocore/static/report/checks/aws/aws_acm.json
@@ -10,7 +10,7 @@
             "risk": "Without ACM certificate transparency, the risk of unauthorized SSL/TLS certificates going undetected increases, posing a threat to website and infrastructure security.",
             "severity": "medium",
             "detect": {
-                "resoto": "is(aws_acm_certificate) and type!=IMPORTED and certificate_transparency_logging!=Enabled"
+                "resoto": "is(aws_acm_certificate) and type!=IMPORTED and certificate_transparency_logging!=ENABLED"
             },
             "remediation": {
                 "text": "To fix this issue, select the certificate you want to check in ACM. In the certificate details, look for the 'Certificate Transparency Logging' attribute and ensure it is enabled.",


### PR DESCRIPTION
# Description
per https://docs.aws.amazon.com/acm/latest/APIReference/API_CertificateOptions.html#ACM-Type-CertificateOptions-CertificateTransparencyLoggingPreference
AWS ACM returns ENABLED|DISABLED for this option

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
