### PR TITLE
[ci][fix] Remove duplicate docker-compose up -d

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -168,8 +168,6 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
-          yq '.services.fixworker.environment += "FIXWORKER_OVERRIDE=fixworker.collector=example"' docker-compose.yaml > docker-compose-model-gen.yaml
-          PSK= FIXCORE_ANALYTICS_OPT_OUT=true docker-compose -f docker-compose-model-gen.yaml up -d
           cd ${{ github.workspace }}/inventory.fix.security/docs/reference/unified-data-model
           python3 ${{ github.workspace }}/inventory.fix.security/tools/export_models.py
 


### PR DESCRIPTION
# Description

In the edge workflow, both `docs.fix.security` and `inventory.fix.security` are updated. The second step updating resource data models doesn't need to `docker-compose up` again.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://inventory.fix.security/code-of-conduct).
